### PR TITLE
Refine messaging around importing configs

### DIFF
--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -373,7 +373,8 @@
                                sort
                                seq)]
       (let [rel-cfg-dir (str (if (.isAbsolute cfg-dir)
-                               (.relativize (.toPath (.getAbsoluteFile (io/file "."))) (.toPath cfg-dir))
+                               (.relativize (.toPath (.getParentFile (.getAbsoluteFile (io/file "."))))
+                                            (.toPath cfg-dir))
                                cfg-dir))]
         (for [new-config new-configs]
           {:imported-config (str (io/file rel-cfg-dir new-config))

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -373,8 +373,8 @@
                                sort
                                seq)]
       (let [rel-cfg-dir (str (if (.isAbsolute cfg-dir)
-                               (.relativize (.toPath (.getParentFile (.getAbsoluteFile (io/file "."))))
-                                            (.toPath cfg-dir))
+                               (.relativize (.normalize (.toPath (.getAbsoluteFile (io/file "."))))
+                                            (.normalize (.toPath cfg-dir)))
                                cfg-dir))]
         (for [new-config new-configs]
           {:imported-config (str (io/file rel-cfg-dir new-config))

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -8,6 +8,7 @@
    [clj-kondo.impl.utils :refer [one-of print-err! map-vals assoc-some]]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
+   [clojure.set :as set]
    [clojure.string :as str])
   (:import [java.util.jar JarFile JarFile$JarFileEntry]))
 
@@ -364,10 +365,31 @@
                                     :row 0
                                     :message "Could not process file."})))))
 
+(defn inactive-config-imports [ctx]
+  (when-let [cfg-dir (io/file (:config-dir ctx))]
+    (when-let [new-configs (-> (set/difference (-> ctx :detected-configs deref set)
+                                               (-> ctx :config :config-paths set))
+                               vec
+                               sort
+                               seq)]
+      (let [rel-cfg-dir (str (if (.isAbsolute cfg-dir)
+                               (.relativize (.toPath (.getAbsoluteFile (io/file "."))) (.toPath cfg-dir))
+                               cfg-dir))]
+        (for [new-config new-configs]
+          {:imported-config (str (io/file rel-cfg-dir new-config))
+           :suggested-config-path (str \" new-config \")
+           :config-file (.getPath (io/file (str rel-cfg-dir) "config.edn"))})))))
+
+(defn print-inactive-config-imports [inactives]
+  (binding [*out* *err*]
+    (doseq [{:keys [imported-config suggested-config-path config-file]} inactives]
+      (println (format "Imported config to %s. To activate, add %s to :config-paths in %s."
+                       imported-config suggested-config-path config-file)))))
+
 (defn process-files [ctx files default-lang filename]
   (let [cache-dir (:cache-dir ctx)
         ctx (assoc ctx :detected-configs (atom [])
-                       :mark-linted (atom []))
+                   :mark-linted (atom []))
         canonical? (-> ctx :config :output :canonical-paths)]
     (run! #(process-file ctx % default-lang canonical? filename) files)
     (when (:parallel ctx)
@@ -377,19 +399,7 @@
         (let [skip-file (io/file cache-dir "skip" mark)]
           (io/make-parents skip-file)
           (spit skip-file path))))
-    (binding [*out* *err*]
-      (when-let [detected-configs (distinct @(:detected-configs ctx))]
-        (when-let [cfg-dir (io/file (:config-dir ctx))]
-          (let [rel-cfg-dir (str (if (.isAbsolute cfg-dir)
-                                   (.relativize (.toPath (.getAbsoluteFile (io/file "."))) (.toPath cfg-dir))
-                                   cfg-dir))]
-            (doseq [detected-config detected-configs]
-              (println "Copied config to"
-                       (str (io/file rel-cfg-dir detected-config)
-                            ".")
-                       "Consider adding" detected-config "to :config-paths in"
-                       (.getPath (io/file (str rel-cfg-dir)
-                                          "config.edn."))))))))))
+    (print-inactive-config-imports (inactive-config-imports ctx))))
 
 ;;;; index defs and calls by language and namespace
 

