### PR TITLE
Fixes #1153 

### DIFF
--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -21,7 +21,8 @@
         alias-or-ns (some-> token namespace symbol)
         ns-sym (cond
                  (and aliased? alias-or-ns)
-                 (get-in ctx [:ns :aliases alias-or-ns] :clj-kondo/unknown-namespace)
+                 (-> (namespace/get-namespace ctx (:base-lang ctx) (:lang ctx) current-ns)
+                     (get-in [:aliases alias-or-ns] :clj-kondo/unknown-namespace))
 
                  aliased?
                  current-ns

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -17,6 +17,20 @@
                        config))))))
 
 (deftest keyword-analysis-test
+  (testing "standalone keywords with top-level require"
+    (let [a (analyze "(require '[bar :as b]) :kw :x/xkwa ::x/xkwb ::fookwa :foo/fookwb ::foo/fookwc :bar/barkwa ::b/barkwb ::bar/barkwc"
+                     {:config {:output {:analysis {:keywords true}}}})]
+      (assert-submaps
+        '[{:name kw}
+          {:name xkwa :ns x}
+          {:name xkwb :ns :clj-kondo/unknown-namespace}
+          {:name fookwa :ns user}
+          {:name fookwb :ns foo}
+          {:name fookwc :ns :clj-kondo/unknown-namespace}
+          {:name barkwa :ns bar}
+          {:name barkwb :ns bar :alias b}
+          {:name barkwc :ns :clj-kondo/unknown-namespace}]
+        (:keywords a))))
   (testing "standalone keywords"
     (let [a (analyze "(ns foo (:require [bar :as b])) :kw :x/xkwa ::x/xkwb ::fookwa :foo/fookwb ::foo/fookwc :bar/barkwa ::b/barkwb ::bar/barkwc"
                      {:config {:output {:analysis {:keywords true}}}})]


### PR DESCRIPTION
Had to use `get-namespace` because `(:ns ctx)` doesn't get updated on `analyze-require` (and probably the other namespace-altering fns). 

