### PR TITLE
[#1056] Detect duplicate key in '{[1 2] 3, (1 2) 4}

### DIFF
--- a/parser/clj_kondo/impl/rewrite_clj/node/protocols.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/node/protocols.clj
@@ -43,7 +43,7 @@
 (defn ^:no-doc concat-strings
   "Convert nodes to strings and concatenate them."
   [nodes]
-  (string/join " " (map string nodes)))
+  (reduce str (map string nodes)))
 
 ;; ## Inner Node
 

--- a/parser/clj_kondo/impl/rewrite_clj/node/protocols.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/node/protocols.clj
@@ -43,7 +43,7 @@
 (defn ^:no-doc concat-strings
   "Convert nodes to strings and concatenate them."
   [nodes]
-  (reduce str (map string nodes)))
+  (string/join " " (map string nodes)))
 
 ;; ## Inner Node
 

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -5,7 +5,7 @@
    [clj-kondo.impl.utils :refer [node->line tag]]))
 
 (defn key-value
-  "We only support tokens as key values for now."
+  "We only support tokens, vectors and lists as key values for now."
   [node]
   (case (tag node)
     :token (or (when-let [v (:k node)]

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -12,6 +12,8 @@
                  (if (:namespaced? node)
                    (str v) v))
                (str node))
+    :vector (map key-value (:children node))
+    :list (map key-value (:children node))
     nil))
 
 (defn lint-map-keys

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -2,8 +2,7 @@
   {:no-doc true}
   (:require
    [clj-kondo.impl.findings :as findings]
-   [clj-kondo.impl.utils :refer [node->line tag]]
-   [clojure.string :as string]))
+   [clj-kondo.impl.utils :refer [node->line tag]]))
 
 (defn- map-without-nils
   "Like map, but returns nil if any mapped value is nil."
@@ -33,30 +32,6 @@
     :quote (recur (first (:children node)))
     nil))
 
-(defn- stringify-key-expr
-  [node]
-  (case (tag node)
-    :vector (->> (:children node)
-                 (map stringify-key-expr)
-                 (string/join " ")
-                 (format "[%s]"))
-    :list (->> (:children node)
-               (map stringify-key-expr)
-               (string/join " ")
-               (format "(%s)"))
-    :set (->> (:children node)
-              (map stringify-key-expr)
-              (string/join " ")
-              (format "#{%s}"))
-    :map (->> (:children node)
-              (map stringify-key-expr)
-              (string/join " ")
-              (format "{%s}"))
-    :quote (str (:prefix node)
-                (reduce str (map stringify-key-expr
-                                 (:children node))))
-    (str node)))
-
 (defn lint-map-keys
   ([ctx expr]
    (lint-map-keys ctx expr nil))
@@ -75,13 +50,13 @@
                ctx
                (node->line filename
                            key-expr :error :duplicate-map-key
-                           (str "duplicate key " (stringify-key-expr key-expr)))))
+                           (str "duplicate key " key-expr))))
             (when-not (known-key? k)
               (findings/reg-finding!
                ctx
                (node->line filename
                            key-expr :error :syntax
-                           (str "unknown option " (stringify-key-expr key-expr)))))
+                           (str "unknown option " key-expr))))
             (update acc :seen conj k))
           acc))
       {:seen #{}}

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -6,7 +6,7 @@
    [clojure.string :as string]))
 
 (defn key-value
-  "We only support tokens, vectors, quoted forms and lists as key values for now."
+  "We only support the following cases for now."
   [node]
   (case (tag node)
     :token (or (when-let [v (:k node)]
@@ -15,6 +15,7 @@
                (str node))
     :vector (map key-value (:children node))
     :list (map key-value (:children node))
+    :set (set (map key-value (:children node)))
     :quote (recur (first (:children node)))
     nil))
 
@@ -29,6 +30,10 @@
                (map stringify-key-expr)
                (string/join " ")
                (format "(%s)"))
