### PR TITLE
Fix schema.core/defmethod linting for vectors dispatch-values

### DIFF
--- a/corpus/schema/defmethod.clj
+++ b/corpus/schema/defmethod.clj
@@ -1,7 +1,7 @@
 (ns schema.defmethod
   (:require
-   [schema.core :as sc]
-   [integrant.core :as ig]))
+   [integrant.core :as ig]
+   [schema.core :as sc]))
 
 ;; no false positives from this:
 
@@ -9,3 +9,19 @@
   [_
    {:keys [:config/env]} :- {:config/env sc/Keyword}]
   {:config/env env})
+
+;; Testing when dispatch-val is vector
+(sc/defmethod ig/init-key [:config1 :config2] :- {:config/env sc/Keyword}
+  [_
+   {:keys [:config/env]} :- {:config/env sc/Keyword}]
+  {:config/env env})
+
+;; Testing with multiple arities
+(sc/defmethod ig/init-key [:config1 :config2] :- {:config/env sc/Keyword}
+  ([_
+    {:keys [:config/env]} :- {:config/env sc/Keyword}]
+   {:config/env env})
+  ([_ :- sc/Str
+    _ :- sc/Int
+    {:keys [:config/env]} :- {:config/env sc/Keyword}]
+   {:config/env env}))

--- a/corpus/schema/defmethod.clj
+++ b/corpus/schema/defmethod.clj
@@ -10,13 +10,23 @@
    {:keys [:config/env]} :- {:config/env sc/Keyword}]
   {:config/env env})
 
-;; Testing when dispatch-val is vector
+;; When dispatch-val is vector
 (sc/defmethod ig/init-key [:config1 :config2] :- {:config/env sc/Keyword}
   [_
    {:keys [:config/env]} :- {:config/env sc/Keyword}]
-  {:config/env env})
+  (let [a 1]
+    {:config/env env
+     :a          a}))
 
-;; Testing with multiple arities
+;; Missing return schema
+(sc/defmethod ig/init-key [:config1 :config2]
+  [_
+   {:keys [:config/env]} :- {:config/env sc/Keyword}]
+  (let [a 1]
+    {:config/env env
+     :a          a}))
+
+;; With multiple arities
 (sc/defmethod ig/init-key [:config1 :config2] :- {:config/env sc/Keyword}
   ([_
     {:keys [:config/env]} :- {:config/env sc/Keyword}]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -858,6 +858,7 @@
 (defn analyze-schema [ctx fn-sym expr]
   (let [{:keys [:expr :schemas]}
         (schema/expand-schema ctx
+                              fn-sym
                               expr)]
     (concat
      (case fn-sym

--- a/src/clj_kondo/impl/schema.clj
+++ b/src/clj_kondo/impl/schema.clj
@@ -42,10 +42,12 @@
                          (update res :schemas conj (first rest-children)))
                   (vector? sexpr)
                   (let [{:keys [:expr :schemas]} (remove-schemas-from-children fst-child)]
-                    (-> res
-                        (update :schemas into schemas)
-                        (update :new-children conj expr)
-                        (update :new-children into rest-children)))
+                    (if (not (some (comp #{:vector :list} utils/tag) rest-children))
+                      (-> res
+                          (update :schemas into schemas)
+                          (update :new-children conj expr)
+                          (update :new-children into rest-children))
+                      (recur rest-children (update res :new-children conj expr))))
                   (list? sexpr)
                   (recur rest-children
                          (let [cchildren (:children fst-child)


### PR DESCRIPTION
Closes: https://github.com/clj-kondo/clj-kondo/issues/1174

--

I preferred to go with the approach to track the `fn-sym` and `index` instead of trying to infer when the vector was supposed to be the arguments or the dispatch value (for any schema.core macro) because the inferring logic was going to be more complex (in the code or even computationally) and would probably still have some bugs in corner cases when using the `:-` keyword inside function bodies