### PR TITLE
Report reader errors at the start of token

### DIFF
--- a/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
@@ -39,7 +39,8 @@
 (defn parse-token
   "Parse a single token."
   [reader]
-  (let [token-location ((juxt rt/get-line-number rt/get-column-number) reader)]
+  (let [token-row (rt/get-line-number reader)
+        token-col (rt/get-column-number reader)]
     (try
       (let [first-char (r/next reader)
             s (->> (if (= first-char \\)
@@ -55,8 +56,8 @@
           (when (and *invalid-token-exceptions*
                      (= :reader-exception type)
                      (= :reader-error ex-kind))
-            (let [f {:row (token-location 0)
-                     :col (token-location 1)
+            (let [f {:row token-row
+                     :col token-col
                      :message (.getMessage e)}]
               (swap! *invalid-token-exceptions* conj (ex-info "Syntax error" {:findings [f]})))))
         reader))))

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -106,7 +106,7 @@
                :level :error
                :filename "test.clj"
                :row 1
-               :col 5
+               :col 1
                :message "Invalid number: 1..1."}]
              @(:findings (analyze "1..1")))))
     (testing "multiple :as aliases and alias fn"

--- a/test/clj_kondo/impl/parser_test.clj
+++ b/test/clj_kondo/impl/parser_test.clj
@@ -55,7 +55,7 @@
     ":"  [["unexpected EOF while reading keyword." 1 2]]
     "\"" [["Unexpected EOF while reading string." 1 2]]
     "#?" [[":reader-macro node expects 1 value." 1 3]]
-    "[1..1]" [["Invalid number: 1..1." 1 6]]
+    "[1..1]" [["Invalid number: 1..1." 1 2]]
     "#:" [["Unexpected EOF." 1 3]]))
 
 ;;;; Scratch

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2734,14 +2734,14 @@ foo/baz
 
 (deftest continue-on-invalid-token-code-test
   (assert-submaps
-   '({:file "<stdin>", :row 2, :col 5, :level :error, :message "Invalid symbol: foo/."}
+   '({:file "<stdin>", :row 2, :col 1, :level :error, :message "Invalid symbol: foo/."}
      {:file "<stdin>", :row 3, :col 1, :level :error, :message "clojure.core/inc is called with 0 args but expects 1"})
    (lint! "
 foo/
 (inc)"))
   (assert-submaps
    '({:file "<stdin>", :row 2, :col 1, :level :error, :message "clojure.core/inc is called with 0 args but expects 1"}
-     {:file "<stdin>", :row 3, :col 5, :level :error, :message "Invalid symbol: foo/."})
+     {:file "<stdin>", :row 3, :col 1, :level :error, :message "Invalid symbol: foo/."})
    (lint! "
 (inc)
 foo/")))


### PR DESCRIPTION
This allows editor plugins to place the squiggly lines below the entire token instead of right at the end.