### PR TITLE
Redundant negation

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -84,6 +84,7 @@ Some linters are not enabled by default. Right now these linters are:
 - `:unsorted-required-namespaces`: warn when namespaces in `:require` are not sorted.
 - `:refer`: warn when there is **any** usage of `:refer` in your namespace requires.
 - `:single-key-in`: warn when using assoc-in, update-in or get-in with single key.
+- `:redundant-negation`: warn on redundant use of `not` or `complement`.
 - `:shadowed-var`: warn when a binding shadows a var.
 
 You can enable these linters by setting the `:level`:

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -30,6 +30,7 @@ Table of contents:
   - [Redefined var](#redefined-var)
   - [Redundant do](#redundant-do)
   - [Redundant let](#redundant-let)
+  - [Redundant negation](#redundant-negation)
   - [Refer](#refer)
   - [Refer all](#refer-all)
   - [Single key in](#single-key-in)
@@ -491,6 +492,29 @@ because directly nested lets.
 *Example trigger:* `(let [x 1] (let [y 2] (+ x y)))`.
 
 *Example message:* `Redundant let expression.`
+
+### Redundant negation
+
+*Keyword:* `:redundant-negation`.
+
+*Description:* warn on usage of `not` or `complement` that is redundant. This includes
+`and` & `or` used with multiple `not`s, negated core fns where their complement is
+already available, and `filter` and `remove` used with negated fns. *N.b.* `:not-empty`
+is a separate (and default enabled) linter.
+
+*Default level:* `:off`.
+
+*Example trigger:* `(and (not (string? "foo")) (not (keyword? :bar)))`.
+
+*Example message:* `And & 2 nots used instead of 1 not with or`.
+
+*Example trigger:* `(not (nil? foo))`.
+
+*Example message:* `not and nil? used instead of some?`.
+
+*Example trigger:* `(filter #(not (string? %)) [:foo "bar" 42])`.
+
+*Example message:* `filter and not used instead of remove`.
 
 ### Refer
 

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -144,6 +144,15 @@
                    (format "%s and not used instead of %s-not"
                            called-name called-name))))))
 
+(defn lint-not-nil [ctx call]
+  (let [[_ x] (:children call)
+        first-x-child-val (:value (first (:children x)))]
+    (when (= 'nil? first-x-child-val)
+      (findings/reg-finding!
+       ctx
+       (node->line (:filename ctx) call :warning :not-nil?-instead-of-some?
+                   "not and nil? used instead of some?")))))
+
 (defn lint-specific-calls! [ctx call called-fn]
   (let [called-ns (:ns called-fn)
         called-name (:name called-fn)]
@@ -160,6 +169,8 @@
       (lint-and-or ctx called-name (:expr call))
       ([clojure.core when])
       (lint-if-when-not ctx called-name (:expr call))
+      ([clojure.core not])
+      (lint-not-nil ctx (:expr call))
       #_([clojure.test is] [cljs.test is])
       #_(lint-test-is ctx (:expr call))
       nil)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -193,7 +193,7 @@
     (when (= 'not first-test-child-val)
       (findings/reg-finding!
        ctx
-       (node->line (:filename ctx) call :warning :separate-if-when-not
+       (node->line (:filename ctx) call :warning :redundant-nots
                    (format "%s and not used instead of %s-not"
                            called-name called-name))))))
 

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -127,10 +127,10 @@
       (findings/reg-finding!
        ctx
        (case called-name
-         and (node->line (:filename ctx) call :warning :redundant-nots
+         and (node->line (:filename ctx) call :warning :redundant-negation
                          (format "And & %s nots used instead of 1 not with or"
                                  (count next-children)))
-         or (node->line (:filename ctx) call :warning :redundant-nots
+         or (node->line (:filename ctx) call :warning :redundant-negation
                         (format "Or & %s nots used instead of 1 not with and"
                                  (count next-children))))))))
 
@@ -138,27 +138,27 @@
   (case negated-child
     nil? (findings/reg-finding!
           ctx
-          (node->line (:filename ctx) call :warning :redundant-nots
+          (node->line (:filename ctx) call :warning :redundant-negation
                       (format "%s and nil? used instead of some?" negator-string)))
 
     = (findings/reg-finding!
        ctx
-       (node->line (:filename ctx) call :warning :redundant-nots
+       (node->line (:filename ctx) call :warning :redundant-negation
                    (format "%s and = used instead of not=" negator-string)))
 
     even? (findings/reg-finding!
            ctx
-           (node->line (:filename ctx) call :warning :redundant-nots
+           (node->line (:filename ctx) call :warning :redundant-negation
                        (format "%s and even? used instead of odd?" negator-string)))
 
     odd? (findings/reg-finding!
           ctx
-          (node->line (:filename ctx) call :warning :redundant-nots
+          (node->line (:filename ctx) call :warning :redundant-negation
                       (format "%s and odd? used instead of even?" negator-string)))
 
     seq (findings/reg-finding!
          ctx
-         (node->line (:filename ctx) call :warning :redundant-nots
+         (node->line (:filename ctx) call :warning :redundant-negation
                      (format "%s and seq used instead of empty?" negator-string)))
     nil))
 
@@ -186,7 +186,7 @@
       (= 'complement first-pred-child-val)
       (findings/reg-finding!
        ctx
-       (node->line (:filename ctx) call :warning :redundant-nots
+       (node->line (:filename ctx) call :warning :redundant-negation
                    (format "%s and complement used instead of %s"
                            called-name alternative)))
 
@@ -194,7 +194,7 @@
            (= 'not second-pred-child-val))
       (findings/reg-finding!
        ctx
-       (node->line (:filename ctx) call :warning :redundant-nots
+       (node->line (:filename ctx) call :warning :redundant-negation
                    (format "%s and comp with not used instead of %s"
                            called-name alternative)))
 
@@ -205,7 +205,7 @@
                (= 'not (-> pred :children last :children first :value))))
       (findings/reg-finding!
        ctx
-       (node->line (:filename ctx) call :warning :redundant-nots
+       (node->line (:filename ctx) call :warning :redundant-negation
                    (format "%s and not used instead of %s"
                            called-name alternative))))))
 
@@ -215,7 +215,7 @@
     (when (= 'not first-test-child-val)
       (findings/reg-finding!
        ctx
-       (node->line (:filename ctx) call :warning :redundant-nots
+       (node->line (:filename ctx) call :warning :redundant-negation
                    (format "%s and not used instead of %s-not"
                            called-name called-name))))))
 

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -141,6 +141,11 @@
           (node->line (:filename ctx) call :warning :redundant-negation
                       (format "%s and nil? used instead of some?" negator-string)))
 
+    some? (findings/reg-finding!
+           ctx
+           (node->line (:filename ctx) call :warning :redundant-negation
+                       (format "%s and some? used instead of nil?" negator-string)))
+
     = (findings/reg-finding!
        ctx
        (node->line (:filename ctx) call :warning :redundant-negation
@@ -160,6 +165,16 @@
          ctx
          (node->line (:filename ctx) call :warning :redundant-negation
                      (format "%s and seq used instead of empty?" negator-string)))
+
+    some (findings/reg-finding!
+          ctx
+          (node->line (:filename ctx) call :warning :redundant-negation
+                      (format "%s and some used instead of not-any?" negator-string)))
+
+    every? (findings/reg-finding!
+            ctx
+            (node->line (:filename ctx) call :warning :redundant-negation
+                        (format "%s and every? used instead of not-every?" negator-string)))
     nil))
 
 (defn lint-comp-not [ctx call]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2897,6 +2897,27 @@ foo/foo ;; this does use the private var
        (lint! "(complement every?)" "--lang" lang
               "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
+  (testing "`if-not` or `when-not` used when `if` or `when` can be used"
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "if-not and nil? used instead of some?"})
+       (lint! "(if-not (nil? :foo) :a :b)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
+
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "when-not and even? used instead of odd?"})
+       (lint! "(when-not (even? :foo) :a :b)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
+
   (testing "`filter` & `complement` used instead of `remove` or vice versa"
     (doseq [lang ["clj" "cljs"]]
       (assert-submaps

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2624,21 +2624,25 @@ foo/foo ;; this does use the private var
 
 (deftest redundant-negation-test
   (testing "`and` & `or` with `not`s can be simplified"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "And & 2 nots used instead of 1 not with or"})
-     (lint! "(and (not :foo) (not :bar))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "And & 2 nots used instead of 1 not with or"})
+       (lint! "(and (not :foo) (not :bar))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "Or & 3 nots used instead of 1 not with and"})
-     (lint! "(or (not :foo) (not :bar) (not :baz))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "Or & 3 nots used instead of 1 not with and"})
+       (lint! "(or (not :foo) (not :bar) (not :baz))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
     (is (empty? (lint! "(or) (and)" {:linters {:redundant-negation {:level :warning}}}))
         "'Or' and 'and' without args isn't a problem")
@@ -2646,296 +2650,366 @@ foo/foo ;; this does use the private var
         "If any arg supplied is not a list with first element 'not', then the call is fine"))
 
   (testing "negated `nil?` can be simplified to `some?`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and nil? used instead of some?"})
-     (lint! "(not (nil? :foo))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and nil? used instead of some?"})
+       (lint! "(not (nil? :foo))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and nil? used instead of some?"})
-     (lint! "(comp not nil?)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and nil? used instead of some?"})
+       (lint! "(comp not nil?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and nil? used instead of some?"})
-     (lint! "(complement nil?)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and nil? used instead of some?"})
+       (lint! "(complement nil?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "negated `some?` can be simplified to `nil?`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and some? used instead of nil?"})
-     (lint! "(not (some? :foo))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and some? used instead of nil?"})
+       (lint! "(not (some? :foo))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and some? used instead of nil?"})
-     (lint! "(comp not some?)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and some? used instead of nil?"})
+       (lint! "(comp not some?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and some? used instead of nil?"})
-     (lint! "(complement some?)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and some? used instead of nil?"})
+       (lint! "(complement some?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "negated `=` can be simplified to `not=`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and = used instead of not="})
-     (lint! "(not (= :foo :bar))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and = used instead of not="})
+       (lint! "(not (= :foo :bar))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and = used instead of not="})
-     (lint! "(comp not =)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and = used instead of not="})
+       (lint! "(comp not =)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and = used instead of not="})
-     (lint! "(complement =)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and = used instead of not="})
+       (lint! "(complement =)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "negated `even?` can be simplified to `odd?`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and even? used instead of odd?"})
-     (lint! "(not (even? 42))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and even? used instead of odd?"})
+       (lint! "(not (even? 42))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and even? used instead of odd?"})
-     (lint! "(comp not even?)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and even? used instead of odd?"})
+       (lint! "(comp not even?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and even? used instead of odd?"})
-     (lint! "(complement even?)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and even? used instead of odd?"})
+       (lint! "(complement even?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "negated `odd?` can be simplified to `even?`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and odd? used instead of even?"})
-     (lint! "(not (odd? 42))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and odd? used instead of even?"})
+       (lint! "(not (odd? 42))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and odd? used instead of even?"})
-     (lint! "(comp not odd?)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and odd? used instead of even?"})
+       (lint! "(comp not odd?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and odd? used instead of even?"})
-     (lint! "(complement odd?)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and odd? used instead of even?"})
+       (lint! "(complement odd?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "negated `seq` can be simplified to `empty?`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and seq used instead of empty?"})
-     (lint! "(not (seq [:foo :bar :baz]))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and seq used instead of empty?"})
+       (lint! "(not (seq [:foo :bar :baz]))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and seq used instead of empty?"})
-     (lint! "(comp not seq)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and seq used instead of empty?"})
+       (lint! "(comp not seq)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and seq used instead of empty?"})
-     (lint! "(complement seq)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and seq used instead of empty?"})
+       (lint! "(complement seq)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "negated `some` can be simplified to `not-any?`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and some used instead of not-any?"})
-     (lint! "(not (some string? [:foo :bar :baz]))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and some used instead of not-any?"})
+       (lint! "(not (some string? [:foo :bar :baz]))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and some used instead of not-any?"})
-     (lint! "(comp not some)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and some used instead of not-any?"})
+       (lint! "(comp not some)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and some used instead of not-any?"})
-     (lint! "(complement some)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and some used instead of not-any?"})
+       (lint! "(complement some)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "negated `every?` can be simplified to `not-every?`"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and every? used instead of not-every?"})
-     (lint! "(not (every? string? [:foo :bar :baz]))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and every? used instead of not-every?"})
+       (lint! "(not (every? string? [:foo :bar :baz]))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "not and every? used instead of not-every?"})
-     (lint! "(comp not every?)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "not and every? used instead of not-every?"})
+       (lint! "(comp not every?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "complement and every? used instead of not-every?"})
-     (lint! "(complement every?)" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "complement and every? used instead of not-every?"})
+       (lint! "(complement every?)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "`filter` & `complement` used instead of `remove` or vice versa"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "filter and complement used instead of remove"})
-     (lint! "(filter (complement foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "filter and complement used instead of remove"})
+       (lint! "(filter (complement foo) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "remove and complement used instead of filter"})
-     (lint! "(remove (complement foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "remove and complement used instead of filter"})
+       (lint! "(remove (complement foo) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "`filter` & `comp` with `not` used instead of `remove` or vice versa"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "filter and comp with not used instead of remove"})
-     (lint! "(filter (comp not foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "filter and comp with not used instead of remove"})
+       (lint! "(filter (comp not foo) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "remove and comp with not used instead of filter"})
-     (lint! "(remove (comp not foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "remove and comp with not used instead of filter"})
+       (lint! "(remove (comp not foo) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "`filter` & fn with `not` wrapping the rest of the body used instead of `remove` or vice versa"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "filter and not used instead of remove"})
-     (lint! "(filter #(not (:foo %)) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "filter and not used instead of remove"})
+       (lint! "(filter #(not (:foo %)) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "filter and not used instead of remove"})
-     (lint! "(filter (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "filter and not used instead of remove"})
+       (lint! "(filter (fn [x] (not (:foo x))) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 18,
-        :level :warning,
-        :message "filter and not used instead of remove"})
-     (lint! "(->> [:bar :baz] (filter (fn [x] (not (:foo x)))))" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 18,
+          :level :warning,
+          :message "filter and not used instead of remove"})
+       (lint! "(->> [:bar :baz] (filter (fn [x] (not (:foo x)))))" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "remove and not used instead of filter"})
-     (lint! "(remove #(not (:foo %)) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "remove and not used instead of filter"})
+       (lint! "(remove #(not (:foo %)) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "remove and not used instead of filter"})
-     (lint! "(remove (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}})))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "remove and not used instead of filter"})
+       (lint! "(remove (fn [x] (not (:foo x))) [:bar :baz])" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "`if` or `when` with `not` used instead of `if-not` or `when-not` respectively"
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "if and not used instead of if-not"})
-     (lint! "(if (not :foo) :bar :baz)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "if and not used instead of if-not"})
+       (lint! "(if (not :foo) :bar :baz)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
-    (assert-submaps
-     '({:file "<stdin>",
-        :row 1,
-        :col 1,
-        :level :warning,
-        :message "when and not used instead of when-not"})
-     (lint! "(when (not :foo) :bar)" {:linters {:redundant-negation {:level :warning}}}))
+    (doseq [lang ["clj" "cljs"]]
+      (assert-submaps
+       '({:file "<stdin>",
+          :row 1,
+          :col 1,
+          :level :warning,
+          :message "when and not used instead of when-not"})
+       (lint! "(when (not :foo) :bar)" "--lang" lang
+              "--config" {:linters {:redundant-negation {:level :warning}}})))
 
     (is (empty? (lint! "(if (not= 7 42) :foo :bar)" {:linters {:redundant-negation {:level :warning}}}))
         "If with any other call starting the test form is ok")

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2688,7 +2688,57 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and seq used instead of empty?"})
-     (lint! "(not (seq [:foo :bar :baz]))" {:linters {:redundant-nots {:level :warning}}}))))
+     (lint! "(not (seq [:foo :bar :baz]))" {:linters {:redundant-nots {:level :warning}}})))
+
+  (testing "`filter` & `complement` used instead of `remove` or vice versa"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "filter and complement used instead of remove"})
+     (lint! "(filter (complement foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "remove and complement used instead of filter"})
+     (lint! "(remove (complement foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}})))
+
+  (testing "`filter` & fn with `not` wrapping the rest of the body used instead of `remove` or vice versa"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "filter and not used instead of remove"})
+     (lint! "(filter #(not (:foo %)) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "filter and not used instead of remove"})
+     (lint! "(filter (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "remove and not used instead of filter"})
+     (lint! "(remove #(not (:foo %)) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "remove and not used instead of filter"})
+     (lint! "(remove (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))))
 
 
 (deftest separate-if-when-not-test

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2622,6 +2622,28 @@ foo/foo ;; this does use the private var
   (testing "don't throw exception when args are missing"
     (is (some? (lint! "(assoc-in)")))))
 
+(deftest redundant-nots-test
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 1,
+      :level :warning,
+      :message "And & 2 nots used instead of 1 not with or"})
+   (lint! "(and (not :foo) (not :bar))" {:linters {:redundant-nots {:level :warning}}}))
+
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 1,
+      :level :warning,
+      :message "Or & 3 nots used instead of 1 not with and"})
+   (lint! "(or (not :foo) (not :bar) (not :baz))" {:linters {:redundant-nots {:level :warning}}}))
+
+  (is (empty? (lint! "(or) (and)" {:linters {:redundant-nots {:level :warning}}}))
+      "'Or' and 'and' without args isn't a problem")
+  (is (empty? (lint! "(and (not :foo) (not :bar) :baz)" {:linters {:redundant-nots {:level :warning}}}))
+      "If any arg supplied is not a list with first element 'not', then the call is fine"))
+
 (deftest multiple-options-test
 
   (testing "multiple --lint option"

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2644,6 +2644,28 @@ foo/foo ;; this does use the private var
   (is (empty? (lint! "(and (not :foo) (not :bar) :baz)" {:linters {:redundant-nots {:level :warning}}}))
       "If any arg supplied is not a list with first element 'not', then the call is fine"))
 
+(deftest separate-if-when-not-test
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 1,
+      :level :warning,
+      :message "if and not used instead of if-not"})
+   (lint! "(if (not :foo) :bar :baz)" {:linters {:separate-if-when-not {:level :warning}}}))
+
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 1,
+      :level :warning,
+      :message "when and not used instead of when-not"})
+   (lint! "(when (not :foo) :bar)" {:linters {:separate-if-when-not {:level :warning}}}))
+
+  (is (empty? (lint! "(if (not= 7 42) :foo :bar)" {:linters {:separate-if-when-not {:level :warning}}}))
+      "If with any other call starting the test form is ok")
+  (is (empty? (lint! "(when (or (not :foo) :bar) :foo :bar)" {:linters {:separate-if-when-not {:level :warning}}}))
+      "When with any other call starting the test form is ok"))
+
 (deftest multiple-options-test
 
   (testing "multiple --lint option"

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2622,7 +2622,7 @@ foo/foo ;; this does use the private var
   (testing "don't throw exception when args are missing"
     (is (some? (lint! "(assoc-in)")))))
 
-(deftest redundant-nots-test
+(deftest redundant-negation-test
   (testing "`and` & `or` with `not`s can be simplified"
     (assert-submaps
      '({:file "<stdin>",
@@ -2668,7 +2668,32 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "complement and nil? used instead of some?"})
-     (lint! "(complement  nil?)" {:linters {:redundant-negation {:level :warning}}})))
+     (lint! "(complement nil?)" {:linters {:redundant-negation {:level :warning}}})))
+
+  (testing "negated `some?` can be simplified to `nil?`"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and some? used instead of nil?"})
+     (lint! "(not (some? :foo))" {:linters {:redundant-negation {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and some? used instead of nil?"})
+     (lint! "(comp not some?)" {:linters {:redundant-negation {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and some? used instead of nil?"})
+     (lint! "(complement some?)" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "negated `=` can be simplified to `not=`"
     (assert-submaps
@@ -2769,6 +2794,56 @@ foo/foo ;; this does use the private var
         :level :warning,
         :message "complement and seq used instead of empty?"})
      (lint! "(complement seq)" {:linters {:redundant-negation {:level :warning}}})))
+
+  (testing "negated `some` can be simplified to `not-any?`"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and some used instead of not-any?"})
+     (lint! "(not (some string? [:foo :bar :baz]))" {:linters {:redundant-negation {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and some used instead of not-any?"})
+     (lint! "(comp not some)" {:linters {:redundant-negation {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and some used instead of not-any?"})
+     (lint! "(complement some)" {:linters {:redundant-negation {:level :warning}}})))
+
+  (testing "negated `every?` can be simplified to `not-every?`"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and every? used instead of not-every?"})
+     (lint! "(not (every? string? [:foo :bar :baz]))" {:linters {:redundant-negation {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and every? used instead of not-every?"})
+     (lint! "(comp not every?)" {:linters {:redundant-negation {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and every? used instead of not-every?"})
+     (lint! "(complement every?)" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "`filter` & `complement` used instead of `remove` or vice versa"
     (assert-submaps

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2630,7 +2630,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "And & 2 nots used instead of 1 not with or"})
-     (lint! "(and (not :foo) (not :bar))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(and (not :foo) (not :bar))" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2638,11 +2638,11 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "Or & 3 nots used instead of 1 not with and"})
-     (lint! "(or (not :foo) (not :bar) (not :baz))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(or (not :foo) (not :bar) (not :baz))" {:linters {:redundant-negation {:level :warning}}}))
 
-    (is (empty? (lint! "(or) (and)" {:linters {:redundant-nots {:level :warning}}}))
+    (is (empty? (lint! "(or) (and)" {:linters {:redundant-negation {:level :warning}}}))
         "'Or' and 'and' without args isn't a problem")
-    (is (empty? (lint! "(and (not :foo) (not :bar) :baz)" {:linters {:redundant-nots {:level :warning}}}))
+    (is (empty? (lint! "(and (not :foo) (not :bar) :baz)" {:linters {:redundant-negation {:level :warning}}}))
         "If any arg supplied is not a list with first element 'not', then the call is fine"))
 
   (testing "negated `nil?` can be simplified to `some?`"
@@ -2652,7 +2652,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and nil? used instead of some?"})
-     (lint! "(not (nil? :foo))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(not (nil? :foo))" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2660,7 +2660,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and nil? used instead of some?"})
-     (lint! "(comp not nil?)" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(comp not nil?)" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2668,7 +2668,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "complement and nil? used instead of some?"})
-     (lint! "(complement  nil?)" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(complement  nil?)" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "negated `=` can be simplified to `not=`"
     (assert-submaps
@@ -2677,7 +2677,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and = used instead of not="})
-     (lint! "(not (= :foo :bar))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(not (= :foo :bar))" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2685,7 +2685,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and = used instead of not="})
-     (lint! "(comp not =)" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(comp not =)" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2693,7 +2693,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "complement and = used instead of not="})
-     (lint! "(complement =)" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(complement =)" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "negated `even?` can be simplified to `odd?`"
     (assert-submaps
@@ -2702,7 +2702,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and even? used instead of odd?"})
-     (lint! "(not (even? 42))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(not (even? 42))" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2710,7 +2710,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and even? used instead of odd?"})
-     (lint! "(comp not even?)" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(comp not even?)" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2718,7 +2718,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "complement and even? used instead of odd?"})
-     (lint! "(complement even?)" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(complement even?)" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "negated `odd?` can be simplified to `even?`"
     (assert-submaps
@@ -2727,7 +2727,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and odd? used instead of even?"})
-     (lint! "(not (odd? 42))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(not (odd? 42))" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2735,7 +2735,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and odd? used instead of even?"})
-     (lint! "(comp not odd?)" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(comp not odd?)" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2743,7 +2743,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "complement and odd? used instead of even?"})
-     (lint! "(complement odd?)" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(complement odd?)" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "negated `seq` can be simplified to `empty?`"
     (assert-submaps
@@ -2752,7 +2752,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and seq used instead of empty?"})
-     (lint! "(not (seq [:foo :bar :baz]))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(not (seq [:foo :bar :baz]))" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2760,7 +2760,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "not and seq used instead of empty?"})
-     (lint! "(comp not seq)" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(comp not seq)" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2768,7 +2768,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "complement and seq used instead of empty?"})
-     (lint! "(complement seq)" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(complement seq)" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "`filter` & `complement` used instead of `remove` or vice versa"
     (assert-submaps
@@ -2777,7 +2777,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "filter and complement used instead of remove"})
-     (lint! "(filter (complement foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(filter (complement foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2785,7 +2785,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "remove and complement used instead of filter"})
-     (lint! "(remove (complement foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(remove (complement foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "`filter` & `comp` with `not` used instead of `remove` or vice versa"
     (assert-submaps
@@ -2794,7 +2794,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "filter and comp with not used instead of remove"})
-     (lint! "(filter (comp not foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(filter (comp not foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2802,7 +2802,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "remove and comp with not used instead of filter"})
-     (lint! "(remove (comp not foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(remove (comp not foo) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "`filter` & fn with `not` wrapping the rest of the body used instead of `remove` or vice versa"
     (assert-submaps
@@ -2811,7 +2811,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "filter and not used instead of remove"})
-     (lint! "(filter #(not (:foo %)) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(filter #(not (:foo %)) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2819,7 +2819,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "filter and not used instead of remove"})
-     (lint! "(filter (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(filter (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2827,7 +2827,7 @@ foo/foo ;; this does use the private var
         :col 18,
         :level :warning,
         :message "filter and not used instead of remove"})
-     (lint! "(->> [:bar :baz] (filter (fn [x] (not (:foo x)))))" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(->> [:bar :baz] (filter (fn [x] (not (:foo x)))))" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2835,7 +2835,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "remove and not used instead of filter"})
-     (lint! "(remove #(not (:foo %)) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(remove #(not (:foo %)) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2843,7 +2843,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "remove and not used instead of filter"})
-     (lint! "(remove (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(remove (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-negation {:level :warning}}})))
 
   (testing "`if` or `when` with `not` used instead of `if-not` or `when-not` respectively"
     (assert-submaps
@@ -2852,7 +2852,7 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "if and not used instead of if-not"})
-     (lint! "(if (not :foo) :bar :baz)" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(if (not :foo) :bar :baz)" {:linters {:redundant-negation {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",
@@ -2860,11 +2860,11 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "when and not used instead of when-not"})
-     (lint! "(when (not :foo) :bar)" {:linters {:redundant-nots {:level :warning}}}))
+     (lint! "(when (not :foo) :bar)" {:linters {:redundant-negation {:level :warning}}}))
 
-    (is (empty? (lint! "(if (not= 7 42) :foo :bar)" {:linters {:redundant-nots {:level :warning}}}))
+    (is (empty? (lint! "(if (not= 7 42) :foo :bar)" {:linters {:redundant-negation {:level :warning}}}))
         "If with any other call starting the test form is ok")
-    (is (empty? (lint! "(when (or (not :foo) :bar) :foo :bar)" {:linters {:redundant-nots {:level :warning}}}))
+    (is (empty? (lint! "(when (or (not :foo) :bar) :foo :bar)" {:linters {:redundant-negation {:level :warning}}}))
         "When with any other call starting the test form is ok")))
 
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2738,30 +2738,32 @@ foo/foo ;; this does use the private var
         :col 1,
         :level :warning,
         :message "remove and not used instead of filter"})
-     (lint! "(remove (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))))
+     (lint! "(remove (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}})))
+
+  (testing "`if` or `when` with `not` used instead of `if-not` or `when-not` respectively"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "if and not used instead of if-not"})
+     (lint! "(if (not :foo) :bar :baz)" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "when and not used instead of when-not"})
+     (lint! "(when (not :foo) :bar)" {:linters {:redundant-nots {:level :warning}}}))
+
+    (is (empty? (lint! "(if (not= 7 42) :foo :bar)" {:linters {:redundant-nots {:level :warning}}}))
+        "If with any other call starting the test form is ok")
+    (is (empty? (lint! "(when (or (not :foo) :bar) :foo :bar)" {:linters {:redundant-nots {:level :warning}}}))
+        "When with any other call starting the test form is ok")))
 
 
-(deftest separate-if-when-not-test
-  (assert-submaps
-   '({:file "<stdin>",
-      :row 1,
-      :col 1,
-      :level :warning,
-      :message "if and not used instead of if-not"})
-   (lint! "(if (not :foo) :bar :baz)" {:linters {:separate-if-when-not {:level :warning}}}))
 
-  (assert-submaps
-   '({:file "<stdin>",
-      :row 1,
-      :col 1,
-      :level :warning,
-      :message "when and not used instead of when-not"})
-   (lint! "(when (not :foo) :bar)" {:linters {:separate-if-when-not {:level :warning}}}))
-
-  (is (empty? (lint! "(if (not= 7 42) :foo :bar)" {:linters {:separate-if-when-not {:level :warning}}}))
-      "If with any other call starting the test form is ok")
-  (is (empty? (lint! "(when (or (not :foo) :bar) :foo :bar)" {:linters {:separate-if-when-not {:level :warning}}}))
-      "When with any other call starting the test form is ok"))
 
 (deftest multiple-options-test
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2666,6 +2666,15 @@ foo/foo ;; this does use the private var
   (is (empty? (lint! "(when (or (not :foo) :bar) :foo :bar)" {:linters {:separate-if-when-not {:level :warning}}}))
       "When with any other call starting the test form is ok"))
 
+(deftest not-nil?-instead-of-some?-test
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
+      :col 1,
+      :level :warning,
+      :message "not and nil? used instead of some?"})
+   (lint! "(not (nil? :foo))" {:linters {:not-nil?-instead-of-some? {:level :warning}}})))
+
 (deftest multiple-options-test
 
   (testing "multiple --lint option"

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2904,8 +2904,8 @@ foo/foo ;; this does use the private var
           :row 1,
           :col 1,
           :level :warning,
-          :message "if-not and nil? used instead of some?"})
-       (lint! "(if-not (nil? :foo) :a :b)" "--lang" lang
+          :message "if-not and some? used instead of if and nil?"})
+       (lint! "(if-not (some? :foo) :a :b)" "--lang" lang
               "--config" {:linters {:redundant-negation {:level :warning}}})))
 
     (doseq [lang ["clj" "cljs"]]
@@ -2914,8 +2914,8 @@ foo/foo ;; this does use the private var
           :row 1,
           :col 1,
           :level :warning,
-          :message "when-not and even? used instead of odd?"})
-       (lint! "(when-not (even? :foo) :a :b)" "--lang" lang
+          :message "when-not and odd? used instead of when and even?"})
+       (lint! "(when-not (odd? :foo) :a :b)" "--lang" lang
               "--config" {:linters {:redundant-negation {:level :warning}}}))))
 
   (testing "`filter` & `complement` used instead of `remove` or vice versa"

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2645,50 +2645,130 @@ foo/foo ;; this does use the private var
     (is (empty? (lint! "(and (not :foo) (not :bar) :baz)" {:linters {:redundant-nots {:level :warning}}}))
         "If any arg supplied is not a list with first element 'not', then the call is fine"))
 
-  (testing "`not` & `nil?` can be simplified to `some?`"
+  (testing "negated `nil?` can be simplified to `some?`"
     (assert-submaps
      '({:file "<stdin>",
         :row 1,
         :col 1,
         :level :warning,
         :message "not and nil? used instead of some?"})
-     (lint! "(not (nil? :foo))" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(not (nil? :foo))" {:linters {:redundant-nots {:level :warning}}}))
 
-  (testing "`not` & `=` can be simplified to `not=`"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and nil? used instead of some?"})
+     (lint! "(comp not nil?)" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and nil? used instead of some?"})
+     (lint! "(complement  nil?)" {:linters {:redundant-nots {:level :warning}}})))
+
+  (testing "negated `=` can be simplified to `not=`"
     (assert-submaps
      '({:file "<stdin>",
         :row 1,
         :col 1,
         :level :warning,
         :message "not and = used instead of not="})
-     (lint! "(not (= :foo :bar))" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(not (= :foo :bar))" {:linters {:redundant-nots {:level :warning}}}))
 
-  (testing "`not` & `even?` can be simplified to `odd?`"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and = used instead of not="})
+     (lint! "(comp not =)" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and = used instead of not="})
+     (lint! "(complement =)" {:linters {:redundant-nots {:level :warning}}})))
+
+  (testing "negated `even?` can be simplified to `odd?`"
     (assert-submaps
      '({:file "<stdin>",
         :row 1,
         :col 1,
         :level :warning,
         :message "not and even? used instead of odd?"})
-     (lint! "(not (even? 42))" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(not (even? 42))" {:linters {:redundant-nots {:level :warning}}}))
 
-  (testing "`not` & `odd?` can be simplified to `even?`"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and even? used instead of odd?"})
+     (lint! "(comp not even?)" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and even? used instead of odd?"})
+     (lint! "(complement even?)" {:linters {:redundant-nots {:level :warning}}})))
+
+  (testing "negated `odd?` can be simplified to `even?`"
     (assert-submaps
      '({:file "<stdin>",
         :row 1,
         :col 1,
         :level :warning,
         :message "not and odd? used instead of even?"})
-     (lint! "(not (odd? 42))" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(not (odd? 42))" {:linters {:redundant-nots {:level :warning}}}))
 
-  (testing "`not` & `seq` can be simplified to `empty?`"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and odd? used instead of even?"})
+     (lint! "(comp not odd?)" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and odd? used instead of even?"})
+     (lint! "(complement odd?)" {:linters {:redundant-nots {:level :warning}}})))
+
+  (testing "negated `seq` can be simplified to `empty?`"
     (assert-submaps
      '({:file "<stdin>",
         :row 1,
         :col 1,
         :level :warning,
         :message "not and seq used instead of empty?"})
-     (lint! "(not (seq [:foo :bar :baz]))" {:linters {:redundant-nots {:level :warning}}})))
+     (lint! "(not (seq [:foo :bar :baz]))" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "not and seq used instead of empty?"})
+     (lint! "(comp not seq)" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "complement and seq used instead of empty?"})
+     (lint! "(complement seq)" {:linters {:redundant-nots {:level :warning}}})))
 
   (testing "`filter` & `complement` used instead of `remove` or vice versa"
     (assert-submaps
@@ -2707,6 +2787,23 @@ foo/foo ;; this does use the private var
         :message "remove and complement used instead of filter"})
      (lint! "(remove (complement foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}})))
 
+  (testing "`filter` & `comp` with `not` used instead of `remove` or vice versa"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "filter and comp with not used instead of remove"})
+     (lint! "(filter (comp not foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 1,
+        :level :warning,
+        :message "remove and comp with not used instead of filter"})
+     (lint! "(remove (comp not foo) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}})))
+
   (testing "`filter` & fn with `not` wrapping the rest of the body used instead of `remove` or vice versa"
     (assert-submaps
      '({:file "<stdin>",
@@ -2723,6 +2820,14 @@ foo/foo ;; this does use the private var
         :level :warning,
         :message "filter and not used instead of remove"})
      (lint! "(filter (fn [x] (not (:foo x))) [:bar :baz])" {:linters {:redundant-nots {:level :warning}}}))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 18,
+        :level :warning,
+        :message "filter and not used instead of remove"})
+     (lint! "(->> [:bar :baz] (filter (fn [x] (not (:foo x)))))" {:linters {:redundant-nots {:level :warning}}}))
 
     (assert-submaps
      '({:file "<stdin>",


### PR DESCRIPTION
This resolves #1080 and as discussed there, I've tried to cover all reasonable negation using clojure core I could envisage . Although it's quite big, I realised it could have been almost endless, as we could warn against `(not (not foo))` or `(not (not-any? foo? bars))` which both seem to me not worth doing. I think it's reasonable to say all these linters can be grouped under one name, but I'm open to discussion about splitting them out if that seems suitable.