### PR TITLE
Fixes #982 Adds locals to analysis with an extra config flag

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -11,6 +11,16 @@ data, use the following configuration:
 When using clj-kondo from the command line, the analysis data will be exported
 with `{:output {:format ...}}` set to `:json` or `:edn`.
 
+## Extra Analysis
+
+Further analysis can be returned by providing `:analysis` with a map of options:
+
+``` shellsession
+{:output {:analysis {... ...}}
+```
+
+- `:locals`: when truthy return `:locals` and `:local-usages` described below
+
 ## Data
 
 The analysis output consists of a map with:
@@ -60,6 +70,20 @@ The analysis output consists of a map with:
     was resolved: `:clj` or `:cljs`
   - several attributes of the used var: `:private`, `:macro`, `:fixed-arities`,
     `:varargs-min-arity`, `:deprecated`.
+
+- `:locals`, a list of maps with:
+  - `:filename`, `:row`, `:col`, `:end-row`, `:end-col`
+  - `:id`: an identification for this local, `:local-usages` will reference this
+  - `:name`: the name of the used local
+  - `:str`: the as written string of the local from the file and position
+  - `:scope-end-row`: the row in which this local will go out of scope
+  - `:scope-end-col`: the column in which this local will go out of scope
+
+- `:local-usages`, a list of maps with:
+  - `:filename`, `:row`, `:col`, `:end-row`, `:end-col`
+  - `:id`: an identification for this local, refers to the local declaration with the same `:id` in `:locals`
+  - `:name`: the name of the used local
+  - `:str`: the as written string of the local from the file and position
 
 Example output after linting this code:
 

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -104,7 +104,7 @@
         files (atom 0)
         findings (atom [])
         analysis? (get-in config [:output :analysis])
-        analyze-locals? (get-in config [:output :locals])
+        analyze-locals? (get-in config [:output :analysis :locals])
         analysis (when analysis?
                    (atom (cond-> {:namespace-definitions []
                                   :namespace-usages []
@@ -126,7 +126,8 @@
              :used-namespaces (atom {:clj #{}
                                      :cljs #{}
                                      :cljc #{}})
-             :ignores (atom {})}
+             :ignores (atom {})
+             :id-gen (when analyze-locals? (atom 0))}
         lang (or lang :clj)
         _ (core-impl/process-files (if parallel
                                      (assoc ctx :parallel parallel)

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -104,11 +104,14 @@
         files (atom 0)
         findings (atom [])
         analysis? (get-in config [:output :analysis])
+        analyze-locals? (get-in config [:output :locals])
         analysis (when analysis?
-                   (atom {:namespace-definitions []
-                          :namespace-usages []
-                          :var-definitions []
-                          :var-usages []}))
+                   (atom (cond-> {:namespace-definitions []
+                                  :namespace-usages []
+                                  :var-definitions []
+                                  :var-usages []}
+                           analyze-locals? (assoc :locals []
+                                                  :local-usages []))))
         ctx {:no-warnings no-warnings
              :config-dir cfg-dir
              :config config

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -74,17 +74,17 @@
               :lang (when (= :cljc base-lang) lang)
               :alias alias)))))
 
-(defn reg-local! [{:keys [:analysis :base-lang :lang] :as _ctx} filename binding]
+(defn reg-local! [{:keys [:analysis] :as ctx} filename binding]
   (when analysis
     (swap! analysis update :locals conj
-           (assoc-some binding
+           (assoc-some (select-keys binding [:name :str :id :row :col :end-row :end-col :scope-end-col :scope-end-row])
                        :filename filename
-                       :lang (when (= :cljc base-lang) lang)))))
+                       :lang (when (= :cljc (:base-lang ctx)) (:lang ctx))))))
 
-(defn reg-local-usage! [{:keys [:analysis :base-lang :lang] :as _ctx} filename binding usage]
+(defn reg-local-usage! [{:keys [:analysis] :as ctx} filename binding usage]
   (when analysis
     (swap! analysis update :local-usages conj
-           (assoc-some usage
+           (assoc-some (select-keys usage [:name :str :id :row :col :end-row :end-col])
                        :filename filename
-                       :lang (when (= :cljc base-lang) lang)
+                       :lang (when (= :cljc (:base-lang ctx)) (:lang ctx))
                        :id (:id binding)))))

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -73,3 +73,18 @@
                :to to-ns}
               :lang (when (= :cljc base-lang) lang)
               :alias alias)))))
