### PR TITLE
Change no-warnings to copy-hooks check when copying hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+### New
+
+- `--copy-hooks` flag to indicate linting is used to copy existing hooks to clj-kondo config dir.
+
 ### Enhanced / fixed
 
 - NullPointerException when ignoring :deprecated-var [#1195](https://github.com/clj-kondo/clj-kondo/issues/1195)

--- a/README.md
+++ b/README.md
@@ -136,14 +136,8 @@ entire classpath to teach `clj-kondo` about all the libraries you are using,
 including Clojure and/or ClojureScript itself:
 
 ``` shellsession
-$ clj-kondo --no-warnings --parallel --lint "<classpath>"
+$ clj-kondo --parallel --lint "<classpath>"
 ```
-
-The `--no-warnings` flag indicates that clj-kondo is used to analyze sources to
-populate the cache. When enabled, clj-kondo will suppress warnings, skips over
-already linted `.jar` files and copies configuration from dependencies into the
-`.clj-kondo` directory (see
-[config.md](doc/config.md#exporting-and-importing-configuration)).
 
 Build tool specific ways to get a classpath:
 - `lein classpath`

--- a/doc/config.md
+++ b/doc/config.md
@@ -296,7 +296,7 @@ Suppose you would have [clj-kondo/config](https://github.com/clj-kondo/config)
 on your classpath and linted like this:
 
 ``` shellsession
-$ clj-kondo --no-warnings --lint "$(clojure -Spath -Sdeps '{:deps {clj-kondo/config {:git/url "https://github.com/clj-kondo/config" :sha "e2e156c53c6c228fee7242629b41013f3e55051d"}}}')"
+$ clj-kondo --copy-hooks --lint "$(clojure -Spath -Sdeps '{:deps {clj-kondo/config {:git/url "https://github.com/clj-kondo/config" :sha "e2e156c53c6c228fee7242629b41013f3e55051d"}}}')"
 Copied config to .clj-kondo/clj-kondo/claypoole. Consider adding clj-kondo/claypoole to :config-paths in .clj-kondo/config.edn.
 ...
 ```
@@ -314,7 +314,7 @@ Imported configurations can be checked into source control, at your convenience.
 Note: configuration is only copied when all of these requirements are met:
 
 - There is a `.clj-kondo` directory that can be used as a target.
-- The `--no-warnings` flag is used to indicate that clj-kondo is used to populate the cache.
+- The `--copy-hooks` flag is used to indicate that clj-kondo is used to populate the cache.
 
 ## Deprecations
 

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -75,6 +75,8 @@
 
   - `:parallel`: optional. A boolean indicating if sources should be linted in parallel.`
 
+  - `:copy-hooks`: optional. A boolean indicating if scanned hooks should be copied to clj-kondo config dir.`
+
   Returns a map with `:findings`, a seqable of finding maps, a
   `:summary` of the findings and the `:config` that was used to
   produce those findings. This map can be passed to `print!` to print
@@ -88,7 +90,8 @@
            :config
            :config-dir
            :parallel
-           :no-warnings]
+           :no-warnings
+           :copy-hooks]
     :or {cache true}}]
   (let [start-time (System/currentTimeMillis)
         cfg-dir
@@ -118,6 +121,7 @@
                         :cljs #{}
                         :cljc #{}})
         ctx {:no-warnings no-warnings
+             :copy-hooks copy-hooks
              :config-dir cfg-dir
              :config config
              :classpath classpath

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -199,7 +199,7 @@
       (mapv (fn [^JarFile$JarFileEntry entry]
               (let [entry-name (.getName entry)
                     source (slurp (.getInputStream jar entry))]
-                (when (and cfg-dir (:no-warnings ctx)
+                (when (and cfg-dir (:copy-hooks ctx)
                            (str/includes? entry-name "clj-kondo.exports"))
                   (copy-config-entry ctx entry-name source cfg-dir))
                 {:filename (str (when canonical?
@@ -238,7 +238,7 @@
                   can-read? (.canRead file)
                   source? (and (.isFile file) (source-file? nm))]
               (when (and cfg-dir source?
-                         (:no-warnings ctx)
+                         (:copy-hooks ctx)
                          (str/includes? path "clj-kondo.exports"))
                 (copy-config-file ctx file cfg-dir))
               (cond

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -67,6 +67,7 @@ Options:
     "--parallel"   :scalar
     "--filename"   :scalar
     "--no-warnings" :scalar
+    "--copy-hooks" :scalar
     :scalar))
 
 (defn- parse-opts [options]
@@ -108,7 +109,8 @@ Options:
                  (when k
                    (or (nil? v)
                        (= "true" v))))
-     :no-warnings (contains? opts "--no-warnings")}))
+     :no-warnings (contains? opts "--no-warnings")
+     :copy-hooks (contains? opts "--copy-hooks")}))
 
 (defn main
   [& options]

--- a/test/clj_kondo/impl/copy_config_test.clj
+++ b/test/clj_kondo/impl/copy_config_test.clj
@@ -11,7 +11,7 @@
     (binding [*err* (java.io.StringWriter.)]
       (clj-kondo/run! {:lint [(io/file "corpus" "exports" "clj-kondo.config.jar")]
                        :config-dir tmp-dir
-                       :no-warnings true}))
+                       :copy-hooks true}))
     (is (.exists (io/file tmp-dir "clj-kondo" "slingshot")))
     (is (= "{:hooks
  {:analyze-call {slingshot.slingshot/try+ clj-kondo.slingshot.try-plus/try+}}}
@@ -24,7 +24,7 @@
     (binding [*err* (java.io.StringWriter.)]
       (clj-kondo/run! {:lint [(io/file "corpus" "exports" "dir")]
                        :config-dir tmp-dir
-                       :no-warnings true}))
+                       :copy-hooks true}))
     (is (.exists (io/file tmp-dir "clj-kondo" "slingshot")))
     (is (= "{:hooks
  {:analyze-call {slingshot.slingshot/try+ clj-kondo.slingshot.try-plus/try+}}}


### PR DESCRIPTION
This will allow clj-kondo to copy hooks while returning findings/analysis, used by clojure-lsp for example.

This can be considered a breaking-change, not sure we should keep checking for no-warnings along with the new flag.