### PR TITLE
Mark let as top-level, so redefined-vars inside are caught

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -50,7 +50,9 @@
                            (one-of fst [[clojure.core comment]
                                         [cljs.core comment]
                                         [clojure.core do]
-                                        [cljs.core do]])))]
+                                        [cljs.core do]
+                                        [clojure.core let]
+                                        [cljs.core let]])))]
      (when-not (config/skip? config callstack)
        (let [len (count children)
              ctx (assoc ctx

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1342,6 +1342,13 @@ foo/foo ;; this does use the private var
   (assert-submaps
    '({:file "<stdin>",
       :row 1,
+      :col 29,
+      :level :warning,
+      :message "redefined var #'user/foo"})
+   (lint! "(let [bar 42] (def foo bar) (def foo bar))"))
+  (assert-submaps
+   '({:file "<stdin>",
+      :row 1,
       :col 1,
       :level :warning,
       :message "inc already refers to #'clojure.core/inc"})


### PR DESCRIPTION
Fix for #1184
@borkdude is it just this simple?