### PR TITLE
Fix recur arities for lazy-seq and lazy-cat

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1636,7 +1636,9 @@
                         (let [next-ctx (cond-> ctx
                                          (one-of [resolved-namespace resolved-name]
                                                  [[clojure.core.async thread]
-                                                  [clojure.core dosync]])
+                                                  [clojure.core dosync]
+                                                  [clojure.core lazy-seq]
+                                                  [clojure.core lazy-cat]])
                                          (assoc-in [:recur-arity :fixed-arity] 0))]
                           (analyze-children next-ctx children false))))]
                 (if (= 'ns resolved-as-clojure-var-name)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1791,6 +1791,8 @@ foo/foo ;; this does use the private var
                      {:linters {:unresolved-symbol {:level :error}}}
                      "--lang" "cljs")))
   (is (empty? (lint! "(defn foo [_a _b] (dosync (recur)))")))
+  (is (empty? (lint! "(defn foo [_a _b] (lazy-seq (recur)))")))
+  (is (empty? (lint! "(defn foo [_a _b] (lazy-cat (recur)))")))
   (is (empty? (lint! "(ns foo (:refer-clojure :only [defn]))")))
   (is (empty? (lint! "
 (ns kitchen-async.promise


### PR DESCRIPTION
Both these functions wrap their bodies in a 0-arity thunk (see #1081)