### PR TITLE
[analysis] Add defined-by on missing var definitions

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -51,6 +51,7 @@ The analysis output consists of a map with:
   - `:filename`, `:row`, `:col`, `end-row`, `end-col`
   - `:ns`: the namespace of the var
   - `:name`: the name of the var
+  - `:defined-by`: the namespaced symbol which defined this var
 
   Optional:
   - `:fixed-arities`: a set of fixed arities
@@ -148,12 +149,14 @@ $ clj-kondo --lint /tmp/foo.clj --config '{:output {:analysis true :format :edn}
                     :end-col 11,
                     :ns foo,
                     :name f,
+                    :defined-by 'clojure.core/defn-
                     :private true,
                     :fixed-arities #{1}}
                    {:added "1.2",
                     :ns foo,
                     :name g,
                     :filename "/tmp/foo.clj",
+                    :defined-by 'clojure.core/defmacro
                     :macro true,
                     :row 11,
                     :col 1,

--- a/corpus/hooks/state_flow.clj
+++ b/corpus/hooks/state_flow.clj
@@ -1,5 +1,0 @@
-(ns baz
-  {:clj-kondo/config '{:hooks {:analyze-call {state-flow.cljtest/defflow hooks.state-flow/defflow}}}}
-  (:require [state-flow.cljtest :refer [defflow]]))
-
-(defflow my-flow)

--- a/corpus/hooks/state_flow.clj
+++ b/corpus/hooks/state_flow.clj
@@ -1,0 +1,5 @@
+(ns baz
+  {:clj-kondo/config '{:hooks {:analyze-call {state-flow.cljtest/defflow hooks.state-flow/defflow}}}}
+  (:require [state-flow.cljtest :refer [defflow]]))
+
+(defflow my-flow)

--- a/src/clj_kondo/impl/analyzer/common.clj
+++ b/src/clj_kondo/impl/analyzer/common.clj
@@ -18,8 +18,8 @@
 (defn analyze-children [ctx expr]
   ((get @common 'analyze-children) ctx expr))
 
-(defn analyze-defn [ctx expr]
-  ((get @common 'analyze-defn) ctx expr))
+(defn analyze-defn [ctx expr defined-by]
+  ((get @common 'analyze-defn) ctx expr defined-by))
 
 (defn analyze-usages2 [ctx expr]
   ((get @common 'analyze-usages2) ctx expr))

--- a/src/clj_kondo/impl/analyzer/test.clj
+++ b/src/clj_kondo/impl/analyzer/test.clj
@@ -4,7 +4,7 @@
     [clj-kondo.impl.analyzer.common :as common]
     [clj-kondo.impl.utils :as utils]))
 
-(defn analyze-deftest [ctx expr resolved-ns resolved-name resolved-as-ns resolved-as-name]
+(defn analyze-deftest [ctx expr defined-by resolved-as-ns resolved-as-name]
   (common/analyze-defn
    ctx
    (-> expr
@@ -16,10 +16,11 @@
            (when name-expr (vary-meta name-expr
                                       assoc
                                       :linted-as (symbol (str resolved-as-ns) (str resolved-as-name))
-                                      :defined-by (symbol (str resolved-ns) (str resolved-name))
+                                      :defined-by defined-by
                                       :test true))
            (utils/vector-node [])
-           body))))))
+           body))))
+   defined-by))
 
 (defn analyze-cljs-test-async [ctx expr]
   (let [[binding-expr & rest-children] (rest (:children expr))

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -3,6 +3,7 @@
    [clj-kondo.core :as clj-kondo]
    [clj-kondo.test-utils :refer [assert-submaps]]
    [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.test :as t :refer [deftest is testing]]))
 
 (defn analyze
@@ -441,6 +442,15 @@
         :from foo,
         :to clojure.core}]
      var-usages)))
+
+(deftest hooks-custom-defined-by-test
+  (assert-submaps
+   '[{:ns baz,
+      :name my-flow,
+      :defined-by state-flow.cljtest/defflow}]
+   (:var-definitions
+    (analyze (slurp (io/file "corpus" "hooks" "state_flow.clj"))
+              {:config-dir (.getPath (io/file "corpus" ".clj-kondo"))}))))
 
 (deftest analysis-alias-test
   (let [{:keys [:var-usages]}

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -499,7 +499,8 @@
        {:fixed-arities #{1}, :end-row 3, :name-end-col 29, :name-end-row 3, :name-row 3, :ns foo, :name f1, :defined-by schema.core/defn, :filename "<stdin>", :col 19, :name-col 27, :end-col 36, :row 3}
        {:fixed-arities #{1 2}, :end-row 4, :name-end-col 29, :name-end-row 4, :name-row 4, :ns foo, :name f2, :defined-by schema.core/defn, :filename "<stdin>", :col 19, :name-col 27, :end-col 49, :row 4}
        {:end-row 5, :name-end-col 33, :name-end-row 5, :name-row 5, :ns foo, :name A, :defined-by schema.core/defrecord, :filename "<stdin>", :col 19, :name-col 32, :end-col 40, :row 5}
-       {:fixed-arities #{2}, :end-row 5, :name-end-col 33, :name-end-row 5, :name-row 5, :ns foo, :name ->A, :defined-by schema.core/defrecord, :filename "<stdin>", :col 19, :name-col 32, :end-col 40, :row 5}]
+       {:fixed-arities #{2}, :end-row 5, :name-end-col 33, :name-end-row 5, :name-row 5, :ns foo, :name ->A, :defined-by schema.core/defrecord, :filename "<stdin>", :col 19, :name-col 32, :end-col 40, :row 5}
+       {:fixed-arities #{1}, :end-row 5, :name-end-col 33, :name-end-row 5, :name-row 5, :ns foo, :name map->A, :defined-by schema.core/defrecord, :filename "<stdin>", :col 19, :name-col 32, :end-col 40, :row 5}]
      var-definitions)))
 
 (deftest declare-var-test
@@ -546,6 +547,3 @@
       '[{:name union :name-row 1 :name-end-row 1 :name-col 33 :name-end-col 38}
         {:name require :name-row 1 :name-end-row 1 :name-col 2 :name-end-col 9}]
      var-usages)))
-
-(comment
-  (t/run-tests))


### PR DESCRIPTION
Fixes #1216 

This should add the `:defined-by` with the full-qualified-symbol for all `var-definitions`.