### PR TITLE
[analysis] Fix missing position fields on require form analysis

### DIFF
--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -173,16 +173,17 @@
                                opt-expr-children (:children opt-expr)]
                            (run! #(utils/handle-ignore ctx %) opt-expr-children)
                            (run! #(namespace/reg-var-usage! ctx current-ns-name
-                                                            (assoc (meta %)
-                                                                   :type :use
-                                                                   :name (sexpr %)
-                                                                   :resolved-ns ns-name
-                                                                   :ns current-ns-name
-                                                                   :lang lang
-                                                                   :base-lang base-lang
-                                                                   :filename filename
-                                                                   :config config
-                                                                   :expr %))
+                                                            (let [m (meta %)]
+                                                              (assoc m
+                                                                     :type :use
+                                                                     :name (with-meta (sexpr %) m)
+                                                                     :resolved-ns ns-name
+                                                                     :ns current-ns-name
+                                                                     :lang lang
+                                                                     :base-lang base-lang
+                                                                     :filename filename
+                                                                     :config config
+                                                                     :expr %)))
                                  opt-expr-children)
                            (swap! (:used-namespaces ctx) update (:base-lang ctx) conj ns-name)
                            (update m :referred into

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -504,6 +504,10 @@
     (is (= 'clojure.set (:to (first var-usages))))))
 
 (deftest standalone-require-test
-  (let [{:keys [:namespace-usages]}
+  (let [{:keys [:namespace-usages :var-usages]}
         (analyze "(require '[clojure [set :refer [union]]])")]
-    (is (= 'clojure.set (:to (first namespace-usages))))))
+    (is (= 'clojure.set (:to (first namespace-usages))))
+    (assert-submaps
+      '[{:name union :name-row 1 :name-end-row 1 :name-col 33 :name-end-col 38}
+        {:name require :name-row 1 :name-end-row 1 :name-col 2 :name-end-col 9}]
+     var-usages)))


### PR DESCRIPTION
Add missing `name-row`, `name-col`, `name-end-row` and `name-end-col` fields to analyzed var-usages on require form