### PR TITLE
Improve keywords analysis

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -97,11 +97,17 @@ The analysis output consists of a map with:
     - `::kw` will have the current ns.
     - `:b/kw` will have `b` as a ns regardless of `require`ed namespaces.
     - `::b/kw` will be the aliased ns of `b` or `:clj-kondo/unknown-namespace` if `b` is not an alias.
+    - `#:b{:kw 1}` will have `b` as ns.
+    - `#:b{:_/kw 1}` will have `nil` as ns.
+    - `#:b{:c/kw 1}` will have `c` as ns.
+    - `#:b{::kw 1}` will have the current ns.
   - `:alias`: the alias used by the keyword. Only present when a valid, external alias.
     - `::a/kw` would have an alias of `a`.
     - `::kw` does not have an alias.
-  - `:keys-destructuring` if the keyword is within a `:keys` vector.
-  - `:def` can be added by `:hooks` using `clj-kondo.hook-api/reg-keyword!` to indicate a registered definition location for the keyword.
+  - `:auto-resolved`: if the keyword `:ns` is auto resolved, example: `::kw`
+  - `:namespace-from-prefix`: if the keyword `:ns` is from the namespaced map, example: `::b{:kw 1}`
+  - `:keys-destructuring`: if the keyword is within a `:keys` vector.
+  - `:def`: can be added by `:hooks` using `clj-kondo.hook-api/reg-keyword!` to indicate a registered definition location for the keyword.
     Can be truthy, either `true` or the fully qualified call that registered it.
 
 Example output after linting this code:

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -104,7 +104,7 @@
   (when (:analyze-keywords? ctx)
     (when-let [analysis (:analysis ctx)]
       (swap! analysis update :keywords conj
-             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :def])
+             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :def :auto-resolved])
                          :name (name (:name usage))
                          :filename filename
                          :lang (when (= :cljc (:base-lang ctx)) (:lang ctx)))))))

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -104,7 +104,7 @@
   (when (:analyze-keywords? ctx)
     (when-let [analysis (:analysis ctx)]
       (swap! analysis update :keywords conj
-             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :def :auto-resolved])
+             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :def :auto-resolved :namespace-applied])
                          :name (name (:name usage))
                          :filename filename
                          :lang (when (= :cljc (:base-lang ctx)) (:lang ctx)))))))

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -104,7 +104,7 @@
   (when (:analyze-keywords? ctx)
     (when-let [analysis (:analysis ctx)]
       (swap! analysis update :keywords conj
-             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :def :auto-resolved :namespace-applied])
+             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :def :auto-resolved :namespace-from-prefix])
                          :name (name (:name usage))
                          :filename filename
                          :lang (when (= :cljc (:base-lang ctx)) (:lang ctx)))))))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -33,8 +33,10 @@
                  aliased?
                  current-ns
 