--- a/test/clj_kondo/impl/inactive_config_test.clj
+++ b/test/clj_kondo/impl/inactive_config_test.clj
@@ -1,0 +1,69 @@
+(ns clj-kondo.impl.inactive-config-test
+  (:require [babashka.fs :as fs]
+            [clj-kondo.impl.core :as core-impl]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest inactive-import-configs-test
+  (testing "no findings"
+    (testing "when clj-kondo :config-dir is not present"
+      (is (nil? (core-impl/inactive-config-imports {:detected-configs (atom ["cfg1" "cfg2"])
+                                                    :config {:config-paths ["cfg3" "cfg4"]}}))))
+    (testing "when clj-kondo :config-paths already specify :detected-configs"
+      (is (nil? (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                    :detected-configs (atom ["cfg1" "cfg2"])
+                                                    :config {:config-paths ["cfg1" "cfg2"]}})))))
+    (testing "when there were no :detected-configs"
+      (is (nil? (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                    :detected-configs (atom [])
+                                                    :config {:config-paths ["cfg1" "cfg2"]}}))))
+  (testing "findings when there are :detected-configs"
+    (testing "and clj-kondo config has no :config-paths"
+      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
+              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+             (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                 :detected-configs (atom ["cfg1" "cfg2"])
+                                                 :config {}}))))
+    (testing "and clj-kondo :config-paths is empty"
+      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
+              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+             (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                 :detected-configs (atom ["cfg1" "cfg2"])
+                                                 :config {:config-paths []}}))))
+    (testing "and clj-kondo :config-paths does not overlap with :detected-configs"
+      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
+              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+             (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                 :detected-configs (atom ["cfg1" "cfg2"])
+                                                 :config {:config-paths ["cfg4" "cfg5"]}}))))
+    (testing "and clj-kondo :config-paths has some overlap with :detected-configs"
+      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
+              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+             (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                 :detected-configs (atom ["cfg1" "cfg2" "cfg3" "cfg6"])
+                                                 :config {:config-paths ["cfg3" "cfg4" "cfg5" "cfg6"]}}))))
+    (testing "are sorted"
+      (is (= [{:imported-config "cfg-dir/bcfg" :suggested-config-path "\"bcfg\"" :config-file "cfg-dir/config.edn"}
+              {:imported-config "cfg-dir/ccfg" :suggested-config-path "\"ccfg\"" :config-file "cfg-dir/config.edn"}
+              {:imported-config "cfg-dir/wcfg" :suggested-config-path "\"wcfg\"" :config-file "cfg-dir/config.edn"}
+              {:imported-config "cfg-dir/zcfg" :suggested-config-path "\"zcfg\"" :config-file "cfg-dir/config.edn"}]
+             (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                 :detected-configs (atom ["ccfg" "zcfg" "bcfg" "wcfg"])
+                                                 :config {}}))))
+    (testing "returns config-dir relative to current dir"
+      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}]
+             (core-impl/inactive-config-imports {:config-dir (str (fs/absolutize "cfg-dir"))
+                                                 :detected-configs (atom ["cfg1"])
+                                                 :config {}}))))))
+
+
+(deftest print-inactive-import-configs-test
+  (is (= (str "Imported config to cfg/a/b. To activate, add \"a/b\" to :config-paths in cfg/config.edn.\n"
+              "Imported config to cfg/c/d. To activate, add \"c/d\" to :config-paths in cfg/config.edn.\n")
+         (let [s (new java.io.StringWriter)]
+           (binding [*err* s]
+             (core-impl/print-inactive-config-imports
+              [{:imported-config "cfg/a/b" :suggested-config-path "\"a/b\"" :config-file "cfg/config.edn"}
+               {:imported-config "cfg/c/d" :suggested-config-path "\"c/d\"" :config-file "cfg/config.edn"}]
+              ))
+           (str s)))))
+

