### PR TITLE
Expose config key to hook fn

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1368,7 +1368,8 @@
                                     (try (hook-fn {:node expr
                                                    :cljc (identical? :cljc base-lang)
                                                    :lang lang
-                                                   :filename filename})
+                                                   :filename filename
+                                                   :config config})
                                          (catch Exception e
                                            (findings/reg-finding!
                                             ctx

--- a/test/clj_kondo/hooks_test.clj
+++ b/test/clj_kondo/hooks_test.clj
@@ -98,17 +98,23 @@
     (let [s (with-out-str (lint! "
 (ns bar
   {:clj-kondo/config
-    '{:hooks {:analyze-call {foo/hook \"(fn [{:keys [:cljc :lang :filename]}] (prn cljc lang filename))\"}}}}
+    '{:hooks {:analyze-call {foo/hook \"(fn [{:keys [:cljc :lang :filename :config]}]
+ (prn cljc lang filename (keys config)))\"}}}}
   (:require [foo :refer [hook]]))
 
 (hook 1 2 3)"
                                  {:hooks {:__dangerously-allow-string-hooks__ true}}))
           s (str/replace s "\r\n" "\n")]
-      (is (= s "false :clj \"<stdin>\"\n")))
+      (is (= s (str/join " "
+                         ["false"
+                          ":clj"
+                          "\"<stdin>\""
+                          "(:skip-args :skip-comments :linters :lint-as :macroexpand :output :hooks :cfg-dir)\n"]))))
     (let [s (with-out-str (lint! "
 (ns bar
   {:clj-kondo/config
-    '{:hooks {:analyze-call {foo/hook \"(fn [{:keys [:cljc :lang :filename]}] (prn cljc lang filename))\"}}}}
+    '{:hooks {:analyze-call {foo/hook \"(fn [{:keys [:cljc :lang :filename :config]}]
+ (prn cljc lang filename (keys config)))\"}}}}
   (:require [foo :refer [hook]]))
 
 (hook 1 2 3)"
@@ -116,7 +122,16 @@
                                  "--lang" "cljc"))
           ;; Windows...
           s (str/replace s "\r\n" "\n")]
-      (is (= s "true :clj \"<stdin>\"\ntrue :cljs \"<stdin>\"\n")))))
+      (is (= s (str (str/join " "
+                          ["true"
+                           ":clj"
+                           "\"<stdin>\""
+                           "(:skip-args :skip-comments :linters :lint-as :macroexpand :output :hooks :cfg-dir)\n"])
+                    (str/join " "
+                              ["true"
+                               ":cljs"
+                               "\"<stdin>\""
+                               "(:skip-args :skip-comments :linters :lint-as :macroexpand :output :hooks :cfg-dir)\n"])))))))
 
 #_(fn [{:keys [:node]}]
   (let [children (next (:children node))


### PR DESCRIPTION
Addressing #1198.

`source/diff` output
```
-R is deprecated, use -A with repl, -M for main, or -X for exec
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
WARNING: When invoking clojure.main, use -M
Cloning into 'clj-kondo'...
remote: Enumerating objects: 248, done.
remote: Counting objects: 100% (248/248), done.
remote: Compressing objects: 100% (167/167), done.
remote: Total 10943 (delta 108), reused 165 (delta 59), pack-reused 10695
Receiving objects: 100% (10943/10943), 11.51 MiB | 2.96 MiB/s, done.
Resolving deltas: 100% (6318/6318), done.
Linting and writing output to /tmp/clj-kondo-diff/master.txt
WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
WARNING: When invoking clojure.main, use -M
2585c2585
< linting took 8281ms, errors: 287, warnings: 2297
---
> linting took 8232ms, errors: 287, warnings: 2297
```