### PR TITLE
[analysis] Add name positions to local-usage analysis

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -84,6 +84,7 @@ The analysis output consists of a map with:
 
 - `:local-usages`, a list of maps with:
   - `:filename`, `:row`, `:col`, `:end-row`, `:end-col`
+  - `:name-row`, `:name-col`, `:name-end-row`, `:name-end-col` 
   - `:id`: an identification for this local, refers to the local declaration with the same `:id` in `:locals`
   - `:name`: the name of the used local
 

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -92,7 +92,7 @@
 (defn reg-local-usage! [{:keys [:analysis] :as ctx} filename binding usage]
   (when analysis
     (swap! analysis update :local-usages conj
-           (assoc-some (select-keys usage [:id :row :col :end-row :end-col])
+           (assoc-some (select-keys usage [:id :row :col :end-row :end-col :name-row :name-col :name-end-row :name-end-col])
                        :name (:name binding)
                        :filename filename
                        :lang (when (= :cljc (:base-lang ctx)) (:lang ctx))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -885,8 +885,8 @@
 (defn analyze-binding-call [ctx fn-name binding expr]
   (let [callstack (:callstack ctx)
         config (:config ctx)
-        ns-name (-> ctx :ns :name)]
-    ;;(prn (:tag binding))
+        ns-name (-> ctx :ns :name)
+        fn-meta (meta fn-name)]
     (when-let [k (types/keyword binding)]
       (when-not (types/match? k :ifn)
         (findings/reg-finding! ctx (node->line (:filename ctx) expr :error
@@ -896,7 +896,11 @@
     (namespace/reg-used-binding! ctx
                                  ns-name
                                  binding
-                                 (meta expr))
+                                 (assoc (meta expr)
+                                        :name-row (:row fn-meta)
+                                        :name-col (:col fn-meta)
+                                        :name-end-row (:end-row fn-meta)
+                                        :name-end-col (:end-col fn-meta)))
     (when-not (config/skip? config :invalid-arity callstack)
       (let [filename (:filename ctx)
             children (:children expr)]

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -114,14 +114,19 @@
            (case t
              :token
              (if-let [symbol-val (symbol-from-token expr)]
-               (let [simple? (simple-symbol? symbol-val)]
+               (let [simple? (simple-symbol? symbol-val)
+                     expr-meta (meta expr)]
                  (if-let [b (when (and simple? (not syntax-quote?))
                               (get (:bindings ctx) symbol-val))]
                    (namespace/reg-used-binding! ctx
                                                 (-> ns :name)
                                                 b
                                                 (when (:analyze-locals? ctx)
-                                                  (assoc-some (meta expr)
+                                                  (assoc-some expr-meta
+                                                              :name-row (:row expr-meta)
+                                                              :name-col (:col expr-meta)
+                                                              :name-end-row (:end-row expr-meta)
+                                                              :name-end-col (:end-col expr-meta)
                                                               :name symbol-val
                                                               :filename (:filename ctx)
                                                               :str (:string-value expr))))


### PR DESCRIPTION
This PR should fix a issue we have on clojure-lsp. When we hover over a local or local-usage we highlight the references:
![image](https://user-images.githubusercontent.com/7820865/111567184-4e583f00-877d-11eb-91db-0c5c7ea42453.png)
But when a local is a function, it shows incorrectly the range:
![image](https://user-images.githubusercontent.com/7820865/111567121-32ed3400-877d-11eb-9e5d-83e96e092905.png)
This also affect features like rename.

This happens because clj-kondo send only the row and column of the local-usage and not the name-* like we do for var-usages and other buckets.

Another example of the issue [here](https://clojurians.slack.com/archives/CPABC1H61/p1615928222016500?thread_ts=1615910590.010200&cid=CPABC1H61)