-                 prefix (when (not= '_ alias-or-ns)
-                          prefix)
+                 (and prefix
+                      (not alias-or-ns))
+                 (when (not= '_ alias-or-ns)
+                   prefix)
 
                  :else
                  alias-or-ns)]

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -34,6 +34,10 @@
                  current-ns
 
                  (and prefix
+                      (= '_ alias-or-ns))
+                 nil
+
+                 (and prefix
                       (not alias-or-ns))
                  prefix
 

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -35,14 +35,15 @@
 
                  (and prefix
                       (not alias-or-ns))
-                 (when (not= '_ alias-or-ns)
-                   prefix)
+                 prefix
 
                  :else
                  alias-or-ns)]
     {:name name-sym
      :ns ns-sym
-     :prefix prefix
+     :prefix (and prefix
+                  (not alias-or-ns)
+                  (not (:namespaced? expr)))
      :alias (when (and aliased? (not= :clj-kondo/unknown-namespace ns-sym)) alias-or-ns)}))
 
 (defn analyze-keyword
@@ -63,7 +64,7 @@
                        :def (:def expr)
                        :keys-destructuring keys-destructuring?
                        :auto-resolved (boolean (:namespaced? expr))
-                       :namespace-applied (boolean (:prefix resolved))
+                       :namespace-from-prefix (boolean (:prefix resolved))
                        :name (:name resolved)
                        :alias (when-not (:alias destructuring) (:alias resolved))
                        :ns (or (:ns destructuring) (:ns resolved))))))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -59,6 +59,7 @@
            (assoc-some (meta expr)
                        :def (:def expr)
                        :keys-destructuring keys-destructuring?
+                       :auto-resolved (boolean (:namespaced? expr))
                        :name (:name resolved)
                        :alias (when-not (:alias destructuring) (:alias resolved))
                        :ns (or (:ns destructuring) (:ns resolved))))))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -42,6 +42,7 @@
                  alias-or-ns)]
     {:name name-sym
      :ns ns-sym
+     :prefix prefix
      :alias (when (and aliased? (not= :clj-kondo/unknown-namespace ns-sym)) alias-or-ns)}))
 
 (defn analyze-keyword
@@ -62,6 +63,7 @@
                        :def (:def expr)
                        :keys-destructuring keys-destructuring?
                        :auto-resolved (boolean (:namespaced? expr))
+                       :namespace-applied (boolean (:prefix resolved))
                        :name (:name resolved)
                        :alias (when-not (:alias destructuring) (:alias resolved))
                        :ns (or (:ns destructuring) (:ns resolved))))))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -45,9 +45,9 @@
                  alias-or-ns)]
     {:name name-sym
      :ns ns-sym
-     :prefix (and prefix
-                  (not alias-or-ns)
-                  (not (:namespaced? expr)))
+     :namespace-from-prefix (and prefix
+                                 (not alias-or-ns)
+                                 (not (:namespaced? expr)))
      :alias (when (and aliased? (not= :clj-kondo/unknown-namespace ns-sym)) alias-or-ns)}))
 
 (defn analyze-keyword
@@ -67,8 +67,8 @@
            (assoc-some (meta expr)
                        :def (:def expr)
                        :keys-destructuring keys-destructuring?
-                       :auto-resolved (boolean (:namespaced? expr))
-                       :namespace-from-prefix (boolean (:prefix resolved))
+                       :auto-resolved (:namespaced? expr)
+                       :namespace-from-prefix (when (:namespace-from-prefix resolved) true)
                        :name (:name resolved)
                        :alias (when-not (:alias destructuring) (:alias resolved))
                        :ns (or (:ns destructuring) (:ns resolved))))))

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -137,16 +137,17 @@
             {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>"}]
           (:keywords a))))
     (testing "auto-resolved"
-      (let [a (analyze ":a ::b :user/c #:d{:e 1 :_/f 2 :g/h 3 ::i 4}"
+      (let [a (analyze "(ns foo)
+                        :a ::b :bar/c #:d{:e 1 :_/f 2 :g/h 3 ::i 4}"
                        {:config {:output {:analysis {:keywords true}}}})]
         (assert-submaps
               '[{:name "a" :auto-resolved false}
-                {:name "b" :auto-resolved true}
-                {:name "c" :auto-resolved false}
-                {:name "e" :auto-resolved false}
+                {:name "b" :auto-resolved true :ns foo}
+                {:name "c" :auto-resolved false :ns bar}
+                {:name "e" :auto-resolved false :ns d}
                 {:name "f" :auto-resolved false}
-                {:name "h" :auto-resolved false}
-                {:name "i" :auto-resolved true}]
+                {:name "h" :auto-resolved false :ns g}
+                {:name "i" :auto-resolved true :ns foo}]
               (:keywords a))))))
 
 (deftest locals-analysis-test

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -127,33 +127,32 @@
     (testing "no namespace for key :a"
       (let [a (analyze "#:xml{:_/a 1}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>" :auto-resolved false :namespace-from-prefix false}]
+        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>"}]
                (:keywords a)))))
     ;; Don't use assertmap here to make sure ns is absent
     (testing "no namespace for key :b"
       (let [a (analyze "#:xml{:a {:b 1}}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>" :auto-resolved false :namespace-from-prefix true}
-                 {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>" :auto-resolved false :namespace-from-prefix false}]
+        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>" :namespace-from-prefix true}
+                 {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>"}]
           (:keywords a)))))
-    (testing "auto-resolved"
+    (testing "auto-resolved and namespace-from-prefix"
       (let [a (analyze "(ns foo)
                         :a ::b :bar/c
                         #:d{:e 1 :_/f 2 :g/h 3 ::i 4}
                         {:j/k 5 :l 6 ::m 7}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (assert-submaps
-              '[{:name "a" :auto-resolved false :namespace-from-prefix false}
-                {:name "b"  :auto-resolved true :namespace-from-prefix false :ns foo}
-                {:name "c" :auto-resolved false :namespace-from-prefix false :ns bar}
-                {:name "e" :auto-resolved false :namespace-from-prefix true :ns d}
-                {:name "f" :auto-resolved false :namespace-from-prefix false}
-                {:name "h" :auto-resolved false :namespace-from-prefix false :ns g}
-                {:name "i" :auto-resolved true :namespace-from-prefix false :ns foo}
-                {:name "k" :auto-resolved false :namespace-from-prefix false :ns j}
-                {:name "l" :auto-resolved false :namespace-from-prefix false}
-                {:name "m" :auto-resolved true :namespace-from-prefix false :ns foo}]
-              (:keywords a))))))
+        (is (= '[{:row 2 :col 25 :end-row 2 :end-col 27 :name "a" :filename "<stdin>"}
+                 {:row 2 :col 28 :end-row 2 :end-col 31 :ns foo :auto-resolved true :name "b" :filename "<stdin>"}
+                 {:row 2 :col 32 :end-row 2 :end-col 38 :ns bar :name "c" :filename "<stdin>"}
+                 {:row 3 :col 29 :end-row 3 :end-col 31 :ns d :namespace-from-prefix true :name "e" :filename "<stdin>"}
+                 {:row 3 :col 34 :end-row 3 :end-col 38 :name "f" :filename "<stdin>"}
+                 {:row 3 :col 41 :end-row 3 :end-col 45 :ns g :name "h" :filename "<stdin>"}
+                 {:row 3 :col 48 :end-row 3 :end-col 51 :ns foo :auto-resolved true :name "i" :filename "<stdin>"}
+                 {:row 4 :col 26 :end-row 4 :end-col 30 :ns j :name "k" :filename "<stdin>"}
+                 {:row 4 :col 33 :end-row 4 :end-col 35 :name "l" :filename "<stdin>"}
+                 {:row 4 :col 38 :end-row 4 :end-col 41 :ns foo :auto-resolved true :name "m" :filename "<stdin>"}]
+              (:keywords a)))))))
 
 (deftest locals-analysis-test
   (let [a (analyze "#(inc %1 %&)" {:config {:output {:analysis {:locals true}}}})]

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -123,19 +123,19 @@
         (assert-submaps
          '[{:name "a" :ns xml}]
          (:keywords a))))
