### PR TITLE
Stop returning lazy sequences to be concatened.

### DIFF
--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -171,10 +171,10 @@
         (if (.isFile file)
           (if (str/ends-with? (.getPath file) ".jar")
             ;; process jar file
-            (map #(ana/analyze-input ctx (:filename %) (:source %)
-                                     (lang-from-file (:filename %) default-language)
-                                     dev?)
-                 (sources-from-jar file canonical?))
+            (mapv #(ana/analyze-input ctx (:filename %) (:source %)
+                                      (lang-from-file (:filename %) default-language)
+                                      dev?)
+                  (sources-from-jar file canonical?))
             ;; assume normal source file
             [(ana/analyze-input ctx (if canonical?
                                       (.getCanonicalPath file)
@@ -182,16 +182,16 @@
                                 (lang-from-file filename default-language)
                                 dev?)])
           ;; assume directory
-          (map #(ana/analyze-input ctx (:filename %) (:source %)
-                                   (lang-from-file (:filename %) default-language)
-                                   dev?)
-               (sources-from-dir file canonical?)))
+          (mapv #(ana/analyze-input ctx (:filename %) (:source %)
+                                    (lang-from-file (:filename %) default-language)
+                                    dev?)
+                (sources-from-dir file canonical?)))
         (= "-" filename)
         [(ana/analyze-input ctx "<stdin>" (slurp *in*) default-language dev?)]
         (classpath? filename)
-        (mapcat #(process-file ctx % default-language canonical?)
-                (str/split filename
-                           (re-pattern path-separator)))
+        (vec (mapcat #(process-file ctx % default-language canonical?)
+                     (str/split filename
+                                (re-pattern path-separator))))
         :else
         (findings/reg-finding! ctx
                                {:filename (if canonical?
@@ -215,7 +215,7 @@
 
 (defn process-files [ctx files default-lang]
   (let [canonical? (-> ctx :config :output :canonical-paths)]
-    (mapcat #(process-file ctx % default-lang canonical?) files)))
+    (vec (mapcat #(process-file ctx % default-lang canonical?) files))))
 
 ;;;; index defs and calls by language and namespace
 


### PR DESCRIPTION
`process-file` is called recursively, through calls to `mapcat` and
`map`. This laziness will build up with large very large classpaths,
eventually spending all its time in the JVM with GC before bombing out
with a GC overhead error.

https://stuartsierra.com/2015/04/26/clojure-donts-concat
----

With ~250 classpath entries (8gb macbook pro).
Before: graal 53s java OOM/exception 
After: graal ?? java 43s

I'm running into issues building the graal image in both docker and locally, I wanted to get this out as it's a pretty major blocker on clojure-lsp for my project at work. But I also understand this is primarily a graal project.

