### PR TITLE
Lint clojure.spec.alpha/keys

### DIFF
--- a/corpus/spec_syntax.clj
+++ b/corpus/spec_syntax.clj
@@ -18,3 +18,16 @@
                                       :substr string?))
 
 (s/fdef xstr/starts-with? ,,,) ;; unresolved symbol
+
+(s/def ::a any?)
+(s/def ::bar (s/keys
+              ;; fine
+              :opt [::a]
+              :opt-un [::a]
+              :req [::a]
+              :req-un [::a]
+              ;; unkown
+              ::opt [::a]
+              ::opt-un [::a]
+              ::req [::a]
+              ::req-un [::a]))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1592,6 +1592,8 @@
                         (spec/analyze-fdef (assoc ctx
                                                   :analyze-children
                                                   analyze-children) expr)
+                        ([clojure.spec.alpha keys] [cljs.spec.alpha keys])
+                        (spec/analyze-keys ctx expr)
                         ([clojure.spec.gen.alpha lazy-combinators]
                          [clojure.spec.gen.alpha lazy-prims])
                         (analyze-declare ctx expr defined-by)

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -39,6 +39,10 @@
                   name-expr)]
     (common/analyze-children ctx (cons reg-val body))))
 
+(defn analyze-keys [ctx expr]
+  (let [body (next (:children expr))]
+    (keys/lint-map-keys ctx {:children body} {:known-key? #{:req :opt :req-un :opt-un}})))
+
 ;;;; Scratch
 (require '[clj-kondo.impl.parser])
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1895,26 +1895,46 @@ foo/foo ;; this does use the private var
 
 (deftest spec-test
   (assert-submaps
-   '({:file "corpus/spec_syntax.clj",
-      :row 9,
-      :col 9,
-      :level :error,
-      :message "expected symbol"}
-     {:file "corpus/spec_syntax.clj",
-      :row 9,
-      :col 11,
-      :level :error,
-      :message "missing value for key :args"}
-     {:file "corpus/spec_syntax.clj",
-      :row 11,
-      :col 13,
-      :level :error,
-      :message "unknown option :xargs"}
-     {:file "corpus/spec_syntax.clj",
-      :row 20,
-      :col 9,
-      :level :error,
-      :message "Unresolved symbol: xstr/starts-with?"})
+   [{:file    "corpus/spec_syntax.clj",
+     :row     9,
+     :col     9,
+     :level   :error,
+     :message "expected symbol"}
+    {:file    "corpus/spec_syntax.clj",
+     :row     9,
+     :col     11,
+     :level   :error,
+     :message "missing value for key :args"}
+    {:file    "corpus/spec_syntax.clj",
+     :row     11,
+     :col     13,
+     :level   :error,
+     :message "unknown option :xargs"}
+    {:file    "corpus/spec_syntax.clj",
+     :row     20,
+     :col     9,
+     :level   :error,
+     :message "Unresolved symbol: xstr/starts-with?"}
+    {:file    "corpus/spec_syntax.clj",
+     :row     30,
+     :col     15,
+     :level   :error,
+     :message "unknown option ::opt"}
+    {:file    "corpus/spec_syntax.clj",
+     :row     31,
+     :col     15,
+     :level   :error,
+     :message "unknown option ::opt-un"}
+    {:file    "corpus/spec_syntax.clj",
+     :row     32,
+     :col     15,
+     :level   :error,
+     :message "unknown option ::req"}
+    {:file    "corpus/spec_syntax.clj",
+     :row     33,
+     :col     15,
+     :level   :error,
+     :message "unknown option ::req-un"}]
    (lint! (io/file "corpus" "spec_syntax.clj")
           '{:linters {:unresolved-symbol {:level :error}}})))
 


### PR DESCRIPTION
Lint maps keys within `clojure.spec.alpha/keys` forms to warn if keys other than `:req`, `:opt`, `:req-un`, and `:opt-un` are used.

Output of `/script/diff` on my machine:

```diff
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
Linting and writing output to /tmp/clj-kondo-diff/master.txt
1904c1904
< clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2169c2169
< inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2556c2556
< linting took 19672ms, errors: 264, warnings: 2291
---
> linting took 18335ms, errors: 264, warnings: 2291
```

Closes #1271