+    :set (->> (:children node)
+              (map stringify-key-expr)
+              (string/join " ")
+              (format "#{%s}"))
     :quote (str (:prefix node)
                 (reduce str (map stringify-key-expr
                                  (:children node))))

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -8,13 +8,13 @@
 (defn- map-without-nils
   "Like map, but returns nil if any mapped value is nil."
   [f coll]
-  (-> (reduce (fn [acc v]
-                (if-let [new-v (f v)]
-                  (conj! acc new-v)
-                  (reduced nil)))
-              (transient [])
-              coll)
-      persistent!))
+  (some-> (reduce (fn [acc v]
+                    (if-let [new-v (f v)]
+                      (conj! acc new-v)
+                      (reduced nil)))
+                  (transient [])
+                  coll)
+          persistent!))
 
 (defn key-value
   "We only support the following cases for now."

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -5,7 +5,7 @@
    [clj-kondo.impl.utils :refer [node->line tag]]))
 
 (defn key-value
-  "We only support tokens, vectors and lists as key values for now."
+  "We only support tokens, vectors, quoted forms and lists as key values for now."
   [node]
   (case (tag node)
     :token (or (when-let [v (:k node)]
@@ -14,6 +14,7 @@
                (str node))
     :vector (map key-value (:children node))
     :list (map key-value (:children node))
+    :quote (recur (first (:children node)))
     nil))
 
 (defn lint-map-keys

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -16,6 +16,7 @@
     :vector (map key-value (:children node))
     :list (map key-value (:children node))
     :set (set (map key-value (:children node)))
+    :map (apply hash-map (map key-value (:children node)))
     :quote (recur (first (:children node)))
     nil))
 
@@ -34,6 +35,10 @@
               (map stringify-key-expr)
               (string/join " ")
               (format "#{%s}"))