--- a/test/clj_kondo/impl/inactive_config_test.clj
+++ b/test/clj_kondo/impl/inactive_config_test.clj
@@ -1,7 +1,14 @@
 (ns clj-kondo.impl.inactive-config-test
   (:require [babashka.fs :as fs]
             [clj-kondo.impl.core :as core-impl]
-            [clojure.test :refer [deftest is testing]]))
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]])
+  (:import [java.io File]))
+
+(defn- osp
+  "Return host os version of path"
+  [s]
+  (str/replace s "/" File/separator))
 
 (deftest inactive-import-configs-test
   (testing "no findings"
@@ -12,58 +19,57 @@
       (is (nil? (core-impl/inactive-config-imports {:config-dir "cfg-dir"
                                                     :detected-configs (atom ["cfg1" "cfg2"])
                                                     :config {:config-paths ["cfg1" "cfg2"]}})))))
-    (testing "when there were no :detected-configs"
-      (is (nil? (core-impl/inactive-config-imports {:config-dir "cfg-dir"
-                                                    :detected-configs (atom [])
-                                                    :config {:config-paths ["cfg1" "cfg2"]}}))))
+  (testing "when there were no :detected-configs"
+    (is (nil? (core-impl/inactive-config-imports {:config-dir "cfg-dir"
+                                                  :detected-configs (atom [])
+                                                  :config {:config-paths ["cfg1" "cfg2"]}}))))
   (testing "findings when there are :detected-configs"
     (testing "and clj-kondo config has no :config-paths"
-      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
-              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+      (is (= [{:imported-config (osp "cfg-dir/cfg1") :suggested-config-path "\"cfg1\"" :config-file (osp "cfg-dir/config.edn")}
+              {:imported-config (osp "cfg-dir/cfg2") :suggested-config-path "\"cfg2\"" :config-file (osp "cfg-dir/config.edn")}]
              (core-impl/inactive-config-imports {:config-dir "cfg-dir"
                                                  :detected-configs (atom ["cfg1" "cfg2"])
                                                  :config {}}))))
     (testing "and clj-kondo :config-paths is empty"
-      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
-              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+      (is (= [{:imported-config (osp "cfg-dir/cfg1") :suggested-config-path "\"cfg1\"" :config-file (osp "cfg-dir/config.edn")}
+              {:imported-config (osp "cfg-dir/cfg2") :suggested-config-path "\"cfg2\"" :config-file (osp "cfg-dir/config.edn")}]
              (core-impl/inactive-config-imports {:config-dir "cfg-dir"
                                                  :detected-configs (atom ["cfg1" "cfg2"])
                                                  :config {:config-paths []}}))))
     (testing "and clj-kondo :config-paths does not overlap with :detected-configs"
-      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
-              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+      (is (= [{:imported-config (osp "cfg-dir/cfg1") :suggested-config-path "\"cfg1\"" :config-file (osp "cfg-dir/config.edn")}
+              {:imported-config (osp "cfg-dir/cfg2") :suggested-config-path "\"cfg2\"" :config-file (osp "cfg-dir/config.edn")}]
              (core-impl/inactive-config-imports {:config-dir "cfg-dir"
                                                  :detected-configs (atom ["cfg1" "cfg2"])
                                                  :config {:config-paths ["cfg4" "cfg5"]}}))))
     (testing "and clj-kondo :config-paths has some overlap with :detected-configs"
-      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}
-              {:imported-config "cfg-dir/cfg2" :suggested-config-path "\"cfg2\"" :config-file "cfg-dir/config.edn"}]
+      (is (= [{:imported-config (osp "cfg-dir/cfg1") :suggested-config-path "\"cfg1\"" :config-file (osp "cfg-dir/config.edn")}
+              {:imported-config (osp "cfg-dir/cfg2") :suggested-config-path "\"cfg2\"" :config-file (osp "cfg-dir/config.edn")}]
              (core-impl/inactive-config-imports {:config-dir "cfg-dir"
                                                  :detected-configs (atom ["cfg1" "cfg2" "cfg3" "cfg6"])
                                                  :config {:config-paths ["cfg3" "cfg4" "cfg5" "cfg6"]}}))))
     (testing "are sorted"
-      (is (= [{:imported-config "cfg-dir/bcfg" :suggested-config-path "\"bcfg\"" :config-file "cfg-dir/config.edn"}
-              {:imported-config "cfg-dir/ccfg" :suggested-config-path "\"ccfg\"" :config-file "cfg-dir/config.edn"}
-              {:imported-config "cfg-dir/wcfg" :suggested-config-path "\"wcfg\"" :config-file "cfg-dir/config.edn"}
-              {:imported-config "cfg-dir/zcfg" :suggested-config-path "\"zcfg\"" :config-file "cfg-dir/config.edn"}]
+      (is (= [{:imported-config (osp "cfg-dir/cfg/b") :suggested-config-path (osp "\"cfg/b\"") :config-file (osp "cfg-dir/config.edn")}
+              {:imported-config (osp "cfg-dir/cfg/c") :suggested-config-path (osp "\"cfg/c\"") :config-file (osp "cfg-dir/config.edn")}
+              {:imported-config (osp "cfg-dir/cfg/w") :suggested-config-path (osp "\"cfg/w\"") :config-file (osp "cfg-dir/config.edn")}
+              {:imported-config (osp "cfg-dir/cfg/z") :suggested-config-path (osp "\"cfg/z\"") :config-file (osp "cfg-dir/config.edn")}]
              (core-impl/inactive-config-imports {:config-dir "cfg-dir"
-                                                 :detected-configs (atom ["ccfg" "zcfg" "bcfg" "wcfg"])
+                                                 :detected-configs (atom [(osp "cfg/c") (osp "cfg/z") (osp "cfg/b") (osp "cfg/w")])
                                                  :config {}}))))
     (testing "returns config-dir relative to current dir"
-      (is (= [{:imported-config "cfg-dir/cfg1" :suggested-config-path "\"cfg1\"" :config-file "cfg-dir/config.edn"}]
+      (is (= [{:imported-config (osp "cfg-dir/cfg1") :suggested-config-path "\"cfg1\"" :config-file (osp "cfg-dir/config.edn")}]
              (core-impl/inactive-config-imports {:config-dir (str (fs/absolutize "cfg-dir"))
                                                  :detected-configs (atom ["cfg1"])
                                                  :config {}}))))))
 
 
 (deftest print-inactive-import-configs-test
-  (is (= (str "Imported config to cfg/a/b. To activate, add \"a/b\" to :config-paths in cfg/config.edn.\n"
-              "Imported config to cfg/c/d. To activate, add \"c/d\" to :config-paths in cfg/config.edn.\n")
+  (is (= (str "Imported config to cfg/a/b. To activate, add \"a/b\" to :config-paths in cfg/config.edn." (System/getProperty "line.separator")
+              "Imported config to cfg/c/d. To activate, add \"c/d\" to :config-paths in cfg/config.edn." (System/getProperty "line.separator"))
          (let [s (new java.io.StringWriter)]
            (binding [*err* s]
              (core-impl/print-inactive-config-imports
               [{:imported-config "cfg/a/b" :suggested-config-path "\"a/b\"" :config-file "cfg/config.edn"}
-               {:imported-config "cfg/c/d" :suggested-config-path "\"c/d\"" :config-file "cfg/config.edn"}]
-              ))
+               {:imported-config "cfg/c/d" :suggested-config-path "\"c/d\"" :config-file "cfg/config.edn"}]))
            (str s)))))
 


### PR DESCRIPTION
Now only reporting detected imported clj-kondo configs from libraries
if they are not already specified in :config-paths in clj-kondo config.

Closes #1256