+    ;; Don't use assertmap here to make sure ns is absent
     (testing "no namespace for key :a"
       (let [a (analyze "#:xml{:_/a 1}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (assert-submaps
-          '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>"}]
-          (:keywords a))))
+        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>" :auto-resolved false :namespace-from-prefix false}]
+               (:keywords a)))))
+    ;; Don't use assertmap here to make sure ns is absent
     (testing "no namespace for key :b"
       (let [a (analyze "#:xml{:a {:b 1}}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (assert-submaps
-          '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>"}
-            {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>"}]
-          (:keywords a))))
+        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>" :auto-resolved false :namespace-from-prefix true}
+                 {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>" :auto-resolved false :namespace-from-prefix false}]
+          (:keywords a)))))
     (testing "auto-resolved"
       (let [a (analyze "(ns foo)
                         :a ::b :bar/c

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -138,16 +138,21 @@
           (:keywords a))))
     (testing "auto-resolved"
       (let [a (analyze "(ns foo)
-                        :a ::b :bar/c #:d{:e 1 :_/f 2 :g/h 3 ::i 4}"
+                        :a ::b :bar/c
+                        #:d{:e 1 :_/f 2 :g/h 3 ::i 4}
+                        {:j/k 5 :l 6 ::m 7}"
                        {:config {:output {:analysis {:keywords true}}}})]
         (assert-submaps
-              '[{:name "a" :auto-resolved false :namespace-applied false}
-                {:name "b"  :auto-resolved true :namespace-applied false :ns foo}
-                {:name "c" :auto-resolved false :namespace-applied false :ns bar}
-                {:name "e" :auto-resolved false :namespace-applied true :ns d}
-                {:name "f" :auto-resolved false :namespace-applied true}
-                {:name "h" :auto-resolved false :namespace-applied true :ns g}
-                {:name "i" :auto-resolved true :namespace-applied true :ns foo}]
+              '[{:name "a" :auto-resolved false :namespace-from-prefix false}
+                {:name "b"  :auto-resolved true :namespace-from-prefix false :ns foo}
+                {:name "c" :auto-resolved false :namespace-from-prefix false :ns bar}
+                {:name "e" :auto-resolved false :namespace-from-prefix true :ns d}
+                {:name "f" :auto-resolved false :namespace-from-prefix false}
+                {:name "h" :auto-resolved false :namespace-from-prefix false :ns g}
+                {:name "i" :auto-resolved true :namespace-from-prefix false :ns foo}
+                {:name "k" :auto-resolved false :namespace-from-prefix false :ns j}
+                {:name "l" :auto-resolved false :namespace-from-prefix false}
+                {:name "m" :auto-resolved true :namespace-from-prefix false :ns foo}]
               (:keywords a))))))
 
 (deftest locals-analysis-test

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -126,14 +126,28 @@
     (testing "no namespace for key :a"
       (let [a (analyze "#:xml{:_/a 1}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (is (= '{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>"}
-               (first (:keywords a))))))
+        (assert-submaps
+          '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>"}]
+          (:keywords a))))
     (testing "no namespace for key :b"
       (let [a (analyze "#:xml{:a {:b 1}}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>"}
-                 {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>"}]
-               (:keywords a)))))))
+        (assert-submaps
+          '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>"}
+            {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>"}]
+          (:keywords a))))
+    (testing "auto-resolved"
+      (let [a (analyze ":a ::b :user/c #:d{:e 1 :_/f 2 :g/h 3 ::i 4}"
+                       {:config {:output {:analysis {:keywords true}}}})]
+        (assert-submaps
+              '[{:name "a" :auto-resolved false}
+                {:name "b" :auto-resolved true}
+                {:name "c" :auto-resolved false}
+                {:name "e" :auto-resolved false}
+                {:name "f" :auto-resolved false}
+                {:name "h" :auto-resolved false}
+                {:name "i" :auto-resolved true}]
+              (:keywords a))))))
 
 (deftest locals-analysis-test
   (let [a (analyze "#(inc %1 %&)" {:config {:output {:analysis {:locals true}}}})]

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -141,13 +141,13 @@
                         :a ::b :bar/c #:d{:e 1 :_/f 2 :g/h 3 ::i 4}"
                        {:config {:output {:analysis {:keywords true}}}})]
         (assert-submaps
-              '[{:name "a" :auto-resolved false}
-                {:name "b" :auto-resolved true :ns foo}
-                {:name "c" :auto-resolved false :ns bar}
-                {:name "e" :auto-resolved false :ns d}
-                {:name "f" :auto-resolved false}
-                {:name "h" :auto-resolved false :ns g}
-                {:name "i" :auto-resolved true :ns foo}]
+              '[{:name "a" :auto-resolved false :namespace-applied false}
+                {:name "b"  :auto-resolved true :namespace-applied false :ns foo}
+                {:name "c" :auto-resolved false :namespace-applied false :ns bar}
+                {:name "e" :auto-resolved false :namespace-applied true :ns d}
+                {:name "f" :auto-resolved false :namespace-applied true}
+                {:name "h" :auto-resolved false :namespace-applied true :ns g}
+                {:name "i" :auto-resolved true :namespace-applied true :ns foo}]
               (:keywords a))))))
 
 (deftest locals-analysis-test


### PR DESCRIPTION
Fix #1156

- Add `auto-resolved` field to keyword analysis
- Add `namespace-from-prefix` field to keyword analysis
- Fix ns overide for namespace maps like `#:a{:b/c 1}` the correct `:ns` should be `:b`  not `:a`