+    :map (->> (:children node)
+              (map stringify-key-expr)
+              (string/join " ")
+              (format "{%s}"))
     :quote (str (:prefix node)
                 (reduce str (map stringify-key-expr
                                  (:children node))))

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -8,12 +8,13 @@
 (defn- map-without-nils
   "Like map, but returns nil if any mapped value is nil."
   [f coll]
-  (reduce (fn [acc v]
-            (if-let [new-v (f v)]
-              (conj acc new-v)
-              (reduced nil)))
-          []
-          coll))
+  (-> (reduce (fn [acc v]
+                (if-let [new-v (f v)]
+                  (conj! acc new-v)
+                  (reduced nil)))
+              (transient [])
+              coll)
+      persistent!))
 
 (defn key-value
   "We only support the following cases for now."

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -63,9 +63,12 @@
 (deftest analyze-input-test
   (let [findings (atom [])
         analyze (fn [^String source]
-                  (ana/analyze-input {:config {:linters {:syntax {:level :error}}}
+                  (ana/analyze-input {:config {:linters {:syntax {:level :error}
+                                                         :duplicate-map-key {:level :error}}}
                                       :findings findings
-                                      :ignores (atom {})} "test.clj" source :clj false))]
+                                      :ignores (atom {})
+                                      :namespaces (atom {})
+                                      :used-namespaces (atom {})} "test.clj" source :clj false))]
     (testing "unmatched delimiters"
       (is (= [{:type :syntax
                :level :error
@@ -109,7 +112,48 @@
              (do
                (reset! findings [])
                (analyze "1..1")
-               @findings))))))
+               @findings))))
+
+    (testing "duplicate map keys"
+      (testing "when the map keys are simple sequences"
+        (is (= [{:type :duplicate-map-key
+                 :level :error
+                 :filename "test.clj"
+                 :row 1
+                 :col 14
+                 :end-col 19
+                 :end-row 1
+                 :message "duplicate key (12)"}]
+               (do
+                 (reset! findings [])
+                 (analyze "{[1 2] \"bar\" (1 2) 12}")
+                 @findings))))
+      (testing "when the map keys are more complex forms"
+        (is (= [{:type :duplicate-map-key
+                 :level :error
+                 :filename "test.clj"
+                 :row 1
+                 :col 22
+                 :end-col 35
+                 :end-row 1
+                 :message "duplicate key (let[x2]x)"}]
+               (do
+                 (reset! findings [])
+                 (analyze "{(let [x 2] x) \"bar\" (let [x 2] x) 12}")
+                 @findings))))
+      (testing "when the map keys are simple tokens"
+        (is (= [{:type :duplicate-map-key
+                 :level :error
+                 :filename "test.clj"
+                 :row 1
+                 :col 12
+                 :end-col 15
+                 :end-row 1
+                 :message "duplicate key foo"}]
+               (do
+                 (reset! findings [])
+                 (analyze "{foo \"bar\" foo 12}")
+                 @findings)))))))
 
 
 

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -63,8 +63,7 @@
 (deftest analyze-input-test
   (let [findings (atom [])
         analyze (fn [^String source]
-                  (ana/analyze-input {:config {:linters {:syntax {:level :error}
-                                                         :duplicate-map-key {:level :error}}}
+                  (ana/analyze-input {:config {:linters {:syntax {:level :error}}}
                                       :findings findings
                                       :ignores (atom {})} "test.clj" source :clj false))]
     (testing "unmatched delimiters"

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -66,9 +66,7 @@
                   (ana/analyze-input {:config {:linters {:syntax {:level :error}
                                                          :duplicate-map-key {:level :error}}}
                                       :findings findings
-                                      :ignores (atom {})
-                                      :namespaces (atom {})
-                                      :used-namespaces (atom {})} "test.clj" source :clj false))]
+                                      :ignores (atom {})} "test.clj" source :clj false))]
     (testing "unmatched delimiters"
       (is (= [{:type :syntax
                :level :error

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -112,48 +112,7 @@
              (do
                (reset! findings [])
                (analyze "1..1")
-               @findings))))
-
-    (testing "duplicate map keys"
-      (testing "when the map keys are simple sequences"
-        (is (= [{:type :duplicate-map-key
-                 :level :error
-                 :filename "test.clj"
-                 :row 1
-                 :col 14
-                 :end-col 19
-                 :end-row 1
-                 :message "duplicate key (12)"}]
-               (do
-                 (reset! findings [])
-                 (analyze "{[1 2] \"bar\" (1 2) 12}")
-                 @findings))))
-      (testing "when the map keys are more complex forms"
-        (is (= [{:type :duplicate-map-key
-                 :level :error
-                 :filename "test.clj"
-                 :row 1
-                 :col 22
-                 :end-col 35
-                 :end-row 1
-                 :message "duplicate key (let[x2]x)"}]
-               (do
-                 (reset! findings [])
-                 (analyze "{(let [x 2] x) \"bar\" (let [x 2] x) 12}")
-                 @findings))))
-      (testing "when the map keys are simple tokens"
-        (is (= [{:type :duplicate-map-key
-                 :level :error
-                 :filename "test.clj"
-                 :row 1
-                 :col 12
-                 :end-col 15
-                 :end-row 1
-                 :message "duplicate key foo"}]
-               (do
-                 (reset! findings [])
-                 (analyze "{foo \"bar\" foo 12}")
-                 @findings)))))))
+               @findings))))))
 
 
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -893,7 +893,25 @@ foo/foo ;; this does use the private var
             :level :error
             :message "duplicate key '(1 2)"
             :row 1})
-         (lint! "{[1 2] \"bar\" '(1 2) 12}"))))
+         (lint! "{[1 2] \"bar\" '(1 2) 12}")))
+  (is (= '({:col 20
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key #{1 3 :foo}"
+            :row 1})
+         (lint! "{#{1 :foo 3} \"bar\" #{1 3 :foo} 12}")))
+  (is (= '({:col 23
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key #{1 'baz :foo}"
+            :row 1})
+         (lint! "{#{1 :foo 'baz} \"bar\" #{1 'baz :foo} 12}")))
+  (is (= '({:col 23
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key #{1 'baz :foo}"
+            :row 1})
+         (lint! "{'#{1 :foo baz} \"bar\" #{1 'baz :foo} 12}"))))
 
 (deftest map-missing-value
   (is (= '({:file "<stdin>",

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -879,13 +879,13 @@ foo/foo ;; this does use the private var
   (is (= '({:col 15
             :file "<stdin>"
             :level :error
-            :message "duplicate key (12)"
+            :message "duplicate key (1 2)"
             :row 1})
          (lint! "'{[1 2] \"bar\" (1 2) 12}")))
   (is (= '({:col 22
             :file "<stdin>"
             :level :error
-            :message "duplicate key (let[x2]x)"
+            :message "duplicate key (let [x 2] x)"
             :row 1})
          (lint! "{(let [x 2] x) \"bar\" (let [x 2] x) 12}"))))
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -923,7 +923,13 @@ foo/foo ;; this does use the private var
             :level :error
             :message "duplicate key {1 2 'foo :bar}"
             :row 1})
