### PR TITLE
Backup any existing clj-kondo binary when installing

### DIFF
--- a/script/install-clj-kondo
+++ b/script/install-clj-kondo
@@ -76,6 +76,7 @@ rm "clj-kondo-$version-$platform-amd64.zip"
 cd "$install_dir"
 if [ -f clj-kondo ]; then
     echo "Moving $install_dir/clj-kondo to $install_dir/clj-kondo.old"
+    mv -f "clj-kondo" "clj-kondo.old"
 fi
 
 mv -f "$download_dir/clj-kondo" "$PWD/clj-kondo"


### PR DESCRIPTION
This partially reverts commit 64497c1a8b960933829437e41b9707b17f804324 which removed this `mv` without removing the `echo` line above.

Fixes #962.

Successfully tested with:
```
$ mkdir /tmp/a /tmp/b
$ ./script/install-clj-kondo --dir /tmp/a --download-dir /tmp/b
Downloading https://github.com/borkdude/clj-kondo/releases/download/v2020.07.29/clj-kondo-2020.07.29-linux-amd64.zip to /tmp/b
Successfully installed clj-kondo in /tmp/a
$ ls /tmp/a
clj-kondo
$ ./script/install-clj-kondo --dir /tmp/a --download-dir /tmp/b
Downloading https://github.com/borkdude/clj-kondo/releases/download/v2020.07.29/clj-kondo-2020.07.29-linux-amd64.zip to /tmp/b
Moving /tmp/a/clj-kondo to /tmp/a/clj-kondo.old
Successfully installed clj-kondo in /tmp/a
$ ls /tmp/a
clj-kondo  clj-kondo.old
```