+
+(defn reg-local! [{:keys [:analysis :base-lang :lang] :as _ctx} filename binding]
+  (when analysis
+    (swap! analysis update :locals conj
+           (assoc-some binding
+                       :filename filename
+                       :lang (when (= :cljc base-lang) lang)))))
+
+(defn reg-local-usage! [{:keys [:analysis :base-lang :lang] :as _ctx} filename binding usage]
+  (when analysis
+    (swap! analysis update :local-usages conj
+           (assoc-some usage
+                       :filename filename
+                       :lang (when (= :cljc base-lang) lang)
+                       :id (:id binding)))))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -30,6 +30,7 @@
     [symbol-call node->line parse-string tag select-lang deep-merge one-of
      linter-disabled? tag sexpr string-from-token assoc-some ctx-with-bindings]]
    [clojure.java.io :as io]
+   [clojure.set :as set]
    [clojure.string :as str]
    [sci.core :as sci]))
 
@@ -109,139 +110,158 @@
      ctx)
    expr))
 
+(defn scope-end
+  "Used within extract-bindings. Extracts the end postion of the
+   scoped-expr for the binding."
+  [scoped-expr]
+  (some-> scoped-expr
+          meta
+          (select-keys [:end-row :end-col])
+          (set/rename-keys {:end-row :scope-end-row :end-col :scope-end-col})))
+
 (defn extract-bindings
-  ([ctx expr] (when expr
-                (extract-bindings ctx expr {})))
-  ([ctx expr opts]
-   (utils/handle-ignore ctx expr)
-   (let [fn-args? (:fn-args? opts)
-         keys-destructuring? (:keys-destructuring? opts)
-         expr (lift-meta-content* ctx expr)
-         t (tag expr)
-         skip-reg-binding? (:skip-reg-binding? ctx)
-         skip-reg-binding? (or skip-reg-binding?
-                               (when (and keys-destructuring? fn-args?)
-                                 (-> ctx :config :linters :unused-binding
-                                     :exclude-destructured-keys-in-fn-args)))]
-     (case t
-       :token
-       (cond
-         ;; symbol
-         (utils/symbol-token? expr)
-         (let [sym (:value expr)]
-           (when (not= '& sym)
-             (let [ns (namespace sym)
-                   valid? (or (not ns)
-                              keys-destructuring?)]
-               (if valid?
-                 (let [s (symbol (name sym))
-                       m (meta expr)
-                       t (or (types/tag-from-meta (:tag m))
-                             (:tag opts))
-                       v (assoc m
-                                :name s
-                                :filename (:filename ctx)
-                                :tag t)]
-                   (when-not skip-reg-binding?
-                     (namespace/reg-binding! ctx
-                                             (-> ctx :ns :name)
-                                             v))
-                   (namespace/check-shadowed-binding! ctx s expr)
-                   (with-meta {s v} (when t {:tag t})))
+  ([ctx expr] (extract-bindings ctx expr expr {}))
+  ([ctx expr scoped-expr opts]
+   (when expr
+     (utils/handle-ignore ctx expr)
+     (let [fn-args? (:fn-args? opts)
+           keys-destructuring? (:keys-destructuring? opts)
+           expr (lift-meta-content* ctx expr)
+           t (tag expr)
+           skip-reg-binding? (:skip-reg-binding? ctx)
+           skip-reg-binding? (or skip-reg-binding?
+                                 (when (and keys-destructuring? fn-args?)
+                                   (-> ctx :config :linters :unused-binding
+                                       :exclude-destructured-keys-in-fn-args)))
+           analyze-locals? (get-in ctx [:config :output :locals])]
+       (case t
+         :token
+         (cond
+           ;; symbol
+           (utils/symbol-token? expr)
+           (let [sym (:value expr)]
+             (when (not= '& sym)
+               (let [ns (namespace sym)
+                     valid? (or (not ns)
+                                keys-destructuring?)]
+                 (if valid?
+                   (let [s (symbol (name sym))
+                         m (meta expr)
+                         t (or (types/tag-from-meta (:tag m))
+                               (:tag opts))
+                         v (cond-> (assoc m
+                                          :name s
+                                          :str (str expr)
+                                          :filename (:filename ctx)
+                                          :tag t)
+                             analyze-locals? (-> (assoc :id (gensym))
+                                                 (merge (scope-end scoped-expr))))]
+                     (when-not skip-reg-binding?
+                       (namespace/reg-binding! ctx
+                                               (-> ctx :ns :name)
+                                               v))
+                     (namespace/check-shadowed-binding! ctx s expr)
+                     (with-meta {s v} (when t {:tag t})))
+                   (findings/reg-finding!
+                     ctx
+                     (node->line (:filename ctx)
+                                 expr
+                                 :error
+                                 :syntax
+                                 (str "unsupported binding form " sym)))))))
+           ;; keyword
+           (:k expr)
+           (let [k (:k expr)]
+             (usages/analyze-keyword ctx expr)
+             (if keys-destructuring?
+               (let [s (-> k name symbol)
+                     m (meta expr)
+                     v (cond-> (assoc m
+                                      :str (str expr)
+                                      :name s
+                                      :filename (:filename ctx))
+                         analyze-locals? (-> (assoc :id (gensym))
+                                             (merge (scope-end scoped-expr))))]
+                 (when-not skip-reg-binding?
+                   (namespace/reg-binding! ctx
+                                           (-> ctx :ns :name)
+                                           v))
+                 {s v})
+               ;; TODO: we probably need to check if :as is supported in this
+               ;; context, e.g. seq-destructuring?
+               (when (not= :as k)
                  (findings/reg-finding!
-                  ctx
-                  (node->line (:filename ctx)
-                              expr
-                              :error
-                              :syntax
-                              (str "unsupported binding form " sym)))))))
-         ;; keyword
-         (:k expr)
-         (let [k (:k expr)]
-           (usages/analyze-keyword ctx expr)
-           (if keys-destructuring?
-             (let [s (-> k name symbol)
-                   m (meta expr)
-                   v (assoc m
-                            :name s
-                            :filename (:filename ctx))]
-               (when-not skip-reg-binding?
-                 (namespace/reg-binding! ctx
-                                         (-> ctx :ns :name)
-                                         v))
-               {s v})
-             ;; TODO: we probably need to check if :as is supported in this
-             ;; context, e.g. seq-destructuring?
-             (when (not= :as k)
-               (findings/reg-finding!
-                ctx
-                (node->line (:filename ctx)
-                            expr
-                            :error
-                            :syntax
-                            (str "unsupported binding form " k))))))
-         :else
+                   ctx
+                   (node->line (:filename ctx)
+                               expr
+                               :error
+                               :syntax
+                               (str "unsupported binding form " k))))))
+           :else
+           (findings/reg-finding!
+             ctx
+             (node->line (:filename ctx)
+                         expr
+                         :error
+                         :syntax
+                         (str "unsupported binding form " expr))))
+         :vector (let [v (map #(extract-bindings ctx % scoped-expr opts) (:children expr))
+                       tags (map :tag (map meta v))
+                       expr-meta (meta expr)
+                       t (:tag expr-meta)
+                       t (when t (types/tag-from-meta t))]
+                   (with-meta (into {} v)
+                              ;; this is used for checking the return tag of a function body
+                              (assoc expr-meta
+                                     :tag t
+                                     :tags tags)))
+         :namespaced-map (extract-bindings ctx (first (:children expr)) scoped-expr opts)
+         :map
+         ;; first check even amount of keys + vals
+         (do (key-linter/lint-map-keys ctx expr)
+             (loop [[k v & rest-kvs] (:children expr)
+                    res {}]
+               (if k
+                 (let [k (lift-meta-content* ctx k)]
+                   (cond (:k k)
+                         (do
+                           (analyze-usages2 ctx k)
+                           (case (keyword (name (:k k)))
+                             (:keys :syms :strs)
+                             (recur rest-kvs
+                                    (into res (map #(extract-bindings
+                                                      ctx
+                                                      %
+                                                      scoped-expr
+                                                      (assoc opts :keys-destructuring? true)))
+                                          (:children v)))
+                             ;; or doesn't introduce new bindings, it only gives defaults
+                             :or
+                             (if (empty? rest-kvs)
+                               ;; or can refer to a binding introduced by what we extracted
+                               (let [prev-ctx ctx
+                                     ctx (ctx-with-bindings ctx res)]
+                                 (analyze-keys-destructuring-defaults ctx prev-ctx res v opts)
+                                 (recur rest-kvs res))
+                               ;; analyze or after the rest
+                               (recur (concat rest-kvs [k v]) res))
+                             :as (if (-> ctx :config :linters :unused-binding
+                                         :exclude-destructured-as)
+                                   (recur rest-kvs (merge res (extract-bindings (assoc ctx :skip-reg-binding? true) v scoped-expr opts)))
+                                   (recur rest-kvs (merge res (extract-bindings ctx v scoped-expr opts))))
+                             (recur rest-kvs res)))
+                         :else
+                         (recur rest-kvs (merge res
+                                                (extract-bindings ctx k scoped-expr opts)
+                                                {:analyzed (analyze-expression** ctx v)}))))
+                 res)))
          (findings/reg-finding!
-          ctx
-          (node->line (:filename ctx)
-                      expr
-                      :error
-                      :syntax
-                      (str "unsupported binding form " expr))))
-       :vector (let [v (map #(extract-bindings ctx % opts) (:children expr))
-                     tags (map :tag (map meta v))
-                     expr-meta (meta expr)
-                     t (:tag expr-meta)
-                     t (when t (types/tag-from-meta t))]
-                 (with-meta (into {} v)
-                   ;; this is used for checking the return tag of a function body
-                   (assoc expr-meta
-                          :tag t
-                          :tags tags)))
-       :namespaced-map (extract-bindings ctx (first (:children expr)) opts)
-       :map
-       ;; first check even amount of keys + vals
-       (do (key-linter/lint-map-keys ctx expr)
-           (loop [[k v & rest-kvs] (:children expr)
-                  res {}]
-             (if k
-               (let [k (lift-meta-content* ctx k)]
-                 (cond (:k k)
-                       (do
-                         (analyze-usages2 ctx k)
-                         (case (keyword (name (:k k)))
-                           (:keys :syms :strs)
-                           (recur rest-kvs
-                                  (into res (map #(extract-bindings
-                                                   ctx %
-                                                   (assoc opts :keys-destructuring? true)))
-                                        (:children v)))
-                           ;; or doesn't introduce new bindings, it only gives defaults
-                           :or
-                           (if (empty? rest-kvs)
-                             ;; or can refer to a binding introduced by what we extracted
-                             (let [prev-ctx ctx
-                                   ctx (ctx-with-bindings ctx res)]
-                               (analyze-keys-destructuring-defaults ctx prev-ctx res v opts)
-                               (recur rest-kvs res))
-                             ;; analyze or after the rest
-                             (recur (concat rest-kvs [k v]) res))
-                           :as (if (-> ctx :config :linters :unused-binding
-                                       :exclude-destructured-as)
-                                (recur rest-kvs (merge res (extract-bindings (assoc ctx :skip-reg-binding? true) v opts)))
-                                (recur rest-kvs (merge res (extract-bindings ctx v opts))))
-                           (recur rest-kvs res)))
-                       :else
-                       (recur rest-kvs (merge res (extract-bindings ctx k opts)
-                                              {:analyzed (analyze-expression** ctx v)}))))
-               res)))
-       (findings/reg-finding!
-        ctx
-        (node->line (:filename ctx)
-                    expr
-                    :error
-                    :syntax
-                    (str "unsupported binding form " expr)))))))
+           ctx
+           (node->line (:filename ctx)
+                       expr
+                       :error
+                       :syntax
+                       (str "unsupported binding form " expr))))))))
 
 (defn analyze-in-ns [ctx {:keys [:children] :as expr}]
   (let [{:keys [:row :col]} expr
@@ -290,7 +310,7 @@
                                            :warning
                                            :syntax
                                            "Function arguments should be wrapped in vector."))
-        (let [arg-bindings (extract-bindings ctx arg-vec {:fn-args? true})
+        (let [arg-bindings (extract-bindings ctx arg-vec (:fn-body body) {:fn-args? true})
               {return-tag :tag
                arg-tags :tags} (meta arg-bindings)
               arg-list (sexpr arg-vec)
@@ -374,13 +394,13 @@
            :ret return-tag
            :args arg-tags)))
 
-(defn fn-bodies [ctx children]
+(defn fn-bodies [ctx children body]
   (loop [[expr & rest-exprs :as exprs] children]
     (when expr
       (let [expr (meta/lift-meta-content2 ctx expr)
             t (tag expr)]
         (case t
-          :vector [{:children exprs}]
+          :vector [{:children exprs :fn-body body}]
           :list exprs
           (recur rest-exprs))))))
 
@@ -415,7 +435,7 @@
         private? (or (= "defn-" call)
                      (:private var-meta))
         docstring (string-from-token (first children))
-        bodies (fn-bodies ctx children)
+        bodies (fn-bodies ctx children expr)
         _ (when (empty? bodies)
             (findings/reg-finding! ctx
                                    (node->line (:filename ctx)
@@ -471,13 +491,13 @@
          (nnext exprs)
          (into parsed (analyze-expression** ctx expr)))))))
 
-(defn expr-bindings [ctx binding-vector]
+(defn expr-bindings [ctx binding-vector scoped-expr]
   (->> binding-vector :children
        (take-nth 2)
-       (map #(extract-bindings ctx %))
+       (map #(extract-bindings ctx % scoped-expr {}))
        (reduce deep-merge {})))
 
-(defn analyze-let-like-bindings [ctx binding-vector]
+(defn analyze-let-like-bindings [ctx binding-vector scoped-expr]
   (let [resolved-as-clojure-var-name (:resolved-as-clojure-var-name ctx)
         for-like? (one-of resolved-as-clojure-var-name [for doseq])
         callstack (:callstack ctx)
@@ -506,7 +526,7 @@
                    new-analyzed :analyzed
                    new-arities :arities}
                   (analyze-let-like-bindings
-                   (ctx-with-bindings ctx bindings) value)]
+                   (ctx-with-bindings ctx bindings) value scoped-expr)]
               (recur rest-bindings
                      (merge bindings new-bindings)
                      (merge arities new-arities)
@@ -525,7 +545,7 @@
                         (let [maybe-call (get @(:calls-by-id ctx) value-id)]
                           (cond maybe-call (:ret maybe-call)
                                 value (types/expr->tag ctx* value))))
-                  new-bindings (when binding (extract-bindings ctx* binding {:tag tag}))
+                  new-bindings (when binding (extract-bindings ctx* binding scoped-expr {:tag tag}))
                   analyzed-binding (:analyzed new-bindings)
                   new-bindings (dissoc new-bindings :analyzed)
                   next-arities (if-let [arity (:arity (meta analyzed-value))]
@@ -589,7 +609,7 @@
             (analyze-let-like-bindings
              (-> ctx
                  ;; prevent linting redundant let when using let in bindings
-                 (update :callstack #(cons [nil :let-bindings] %))) valid-bv-node)
+                 (update :callstack #(cons [nil :let-bindings] %))) valid-bv-node expr)
             let-body (nnext (:children expr))
             let-parent (when (and current-let (= 1 (count let-body)))
                          current-let)
@@ -647,24 +667,24 @@
         bv (first children)
         vec? (when bv (= :vector (tag bv)))]
     (when vec?
-      (let [bindings (expr-bindings ctx bv)
+      (let [if? (one-of call [if-let if-some])
             condition (-> bv :children second)
             body-exprs (next children)
+            bindings (expr-bindings ctx bv (if if? (first body-exprs) expr))
             ctx-with-binding (ctx-with-bindings ctx
                                                 (dissoc bindings
-                                                        :analyzed))
-            if? (one-of call [if-let if-some])]
+                                                        :analyzed))]
         (lint-two-forms-binding-vector! ctx call bv)
         (concat (:analyzed bindings)
                 (analyze-expression** ctx condition)
                 (if if?
                   ;; in the case of if, the binding is only valid in the first expression
                   (concat
-                   (analyze-expression** (ctx-with-bindings ctx
-                                                            (dissoc bindings
-                                                                    :analyzed))
-                                         (first body-exprs))
-                   (analyze-children ctx (rest body-exprs) false))
+                    (analyze-expression** (ctx-with-bindings ctx
+                                                             (dissoc bindings
+                                                                     :analyzed))
+                                          (first body-exprs))
+                    (analyze-children ctx (rest body-exprs) false))
                   (analyze-children ctx-with-binding body-exprs false)))))))
 
 (defn fn-arity [ctx bodies]
@@ -681,9 +701,9 @@
         ?fn-name (when-let [?name-expr (second children)]
                    (when-let [n (utils/symbol-from-token ?name-expr)]
                      n))
-        bodies (fn-bodies ctx (next children))
+        bodies (fn-bodies ctx (next children) expr)
         ;; we need the arity beforehand because this is valid in each body
-        arity (fn-arity ctx bodies)
+        arity (fn-arity (assoc ctx :skip-reg-binding? true) bodies)
         parsed-bodies
         (map #(analyze-fn-body
                (if ?fn-name
@@ -767,18 +787,22 @@
 (defn analyze-letfn [ctx expr]
   (let [fns (-> expr :children second :children)
         name-exprs (map #(-> % :children first) fns)
-        ctx (ctx-with-bindings ctx
-                               (map (fn [name-expr]
-                                      [(:value name-expr)
-                                       (assoc (meta name-expr)
+        bindings (when (seq name-exprs)
+                   (mapv (fn [name-expr]
+                           (let [v (-> (meta name-expr)
+                                       (assoc :id (gensym)
                                               :name (:value name-expr)
-                                              :filename (:filename ctx))])
-                                    name-exprs))
+                                              :filename (:filename ctx))
+                                       (merge (scope-end expr)))]
+                             (namespace/reg-binding! ctx (-> ctx :ns :name) v)
+                             [(:value name-expr) v]))
+                        name-exprs))
+        ctx (ctx-with-bindings ctx bindings)
         processed-fns (for [f fns
                             :let [children (:children f)
                                   fn-name (:value (first children))
-                                  bodies (fn-bodies ctx (next children))
-                                  arity (fn-arity ctx bodies)]]
+                                  bodies (fn-bodies ctx (next children) f)
+                                  arity (fn-arity (assoc ctx :skip-reg-binding? true) bodies)]]
                         {:name fn-name
                          :arity arity
                          :bodies bodies})
@@ -829,7 +853,8 @@
   ;; TODO: optimize getting the filename from the ctx etc in this function, for the happy path
   (let [callstack (:callstack ctx)
         config (:config ctx)
-        ns-name (-> ctx :ns :name)]
+        ns-name (-> ctx :ns :name)
+        m (meta expr)]
     ;;(prn (:tag binding))
     (when-let [k (types/keyword binding)]
       (when-not (types/match? k :ifn)
@@ -839,7 +864,12 @@
                                                        (str/capitalize (types/label k)))))))
     (namespace/reg-used-binding! ctx
                                  ns-name
-                                 binding)
+                                 binding
+                                 (assoc-some m
+                                             :str (:string-value expr)
+                                             :name (:value expr)
+                                             :filename (:filename ctx)
+                                             :tag (types/tag-from-meta (:tag m))))
     (when-not (config/skip? config :invalid-arity callstack)
       (let [filename (:filename ctx)
             children (:children expr)]
@@ -874,7 +904,7 @@
 (defn analyze-catch [ctx expr]
   (let [[class-expr binding-expr & exprs] (next (:children expr))
         _ (analyze-expression** ctx class-expr) ;; analyze usage for unused import linter
-        binding (extract-bindings ctx binding-expr)]
+        binding (extract-bindings ctx binding-expr (last exprs) {})]
     (analyze-children (ctx-with-bindings ctx binding)
                       exprs)))
 
@@ -955,7 +985,9 @@
         field-count (when bindings? (count (:children binding-vector)))
         bindings (when bindings? (extract-bindings (assoc ctx
                                                           :skip-reg-binding? true)
-                                                   binding-vector))
+                                                   binding-vector
+                                                   expr
+                                                   {}))
         ctx (ctx-with-bindings ctx bindings)]
     (namespace/reg-var! ctx ns-name record-name expr metadata)
     (when-not (= 'definterface resolved-as)
@@ -983,7 +1015,7 @@
   (let [children (next (:children expr))
         [method-name-node dispatch-val-node & body-exprs] children
         _ (analyze-usages2 ctx method-name-node)
-        bodies (fn-bodies ctx body-exprs)
+        bodies (fn-bodies ctx body-exprs expr)
         analyzed-bodies (map #(analyze-fn-body ctx %) bodies)]
     (concat (analyze-expression** ctx dispatch-val-node)
             (mapcat :parsed analyzed-bodies))))
@@ -991,8 +1023,8 @@
 (defn analyze-areduce [ctx expr]
   (let [children (next (:children expr))
         [array-expr index-binding-expr ret-binding-expr init-expr body] children
-        index-binding (extract-bindings ctx index-binding-expr)
-        ret-binding (extract-bindings ctx ret-binding-expr)
+        index-binding (extract-bindings ctx index-binding-expr expr {})
+        ret-binding (extract-bindings ctx ret-binding-expr expr {})
         bindings (merge index-binding ret-binding)
         analyzed-array-expr (analyze-expression** ctx array-expr)
         analyzed-init-expr (analyze-expression** ctx init-expr)
@@ -1001,7 +1033,7 @@
 
 (defn analyze-this-as [ctx expr]
   (let [[binding-expr & body-exprs] (next (:children expr))
-        binding (extract-bindings ctx binding-expr)]
+        binding (extract-bindings ctx binding-expr expr {})]
     (analyze-children (ctx-with-bindings ctx binding)
                       body-exprs)))
 
@@ -1009,7 +1041,7 @@
   (let [children (next (:children expr))
         [as-expr name-expr & forms-exprs] children
         analyzed-as-expr (analyze-expression** ctx as-expr)
-        binding (extract-bindings ctx name-expr)]
+        binding (extract-bindings ctx name-expr expr {})]
     (concat analyzed-as-expr
             (analyze-children (ctx-with-bindings ctx binding)
                               forms-exprs))))
@@ -1198,13 +1230,14 @@
       (let [ns-name (-> ctx :ns :name)]
         (namespace/reg-used-binding! ctx
                                      ns-name
-                                     this-binding))))
+                                     this-binding
+                                     nil))))
   (analyze-children ctx (nnext (:children expr)) false))
 
 (defn analyze-amap [ctx expr]
   (let [[_ array idx-binding ret-binding body] (:children expr)
         ctx (ctx-with-bindings ctx
-                               (into {} (map #(extract-bindings ctx %)
+                               (into {} (map #(extract-bindings ctx % expr {})
                                              [idx-binding ret-binding])))]
     (analyze-children ctx [array body] false)))
 

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -78,17 +78,14 @@
                (let [simple? (simple-symbol? symbol-val)]
                  (if-let [b (when (and simple? (not syntax-quote?))
                               (get (:bindings ctx) symbol-val))]
-                   (let [m (meta expr)
-                         v (assoc-some m
-                                       :name symbol-val
-                                       :filename (:filename ctx)
-                                       :str (:string-value expr)
-                                       :tag (or (types/tag-from-meta (:tag m))
-                                                (:tag opts)))]
-                     (namespace/reg-used-binding! ctx
-                                                  (-> ns :name)
-                                                  b
-                                                  v))
+                   (namespace/reg-used-binding! ctx
+                                                (-> ns :name)
+                                                b
+                                                (when (get-in ctx [:config :output :analysis :locals])
+                                                  (assoc-some (meta expr)
+                                                              :name symbol-val
+                                                              :filename (:filename ctx)
+                                                              :str (:string-value expr))))
                    (let [{resolved-ns :ns
                           resolved-name :name
                           unresolved? :unresolved?

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -212,13 +212,11 @@
 
 (defn reg-binding!
   [{:keys [:base-lang :lang :namespaces :filename] :as ctx} ns-sym binding]
-  (let [config (:config ctx)
-        analyze-locals? (-> config :output :locals)]
-    (when-not (:clj-kondo/mark-used binding)
-      (when analyze-locals?
-        (analysis/reg-local! ctx filename binding))
-      (swap! namespaces update-in [base-lang lang ns-sym :bindings]
-             conj binding)))
+  (when-not (:clj-kondo/mark-used binding)
+    (when (-> ctx :config :output :analysis :locals)
+      (analysis/reg-local! ctx filename binding))
+    (swap! namespaces update-in [base-lang lang ns-sym :bindings]
+           conj binding))
   nil)
 
 (defn reg-destructuring-default!
@@ -230,13 +228,11 @@
 
 (defn reg-used-binding!
   [{:keys [:base-lang :lang :namespaces :filename] :as ctx} ns-sym binding usage]
-  (let [config (:config ctx)
-        analyze-locals? (-> config :output :locals)]
-    (when (and usage analyze-locals? (not (:clj-kondo/mark-used binding)))
-      (analysis/reg-local-usage! ctx filename binding usage))
-    (swap! namespaces update-in [base-lang lang ns-sym :used-bindings]
-           conj binding)
-    nil))
+  (when (and usage (-> ctx :config :output :analysis :locals) (not (:clj-kondo/mark-used binding)))
+    (analysis/reg-local-usage! ctx filename binding usage))
+  (swap! namespaces update-in [base-lang lang ns-sym :used-bindings]
+         conj binding)
+  nil)
 
 (defn reg-required-namespaces!
   [{:keys [:base-lang :lang :namespaces] :as ctx} ns-sym analyzed-require-clauses]

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -17,9 +17,9 @@
                        config))))))
 
 (deftest locals-analysis-test
-  (let [a (analyze "#(inc %1 %&)" {:config {:output {:analysis true :locals true}}})]
+  (let [a (analyze "#(inc %1 %&)" {:config {:output {:analysis {:locals true}}}})]
     (is (= [] (:locals a) (:local-usages a))))
-  (let [a (analyze "(areduce [] i j 0 (+ i j))" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(areduce [] i j 0 (+ i j))" {:config {:output {:analysis {:locals true}}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -28,7 +28,7 @@
       (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(defn x [a] (let [a a] a) a)" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(defn x [a] (let [a a] a) a)" {:config {:output {:analysis {:locals true}}}})
         [first-a second-a] (:locals a)
         [first-use second-use third-use] (:local-usages a)]
     (assert-submaps
@@ -37,14 +37,14 @@
       (:locals a))
     (is (= (:id first-a) (:id first-use) (:id third-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(as-> {} $ $)" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(as-> {} $ $)" {:config {:output {:analysis {:locals true}}}})
         [first-a] (:locals a)
         [first-use] (:local-usages a)]
     (assert-submaps
       [{:end-col 11 :scope-end-col 14}]
       (:locals a))
     (is (= (:id first-a) (:id first-use))))
-  (let [a (analyze "(letfn [(a [b] b)] a)" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(letfn [(a [b] b)] a)" {:config {:output {:analysis {:locals true}}}})
          [first-a second-a] (:locals a)
          [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -53,7 +53,7 @@
       (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(let [a 0] (let [a a] a))" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(let [a 0] (let [a a] a))" {:config {:output {:analysis {:locals true}}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -62,7 +62,7 @@
       (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(let [a 0 a a] a)" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(let [a 0 a a] a)" {:config {:output {:analysis {:locals true}}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -71,7 +71,7 @@
       (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(if-let [a 0] a a)" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(if-let [a 0] a a)" {:config {:output {:analysis {:locals true}}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -79,7 +79,7 @@
       (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= nil second-a second-use)))
-  (let [a (analyze "(for [a [123] :let [a a] :when a] a)" {:config {:output {:analysis true :locals true}}})
+  (let [a (analyze "(for [a [123] :let [a a] :when a] a)" {:config {:output {:analysis {:locals true}}}})
         [first-a second-a] (:locals a)
         [first-use second-use third-use] (:local-usages a)]
     (assert-submaps

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -16,6 +16,80 @@
                         :config {:output {:analysis true}}}
                        config))))))
 
+(deftest locals-analysis-test
+  (let [a (analyze "#(inc %1 %&)" {:config {:output {:analysis true :locals true}}})]
+    (is (= [] (:locals a) (:local-usages a))))
+  (let [a (analyze "(areduce [] i j 0 (+ i j))" {:config {:output {:analysis true :locals true}}})
+        [first-a second-a] (:locals a)
+        [first-use second-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 14 :scope-end-col 27}
+       {:end-col 16 :scope-end-col 27}]
+      (:locals a))
+    (is (= (:id first-a) (:id first-use)))
+    (is (= (:id second-a) (:id second-use))))
+  (let [a (analyze "(defn x [a] (let [a a] a) a)" {:config {:output {:analysis true :locals true}}})
+        [first-a second-a] (:locals a)
+        [first-use second-use third-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 11 :scope-end-col 29}
+       {:end-col 20 :scope-end-col 26}]
+      (:locals a))
+    (is (= (:id first-a) (:id first-use) (:id third-use)))
+    (is (= (:id second-a) (:id second-use))))
+  (let [a (analyze "(as-> {} $ $)" {:config {:output {:analysis true :locals true}}})
+        [first-a] (:locals a)
+        [first-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 11 :scope-end-col 14}]
+      (:locals a))
+    (is (= (:id first-a) (:id first-use))))
+  (let [a (analyze "(letfn [(a [b] b)] a)" {:config {:output {:analysis true :locals true}}})
+         [first-a second-a] (:locals a)
+         [first-use second-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 11 :scope-end-col 22}
+       {:end-col 14 :scope-end-col 18}]
+      (:locals a))
+    (is (= (:id first-a) (:id first-use)))
+    (is (= (:id second-a) (:id second-use))))
+  (let [a (analyze "(let [a 0] (let [a a] a))" {:config {:output {:analysis true :locals true}}})
+        [first-a second-a] (:locals a)
+        [first-use second-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 8 :scope-end-col 26}
+       {:end-col 19 :scope-end-col 25}]
+      (:locals a))
+    (is (= (:id first-a) (:id first-use)))
+    (is (= (:id second-a) (:id second-use))))
+  (let [a (analyze "(let [a 0 a a] a)" {:config {:output {:analysis true :locals true}}})
+        [first-a second-a] (:locals a)
+        [first-use second-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 8 :scope-end-col 18}
+       {:end-col 12 :scope-end-col 18}]
+      (:locals a))
+    (is (= (:id first-a) (:id first-use)))
+    (is (= (:id second-a) (:id second-use))))
+  (let [a (analyze "(if-let [a 0] a a)" {:config {:output {:analysis true :locals true}}})
+        [first-a second-a] (:locals a)
+        [first-use second-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 11 :scope-end-col 16}]
+      (:locals a))
+    (is (= (:id first-a) (:id first-use)))
+    (is (= nil second-a second-use)))
+  (let [a (analyze "(for [a [123] :let [a a] :when a] a)" {:config {:output {:analysis true :locals true}}})
+        [first-a second-a] (:locals a)
+        [first-use second-use third-use] (:local-usages a)]
+    (assert-submaps
+      [{:end-col 8 :scope-end-col 37}
+       {:end-col 22 :scope-end-col 37}]
+      (:locals a))
+    (is (not= (:id first-a) (:id second-a)))
+    (is (= (:id first-a) (:id first-use)))
+    (is (= (:id second-a) (:id second-use) (:id third-use)))))
+
 (deftest analysis-test
   (let [{:keys [:var-definitions
                 :var-usages]} (analyze "(defn ^:deprecated foo \"docstring\" {:added \"1.2\"} [])")]


### PR DESCRIPTION
As described in #982, this is to add an extra level of analysis to kondo for other tools.

A new config output flag `:locals` to turn this on.

`:scope-end-col` and `:scope-end-row` are important keys on the `:locals` analysis for completion type tools that need to know at what positions a var is valid for (using the `:end-row` and `:end-col` of a symbol is sufficient for start of completion in most cases but an argument could be made for a more explicit `:scope-start-row/col`.

The `:str` is important to know how an expr appears in code as it is difficult (impossible?) to recreate the string from the symbol and namespace with namespaced keywords and destructuring differences.

Locally I have 5 failing tests on master, and this branch has the same, so it seems like an environment problem that I hope ci accounts for.

https://github.com/clojure-lsp/clojure-lsp/pull/176