### PR TITLE
chore(editor-integration): improve documentation

### DIFF
--- a/doc/editor-integration.md
+++ b/doc/editor-integration.md
@@ -228,8 +228,8 @@ and CLJC (`.cljc`)<sup>1</sup>.
 4. Scope: `Current file`
 5. In the Program field, type `clj-kondo`
 6. In the Arguments field, type `--lint $FilePath$`<br>
-You may use a custom config E.g `--lint $FilePath$ --config "{:lint-as {manifold.deferred/let-flow clojure.core/let}}"`
-7. In the Working directory field, type `$FileDir$`
+You may use a custom config E.g `--lint $FilePath$ --config "{:lint-as {manifold.deferred/let-flow clojure.core/let}}"` or `--lint $FilePath$ --config your-custom-path/clj-kondo.conf.js"`
+7. In the Working directory field, type `$ProjectFileDir$`
 8. Enable `Create output file from stdout`
 9. Show console: `Never`
 10. In output filters put `$FILE_PATH$:$LINE$:$COLUMN$: $MESSAGE$`


### PR DESCRIPTION
`$FileDir$` si a default value for the Working directory field, so we can omit it.
It is more useful to use the root project directory `$ProjectFileDir$` for example to access a custom config file location