### PR TITLE
Improve keyword reg

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -109,8 +109,8 @@ The analysis output consists of a map with:
   - `:auto-resolved`: if the keyword `:ns` is auto resolved, example: `::kw`
   - `:namespace-from-prefix`: if the keyword `:ns` is from the namespaced map, example: `::b{:kw 1}`
   - `:keys-destructuring`: if the keyword is within a `:keys` vector.
-  - `:def`: can be added by `:hooks` using `clj-kondo.hook-api/reg-keyword!` to indicate a registered definition location for the keyword.
-    Can be truthy, either `true` or the fully qualified call that registered it.
+  - `:reg`: can be added by `:hooks` using `clj-kondo.hook-api/reg-keyword!` to indicate a registered definition location for the keyword.
+    It should be the fully qualified call that registered it.
 
 Example output after linting this code:
 

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -104,7 +104,7 @@
   (when (:analyze-keywords? ctx)
     (when-let [analysis (:analysis ctx)]
       (swap! analysis update :keywords conj
-             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :def :auto-resolved :namespace-from-prefix])
+             (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :reg :auto-resolved :namespace-from-prefix])
                          :name (name (:name usage))
                          :filename filename
                          :lang (when (= :cljc (:base-lang ctx)) (:lang ctx)))))))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -13,6 +13,7 @@
    [clj-kondo.impl.analyzer.namespace :as namespace-analyzer
     :refer [analyze-ns-decl]]
    [clj-kondo.impl.analyzer.potemkin :as potemkin]
+   [clj-kondo.impl.analyzer.re-frame :as re-frame]
    [clj-kondo.impl.analyzer.spec :as spec]
    [clj-kondo.impl.analyzer.test :as test]
    [clj-kondo.impl.analyzer.usages :as usages :refer [analyze-usages2]]
@@ -1642,6 +1643,14 @@
                         (analyze-like-let ctx expr)
                         [babashka.process $]
                         (babashka/analyze-$ ctx expr)
