### PR TITLE
[#1099] Add :single-operand-logical linter for `and` and `or`

### DIFF
--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -82,6 +82,7 @@
                                  :aliases {#_clojure.string #_str}}
               :unused-import {:level :warning}
               :single-operand-comparison {:level :warning}
+              :single-operand-logical {:level :warning}
               :single-key-in {:level :off}
               :missing-clause-in-try {:level :warning}
               :missing-body-in-when {:level :warning}

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -82,7 +82,7 @@
                                  :aliases {#_clojure.string #_str}}
               :unused-import {:level :warning}
               :single-operand-comparison {:level :warning}
-              :single-operand-logical {:level :warning}
+              :single-logical-operand {:level :warning}
               :single-key-in {:level :off}
               :missing-clause-in-try {:level :warning}
               :missing-body-in-when {:level :warning}

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -186,7 +186,7 @@
                    (str ns-nm "/" fn-name)
                    (some? const-true))))))))
 
-(defn lint-single-operand-logical-operator
+(defn lint-single-logical-operand
   "Lints calls of single operand logical operators with always the same value."
   [call]
   (when (utils/one-of (:resolved-ns call) [clojure.core cljs.core])
@@ -197,7 +197,7 @@
          (:filename call)
          (:expr call)
          :warning
-         :single-operand-logical
+         :single-logical-operand
          (format "Single arg use of %s always returns the arg itself" call-name))))))
 
 (defn lint-var-usage
@@ -315,10 +315,10 @@
                   (and call?
                        (not (utils/linter-disabled? call :single-operand-comparison))
                        (lint-single-operand-comparison call))
-                  single-operand-logical-operator-error
+                  single-logical-operand-error
                   (and call?
-                       (not (utils/linter-disabled? call :single-operand-logical))
-                       (lint-single-operand-logical-operator call))]]
+                       (not (utils/linter-disabled? call :single-logical-operand))
+                       (lint-single-logical-operand call))]]
       (when arity-error?
         (findings/reg-finding!
          ctx
@@ -332,9 +332,9 @@
       (when single-operand-comparison-error
         (findings/reg-finding! ctx
                                single-operand-comparison-error))
-      (when single-operand-logical-operator-error
+      (when single-logical-operand-error
         (findings/reg-finding! ctx
-                               single-operand-logical-operator-error))
+                               single-logical-operand-error))
       (when (and (:private called-fn)
                  (not= caller-ns-sym
                        fn-ns)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -186,6 +186,20 @@
                    (str ns-nm "/" fn-name)
                    (some? const-true))))))))
 
+(defn lint-single-operand-logical-operator
+  "Lints calls of single operand logical operators with always the same value."
+  [call]
+  (when (utils/one-of (:resolved-ns call) [clojure.core cljs.core])
+    (let [call-name (:name call)
+          const-true (utils/one-of call-name [and or])]
+      (when (and const-true (= 1 (:arity call)))
+        (node->line
+         (:filename call)
+         (:expr call)
+         :warning
+         :single-operand-logical
+         (format "Single arg use of %s always returns the arg itself" call-name))))))
+
 (defn lint-var-usage
   "Lints calls for arity errors, private calls errors. Also dispatches
   to call-specific linters."
@@ -300,7 +314,11 @@
                   single-operand-comparison-error
                   (and call?
                        (not (utils/linter-disabled? call :single-operand-comparison))
-                       (lint-single-operand-comparison call))]]
+                       (lint-single-operand-comparison call))
+                  single-operand-logical-operator-error
+                  (and call?
+                       (not (utils/linter-disabled? call :single-operand-logical))
+                       (lint-single-operand-logical-operator call))]]
       (when arity-error?
         (findings/reg-finding!
          ctx
@@ -314,6 +332,9 @@
       (when single-operand-comparison-error
         (findings/reg-finding! ctx
                                single-operand-comparison-error))
+      (when single-operand-logical-operator-error
+        (findings/reg-finding! ctx
+                               single-operand-logical-operator-error))
       (when (and (:private called-fn)
                  (not= caller-ns-sym
                        fn-ns)

--- a/test/clj_kondo/single_operand_test.clj
+++ b/test/clj_kondo/single_operand_test.clj
@@ -41,7 +41,7 @@
                   "(def x 11)(->> x (+ 1) (> 2))"]]
       (is (empty? (lint! expr))))))
 
-(deftest single-operand-logical-operator-test
+(deftest single-logical-operand-test
   (testing "and called with one arg is a warning"
     (doseq [lang ["clj" "cljs"]]
       (assert-submaps
@@ -52,6 +52,7 @@
        '({:file "<stdin>", :row 1, :col 12, :level :warning,
           :message "Single arg use of and always returns the arg itself"})
        (lint! "(->> 1 foo and)" "--lang" lang))))
+
   (testing "or called with one arg is a warning"
     (doseq [lang ["clj" "cljs"]]
       (assert-submaps
@@ -61,4 +62,8 @@
       (assert-submaps
        '({:file "<stdin>", :row 1, :col 7, :level :warning,
           :message "Single arg use of or always returns the arg itself"})
-       (lint! "(-> 1 (or))" "--lang" lang)))))
+       (lint! "(-> 1 (or))" "--lang" lang))))
+
+  (doseq [lang ["clj" "cljs"]]
+    (is (empty? (lint! "(and 1 2)" "--lang" lang)) "and with > 1 arg is ok")
+    (is (empty? (lint! "(or 1 2 3)" "--lang" lang)) "or with > 1 arg is ok")))

--- a/test/clj_kondo/single_operand_test.clj
+++ b/test/clj_kondo/single_operand_test.clj
@@ -1,4 +1,4 @@
-(ns clj-kondo.single-operand-comparison-test
+(ns clj-kondo.single-operand-test
   (:require
    [clj-kondo.test-utils :refer [lint! assert-submaps]]
    [clojure.test :as t :refer [deftest is testing]]))
@@ -40,3 +40,25 @@
                   "(->> 10 (< 20))"
                   "(def x 11)(->> x (+ 1) (> 2))"]]
       (is (empty? (lint! expr))))))
+
+(deftest single-operand-logical-operator-test
+  (testing "and called with one arg is a warning"
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>", :row 1, :col 1, :level :warning,
+          :message "Single arg use of and always returns the arg itself"})
+       (lint! "(and 1)" "--lang" lang))
+      (assert-submaps
+       '({:file "<stdin>", :row 1, :col 12, :level :warning,
+          :message "Single arg use of and always returns the arg itself"})
+       (lint! "(->> 1 foo and)" "--lang" lang))))
+  (testing "or called with one arg is a warning"
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>", :row 1, :col 1, :level :warning,
+          :message "Single arg use of or always returns the arg itself"})
+       (lint! "(or 1)" "--lang" lang))
+      (assert-submaps
+       '({:file "<stdin>", :row 1, :col 7, :level :warning,
+          :message "Single arg use of or always returns the arg itself"})
+       (lint! "(-> 1 (or))" "--lang" lang)))))


### PR DESCRIPTION
Unsure whether to combine this with :single-operand-comparison or not. Happy to merge the two if that's a better approach.