### PR TITLE
Add ns alias check to symbol normalization

### DIFF
--- a/corpus/shadow_cljs/dot_alias.cljs
+++ b/corpus/shadow_cljs/dot_alias.cljs
@@ -1,0 +1,7 @@
+(ns shadow-cljs.dot-alias
+  (:require ["dayjs" :as dayjs]
+            ["dayjs/plugin/timezone" :as dayjs.timezone]
+            ["dayjs/plugin/utc" :as dayjs.utc]))
+
+(.extend dayjs dayjs.utc)
+(.extend dayjs dayjs.timezone)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1854,7 +1854,7 @@
                                             s))]
                     (let [simple? (simple-symbol? full-fn-name)
                           full-fn-name (if simple?
-                                         (namespace/normalize-sym-name lang full-fn-name)
+                                         (namespace/normalize-sym-name ctx full-fn-name)
                                          full-fn-name)
                           full-fn-name (with-meta full-fn-name (meta function))
                           binding (and simple?

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -141,7 +141,7 @@
              (if-let [symbol-val (symbol-from-token expr)]
                (let [simple? (simple-symbol? symbol-val)
                      symbol-val (if simple?
-                                  (namespace/normalize-sym-name (:lang ctx) symbol-val)
+                                  (namespace/normalize-sym-name ctx symbol-val)
                                   symbol-val)
                      expr-meta (meta expr)]
                  (if-let [b (when (and simple? (not syntax-quote?))

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -391,10 +391,11 @@
 
 (defn normalize-sym-name
   "Strips foo.bar.baz into foo, as it ignores property access in CLJS. Assumes simple symbol."
-  [lang sym]
-  (if (identical? :cljs lang)
+  [ctx sym]
+  (if (identical? :cljs (:lang ctx))
     (let [name-str (str sym)]
       (if (and
+           (not (get-in ctx [:ns :aliases sym]))
            (not (str/starts-with? name-str "."))
            (not (str/ends-with? name-str "."))
            (str/includes? name-str "."))
@@ -454,7 +455,7 @@
               {:name (symbol (name name-sym))
                :unresolved? true
                :unresolved-ns ns-sym})))
-      (let [name-sym (normalize-sym-name lang name-sym)]
+      (let [name-sym (normalize-sym-name ctx name-sym)]
         (or
          (when-let [[k v] (find (:referred-vars ns)
                                 name-sym)]

--- a/test/clj_kondo/unused_namespace_test.clj
+++ b/test/clj_kondo/unused_namespace_test.clj
@@ -118,6 +118,7 @@
   (is (empty? (lint! "(ns foo (:require [clojure.string :as str]))
                        (loop [{:keys [:id] :or {id (str/lower-case \"HI\")}} {:id \"hello\"}])")))
   (is (empty? (lint! (io/file "corpus" "shadow_cljs" "default.cljs"))))
+  (is (empty? (lint! (io/file "corpus" "shadow_cljs" "dot_alias.cljs"))))
   (is (empty? (lint! "(ns foo (:require [bar])) (:id bar/x)")))
   (is (empty? (lint! (io/file "corpus" "no_unused_namespace.clj"))))
   (is (empty? (lint! "(ns foo (:require [bar :as b])) (let [{::b/keys [:baz]} nil] baz)")))


### PR DESCRIPTION
Normalization was working incorrectly for namespace aliases containing
dots in it because they were mistaken for property access in cljs.

Now symbol normalization checks if the symbol is an alias before
assuming it a property access.

Closes #1248.