-         (lint! "{'{1 2 foo :bar} \"bar\" {1 2 'foo :bar} 12}"))))
+         (lint! "{'{1 2 foo :bar} \"bar\" {1 2 'foo :bar} 12}")))
+  (is (= '({:col 37
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key '{1 {:foo #{3 4} bar (1 2)}}"
+            :row 1})
+         (lint! "{{1 {:foo #{3 4} 'bar [1 2]}} \"bar\" '{1 {:foo #{3 4} bar (1 2)}} 12}"))))
 
 (deftest map-missing-value
   (is (= '({:file "<stdin>",

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -875,7 +875,19 @@ foo/foo ;; this does use the private var
   (:require [foo.bar :as bar]))
 
 (def foo {:bar/id \"asdf\"
-          ::bar/id \"lkj\"})"))))
+          ::bar/id \"lkj\"})")))
+  (is (= '({:col 15
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key (12)"
+            :row 1})
+         (lint! "'{[1 2] \"bar\" (1 2) 12}")))
+  (is (= '({:col 22
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key (let[x2]x)"
+            :row 1})
+         (lint! "{(let [x 2] x) \"bar\" (let [x 2] x) 12}"))))
 
 (deftest map-missing-value
   (is (= '({:file "<stdin>",

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -887,7 +887,13 @@ foo/foo ;; this does use the private var
             :level :error
             :message "duplicate key (let [x 2] x)"
             :row 1})
-         (lint! "{(let [x 2] x) \"bar\" (let [x 2] x) 12}"))))
+         (lint! "{(let [x 2] x) \"bar\" (let [x 2] x) 12}")))
+  (is (= '({:col 14
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key '(1 2)"
+            :row 1})
+         (lint! "{[1 2] \"bar\" '(1 2) 12}"))))
 
 (deftest map-missing-value
   (is (= '({:file "<stdin>",

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -911,7 +911,19 @@ foo/foo ;; this does use the private var
             :level :error
             :message "duplicate key #{1 'baz :foo}"
             :row 1})
-         (lint! "{'#{1 :foo baz} \"bar\" #{1 'baz :foo} 12}"))))
+         (lint! "{'#{1 :foo baz} \"bar\" #{1 'baz :foo} 12}")))
+  (is (= '({:col 14
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key {1 2}"
+            :row 1})
+         (lint! "{{1 2} \"bar\" {1 2} 12}")))
+  (is (= '({:col 24
+            :file "<stdin>"
+            :level :error
+            :message "duplicate key {1 2 'foo :bar}"
+            :row 1})
+         (lint! "{'{1 2 foo :bar} \"bar\" {1 2 'foo :bar} 12}"))))
 
 (deftest map-missing-value
   (is (= '({:file "<stdin>",


### PR DESCRIPTION
Implements https://github.com/clj-kondo/clj-kondo/issues/1056.

Output of `script/diff`: 

```
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
Cloning into 'clj-kondo'...
remote: Enumerating objects: 9672, done.
remote: Total 9672 (delta 0), reused 0 (delta 0), pack-reused 9672
Receiving objects: 100% (9672/9672), 11.04 MiB | 5.55 MiB/s, done.
Resolving deltas: 100% (5594/5594), done.
Linting and writing output to /tmp/clj-kondo-diff/master.txt
1c1
< "Elapsed time: 8.203851 msecs"
---
> "Elapsed time: 8.956134 msecs"
1966c1966
< clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2253c2253
< inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2693c2693
< linting took 10730ms, errors: 400, warnings: 2291
---
> linting took 11817ms, errors: 400, warnings: 2291
```