### PR TITLE
Add name-* positions to more things.

### DIFF
--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -63,7 +63,7 @@
             :lang (when (= :cljc base-lang) lang)))))
 
 (defn reg-namespace-usage! [{:keys [:analysis :base-lang :lang] :as _ctx}
-                            filename row col from-ns to-ns alias]
+                            filename row col from-ns to-ns alias metadata]
   (when analysis
     (let [m (meta to-ns)
           to-raw (:raw-name m)
@@ -71,11 +71,12 @@
                   to-raw to-ns)]
       (swap! analysis update :namespace-usages conj
              (assoc-some
-              {:filename filename
-               :row row
-               :col col
-               :from from-ns
-               :to to-ns}
+               (merge {:filename filename
+                       :row row
+                       :col col
+                       :from from-ns
+                       :to to-ns}
+                      metadata)
               :lang (when (= :cljc base-lang) lang)
               :alias alias)))))
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -952,12 +952,14 @@
         ns-name (:name ns)]
     (when protocol-name
       (namespace/reg-var! ctx ns-name protocol-name expr
-                          {:defined-by 'clojure.core/defprotocol}))
+                          (assoc (meta name-node)
+                                 :defined-by 'clojure.core/defprotocol)))
     (doseq [c (next children)
             :when (= :list (tag c)) ;; skip first docstring
             :let [children (:children c)
                   name-node (first children)
                   name-node (meta/lift-meta-content2 ctx name-node)
+                  name-meta (meta name-node)
                   fn-name (:value name-node)
                   arity-vecs (rest children)
                   fixed-arities (set (keep #(when (= :vector (tag %))
@@ -968,6 +970,10 @@
       (when fn-name
         (namespace/reg-var!
          ctx ns-name fn-name expr (assoc (meta c)
+                                         :name-row (:row name-meta)
+                                         :name-col (:col name-meta)
+                                         :name-end-row (:end-row name-meta)
+                                         :name-end-col (:end-col name-meta)
                                          :fixed-arities fixed-arities
                                          :defined-by 'clojure.core/defprotocol))))))
 

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -416,15 +416,28 @@
     (when (-> ctx :config :output :analysis)
       (analysis/reg-namespace! ctx filename row col
                                ns-name false (assoc-some {}
+                                                         :name-row (:row metadata)
+                                                         :name-col (:col metadata)
+                                                         :name-end-row (:end-row metadata)
+                                                         :name-end-col (:end-col metadata)
                                                          :deprecated (:deprecated ns-meta)
                                                          :doc docstring
                                                          :added (:added ns-meta)
                                                          :no-doc (:no-doc ns-meta)
                                                          :author (:author ns-meta)))
       (doseq [req (:required ns)]
-        (let [{:keys [row col alias]} (meta req)]
+        (let [{:keys [row col end-row end-col alias]} (meta req)
+              meta-alias (meta alias)
+              meta-name (meta ns-name)]
           (analysis/reg-namespace-usage! ctx filename row col ns-name
-                                         req alias))))
+                                         req alias {:name-row row
+                                                    :name-col col
+                                                    :name-end-row end-row
+                                                    :name-end-col end-col
+                                                    :alias-row (:row meta-alias)
+                                                    :alias-col (:col meta-alias)
+                                                    :alias-end-row (:end-row meta-alias)
+                                                    :alias-end-col (:end-col meta-alias)}))))
     (namespace/reg-namespace! ctx ns)
     ns))
 

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -116,7 +116,9 @@
                                                       resolved-ns)
                        (namespace/reg-var-usage! ctx ns-name
                                                  {:type :use
-                                                  :name resolved-name
+                                                  :name (with-meta
+                                                          resolved-name
+                                                          m)
                                                   :resolved-ns resolved-ns
                                                   :ns ns-name
                                                   :unresolved? unresolved?

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -104,10 +104,10 @@
          metadata (assoc metadata
                          :ns ns-sym
                          :name var-sym
-                         :name-row (:row metadata)
-                         :name-col (:col metadata)
-                         :name-end-row (:end-row metadata)
-                         :name-end-col (:end-col metadata)
+                         :name-row (or (:name-row metadata) (:row metadata))
+                         :name-col (or (:name-col metadata) (:col metadata))
+                         :name-end-row (or (:name-end-row metadata) (:end-row metadata))
+                         :name-end-col (or (:name-end-col metadata) (:end-col metadata))
                          :row expr-row
                          :col expr-col
                          :end-row expr-end-row


### PR DESCRIPTION
Added to namespace-definitions.
Added to defprotocol, catch.
namespace-usages name-* points to the last piece of a namespace.
namespace-usages alias-* points to the position of the alias token.

Adds to https://github.com/clj-kondo/clj-kondo/pull/1110 a couple positions were missed and after working at integrating into clojure-lsp, the need for positioning in the namespace-definitions and the namespace-usages is also needed.