+                        ([re-frame.core reg-event-db]
+                         [re-frame.core reg-event-fx]
+                         [re-frame.core reg-event-ctx]
+                         [re-frame.core reg-sub]
+                         [re-frame.core reg-sub-raw]
+                         [re-frame.core reg-fx]
+                         [re-frame.core reg-cofx])
+                        (re-frame/analyze-reg ctx expr (symbol (str resolved-as-namespace) (str resolved-as-name)))
                         ;; catch-all
                         (let [next-ctx (cond-> ctx
                                          (one-of [resolved-namespace resolved-name]

--- a/src/clj_kondo/impl/analyzer/re_frame.clj
+++ b/src/clj_kondo/impl/analyzer/re_frame.clj
@@ -1,0 +1,12 @@
+(ns clj-kondo.impl.analyzer.re-frame
+  {:no-doc true}
+  (:require
+     [clj-kondo.impl.analyzer.common :as common]
+     [clj-kondo.impl.utils :as utils]))
+
+(defn analyze-reg [ctx expr fq-def]
+  (let [[name-expr & body] (next (:children expr))
+        reg-val (if (:k name-expr)
+                  (assoc name-expr :reg fq-def)
+                  name-expr)]
+    (common/analyze-children ctx (cons reg-val body))))

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -35,7 +35,7 @@
 (defn analyze-def [ctx expr fq-def]
   (let [[name-expr & body] (next (:children expr))
         reg-val (if (:k name-expr)
-                  (assoc name-expr :def fq-def)
+                  (assoc name-expr :reg fq-def)
                   name-expr)]
     (common/analyze-children ctx (cons reg-val body))))
 

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -61,7 +61,7 @@
            ctx
            (:filename ctx)
            (assoc-some (meta expr)
-                       :def (:def expr)
+                       :reg (:reg expr)
                        :keys-destructuring keys-destructuring?
                        :auto-resolved (:namespaced? expr)
                        :namespace-from-prefix (when (:namespace-from-prefix resolved) true)

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -1,7 +1,7 @@
 (ns clj-kondo.impl.hooks
   {:no-doc true}
   (:require [clj-kondo.impl.findings :as findings]
-            [clj-kondo.impl.utils :as utils :refer [vector-node list-node
+            [clj-kondo.impl.utils :as utils :refer [assoc-some vector-node list-node
                                                     sexpr token-node keyword-node
                                                     string-node #_map-node]]
             [clojure.java.io :as io]
@@ -19,9 +19,9 @@
 
 (defn reg-keyword!
   ([k]
-   (reg-keyword! k true))
+   (reg-keyword! k nil))
   ([k reg-by]
-   (assoc k :def reg-by)))
+   (assoc-some k :reg reg-by)))
 
 (def zip-ns (sci/create-ns 'clojure.zip nil))
 

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -81,13 +81,13 @@
           {:name "s" :ns bar}
           {:name "t" :ns x}]
         (:keywords a))))
-  (testing "clojure.spec.alpha/def can add :def"
+  (testing "clojure.spec.alpha/def can add :reg"
     (let [a (analyze "(require '[clojure.spec.alpha :as s]) (s/def ::kw (inc))"
                      {:config {:output {:analysis {:keywords true}}}})]
       (assert-submaps
-        '[{:name "kw" :def clojure.spec.alpha/def}]
+        '[{:name "kw" :reg clojure.spec.alpha/def}]
         (:keywords a))))
-  (testing "hooks can add :def"
+  (testing "hooks can add :reg"
     (let [a (analyze "(user/mydef ::kw (inc))"
                      {:config {:output {:analysis {:keywords true}}
                                :hooks {:__dangerously-allow-string-hooks__ true
@@ -101,7 +101,7 @@
                                              "                    (a/reg-keyword! (second c) 'user/mydef)"
                                              "                    (drop 2 c)))}))")}}}})]
       (assert-submaps
-        '[{:name "kw" :def user/mydef}]
+        '[{:name "kw" :reg user/mydef}]
         (:keywords a))))
   (testing "valid ns name with clojure.data.xml"
     (let [a (analyze "(ns foo (:require [clojure.data.xml :as xml]))

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -87,6 +87,25 @@
       (assert-submaps
         '[{:name "kw" :reg clojure.spec.alpha/def}]
         (:keywords a))))
+  (testing "re-frame.core/reg-event-db can add :reg"
+    (let [a (analyze "(require '[re-frame.core :as rf])
+                      (rf/reg-event-db ::a (constantly {}))
+                      (rf/reg-event-fx ::b (constantly {}))
+                      (rf/reg-event-ctx ::c (constantly {}))
+                      (rf/reg-sub ::d (constantly {}))
+                      (rf/reg-sub-raw ::e (constantly {}))
+                      (rf/reg-fx ::f (constantly {}))
+                      (rf/reg-cofx ::g (constantly {}))"
+                     {:config {:output {:analysis {:keywords true}}}})]
+      (assert-submaps
+        '[{:name "a" :reg re-frame.core/reg-event-db}
+          {:name "b" :reg re-frame.core/reg-event-fx}
+          {:name "c" :reg re-frame.core/reg-event-ctx}
+          {:name "d" :reg re-frame.core/reg-sub}
+          {:name "e" :reg re-frame.core/reg-sub-raw}
+          {:name "f" :reg re-frame.core/reg-fx}
+          {:name "g" :reg re-frame.core/reg-cofx}]
+        (:keywords a))))
   (testing "hooks can add :reg"
     (let [a (analyze "(user/mydef ::kw (inc))"
                      {:config {:output {:analysis {:keywords true}}


### PR DESCRIPTION
Fixes #1159 

- Rename `:def` -> `:reg`
- Add support for `re-frame.core` functions that register a keyword as definition.