### PR TITLE
[#1078] Detect periods contained in lib names inside prefix lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ### New
 
+- Alpine Docker build [#1111](https://github.com/clj-kondo/clj-kondo/issues/1111)
+
 ### Enhanced / fixed
 
 - Fix finding without location info [#1101](https://github.com/clj-kondo/clj-kondo/issues/1101)

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -61,7 +61,8 @@
                                                  libspec-expr
                                                  :error
                                                  :syntax
-                                                 "Lib names inside prefix lists must not contain periods.")))
+                                                 (format "found lib name '%s' containing period with prefix '%s'. lib names inside prefix lists must not contain periods."
+                                                         form prefix))))
             [(with-meta (token-node full-form)
                (cond-> (assoc (meta libspec-expr)
                               :raw-name form)

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -46,7 +46,7 @@
                                                        libspec-expr
                                                        :error
                                                        :syntax
-                                                       "nested prefix lists are not allowed.")))
+                                                       "Prefix lists can only have two levels.")))
               (mapcat (fn [f]
                         (normalize-libspec ctx
                                            (symbol (str (when prefix (str prefix "."))

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -54,6 +54,14 @@
           (valid-ns-name? form)
           (let [full-form (symbol (str (when prefix (str prefix "."))
                                        form))]
+            (when (and prefix
+                       (str/includes? (str form) "."))
+              (findings/reg-finding! ctx
+                                     (node->line (:filename ctx)
+                                                 libspec-expr
+                                                 :error
+                                                 :syntax
+                                                 "Lib names inside prefix lists must not contain periods.")))
             [(with-meta (token-node full-form)
                (cond-> (assoc (meta libspec-expr)
                               :raw-name form)

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -41,12 +41,18 @@
         children (:children libspec-expr)
         form (sexpr libspec-expr)]
     (cond (prefix-spec? form)
-          (mapcat (fn [f]
-                    (normalize-libspec ctx
-                                       (symbol (str (when prefix (str prefix "."))
-                                                    (first form)))
-                                       f))
-                  (rest children))
+          (do (when prefix
+                (findings/reg-finding! ctx (node->line (:filename ctx)
+                                                       libspec-expr
+                                                       :error
+                                                       :syntax
+                                                       "nested prefix lists are not allowed.")))
+              (mapcat (fn [f]
+                        (normalize-libspec ctx
+                                           (symbol (str (when prefix (str prefix "."))
+                                                        (first form)))
+                                           f))
+                      (rest children)))
           (option-spec? form)
           [(with-meta
              (vector-node (into (normalize-libspec ctx prefix (first children)) (rest children)))

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -489,7 +489,7 @@ foo/foo ;; this does use the private var
    '({:col 14
       :file "corpus/prefixed_libspec.clj"
       :level :error
-      :message "nested prefix lists are not allowed."
+      :message "Prefix lists can only have two levels."
       :row 11}
      {:file "corpus/prefixed_libspec.clj",
       :row 14,

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -498,6 +498,44 @@ foo/foo ;; this does use the private var
       :message "foo.baz/c is called with 0 args but expects 1"})
    (lint! (io/file "corpus" "prefixed_libspec.clj"))))
 
+(deftest prefix-libspec-containing-periods-test
+  (testing "when a lib name with a period is found"
+    (is (= '({:col 32
+              :file "<stdin>"
+              :level :error
+              :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
+              :row 3})
+           (lint! "(ns baz
+                   (:require [clj-kondo.impl.analyzer
+                              [foo.bar :as baz]]))"
+                  {:linters {:unused-namespace {:level :off}}}))))
+  (testing "when multiple lib names with periods are found"
+    (is (= '({:col 32
+              :file "<stdin>"
+              :level :error
+              :message "found lib name 'babashka.quux' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
+              :row 3}
+             {:col 32
+              :file "<stdin>"
+              :level :error
+              :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
+              :row 4})
+           (lint! "(ns baz
+                   (:require [clj-kondo.impl.analyzer
+                              [babashka.quux :as baz]
+                              [foo.bar :as quux]]))"
+                  {:linters {:unused-namespace {:level :off}}}))))
+  (testing "when a lib name with periods is a simple symbol"
+    (is (= '({:col 31
+              :file "<stdin>"
+              :level :error
+              :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
+              :row 3})
+           (lint! "(ns baz
+                   (:require [clj-kondo.impl.analyzer
+                              foo.bar]))"
+                  {:linters {:unused-namespace {:level :off}}})))))
+
 (deftest rename-test
   (testing "the renamed function isn't available under the referred name"
     (assert-submaps
@@ -2528,36 +2566,6 @@ foo/foo ;; this does use the private var
             [echo]))
 
 " {:linters {:unsorted-required-namespaces {:level :warning}}})))))
-
-(deftest prefix-libspec-containing-periods-test
-  (is (= '({:col     32
-            :file    "<stdin>"
-            :level   :error
-            :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
-            :row     4})
-         (lint! "(ns baz
-                   (:require [clj-kondo.impl.analyzer
-                              [babashka :as baz]
-                              [foo.bar :as quux]]))"
-                {:linters {:unused-namespace {:level :off}}})))
-  (is (= '({:col     32
-            :file    "<stdin>"
-            :level   :error
-            :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
-            :row     3})
-         (lint! "(ns baz
-                   (:require [clj-kondo.impl.analyzer
-                              [foo.bar :as baz]]))"
-                {:linters {:unused-namespace {:level :off}}})))
-  (is (= '({:col     31
-            :file    "<stdin>"
-            :level   :error
-            :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
-            :row     3})
-         (lint! "(ns baz
-                   (:require [clj-kondo.impl.analyzer
-                              foo.bar]))"
-                {:linters {:unused-namespace {:level :off}}}))))
 
 (deftest set!-test
   (assert-submaps '[{:col 13 :message #"arg"}]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2475,6 +2475,36 @@ foo/foo ;; this does use the private var
 
 " {:linters {:unsorted-required-namespaces {:level :warning}}})))))
 
+(deftest require-prefix-form-containing-periods-test
+  (is (= '({:col     32
+            :file    "<stdin>"
+            :level   :error
+            :message "Lib names inside prefix lists must not contain periods."
+            :row     4})
+         (lint! "(ns baz
+                   (:require [clj-kondo.impl.analyzer
+                              [babashka :as baz]
+                              [foo.bar :as quux]]))"
+                {:linters {:unused-namespace {:level :off}}})))
+  (is (= '({:col     32
+            :file    "<stdin>"
+            :level   :error
+            :message "Lib names inside prefix lists must not contain periods."
+            :row     3})
+         (lint! "(ns baz
+                   (:require [clj-kondo.impl.analyzer
+                              [foo.bar :as baz]]))"
+                {:linters {:unused-namespace {:level :off}}})))
+  (is (= '({:col     31
+            :file    "<stdin>"
+            :level   :error
+            :message "Lib names inside prefix lists must not contain periods."
+            :row     3})
+         (lint! "(ns baz
+                   (:require [clj-kondo.impl.analyzer
+                              foo.bar]))"
+                {:linters {:unused-namespace {:level :off}}}))))
+
 (deftest set!-test
   (assert-submaps '[{:col 13 :message #"arg"}]
                   (lint! "(declare x) (set! (.-foo x) 1 2 3)"))

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -486,7 +486,12 @@ foo/foo ;; this does use the private var
 
 (deftest prefix-libspec-test []
   (assert-submaps
-   '({:file "corpus/prefixed_libspec.clj",
+   '({:col 14
+      :file "corpus/prefixed_libspec.clj"
+      :level :error
+      :message "nested prefix lists are not allowed."
+      :row 11}
+     {:file "corpus/prefixed_libspec.clj",
       :row 14,
       :col 1,
       :level :error,

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2529,11 +2529,11 @@ foo/foo ;; this does use the private var
 
 " {:linters {:unsorted-required-namespaces {:level :warning}}})))))
 
-(deftest require-prefix-form-containing-periods-test
+(deftest prefix-libspec-containing-periods-test
   (is (= '({:col     32
             :file    "<stdin>"
             :level   :error
-            :message "Lib names inside prefix lists must not contain periods."
+            :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
             :row     4})
          (lint! "(ns baz
                    (:require [clj-kondo.impl.analyzer
@@ -2543,7 +2543,7 @@ foo/foo ;; this does use the private var
   (is (= '({:col     32
             :file    "<stdin>"
             :level   :error
-            :message "Lib names inside prefix lists must not contain periods."
+            :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
             :row     3})
          (lint! "(ns baz
                    (:require [clj-kondo.impl.analyzer
@@ -2552,7 +2552,7 @@ foo/foo ;; this does use the private var
   (is (= '({:col     31
             :file    "<stdin>"
             :level   :error
-            :message "Lib names inside prefix lists must not contain periods."
+            :message "found lib name 'foo.bar' containing period with prefix 'clj-kondo.impl.analyzer'. lib names inside prefix lists must not contain periods."
             :row     3})
          (lint! "(ns baz
                    (:require [clj-kondo.impl.analyzer


### PR DESCRIPTION
Fixes https://github.com/clj-kondo/clj-kondo/issues/1078.

Output of `script/diff`:
```
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
Cloning into 'clj-kondo'...
remote: Enumerating objects: 82, done.
remote: Counting objects: 100% (82/82), done.
remote: Compressing objects: 100% (65/65), done.
remote: Total 9754 (delta 29), reused 48 (delta 11), pack-reused 9672
Receiving objects: 100% (9754/9754), 11.10 MiB | 5.71 MiB/s, done.
Resolving deltas: 100% (5623/5623), done.
Linting and writing output to /tmp/clj-kondo-diff/master.txt
1c1
< "Elapsed time: 10.222993 msecs"
---
> "Elapsed time: 9.500667 msecs"
1966c1966
< clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2253c2253
< inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2693c2693
< linting took 11818ms, errors: 400, warnings: 2291
---
> linting took 12279ms, errors: 400, warnings: 2291
```