### PR TITLE
Correct escaping for docstrings in analysis

### DIFF
--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -159,8 +159,8 @@
   (char? (:value node)))
 
 (defn string-from-token [node]
-  (when-let [lines (:lines node)]
-    (str/join "\n" lines)))
+  (when (:lines node)
+    (node/sexpr node)))
 
 (defn number-token? [node]
   (number? (:value node)))

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -297,6 +297,20 @@
         :arity 4}]
      var-usages))
 
+  (let [{:keys [:var-definitions]} (analyze "(defn foo \"docstring with\\n \\\"escaping\\\"\" [])")]
+    (assert-submaps
+     '[{:filename "<stdin>",
+        :row 1,
+        :col 1,
+        :end-row 1,
+        :end-col 46,
+        :ns user,
+        :name foo,
+        :defined-by clojure.core/defn,
+        :fixed-arities #{0},
+        :doc "docstring with\n \"escaping\""}]
+     var-definitions))  
+
   (let [{:keys [:var-definitions]} (analyze "(def ^:deprecated x \"docstring\" 1)")]
     (assert-submaps
      '[{:filename "<stdin>",


### PR DESCRIPTION
Docstrings returned via :doc in analysis are no longer over-escaped.

Fix is to simply call `sexpr` on string node.
Lemme know if this works for you.

Fixes #1223