### PR TITLE
Add :exclude config for the :use linter

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -959,3 +959,7 @@ it. That can be done as follows:
 
 *Example message:* `use :require with alias or :refer`.
 
+*Config:*
+
+This linter is closely tied to [Refer All](#refer-all). Namespaces configured to
+suppress the `:refer-all` warning will also suppress the `:use` warning.

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -154,8 +154,7 @@
                                    (str "require with " (str child-k))))))
                   (recur
                    (nnext children)
-                   (cond (and (not self-require?) (sequential? opt)
-                              (not (contains? (set (get-in ctx [:config :linters :use :exclude])) ns-name)))
+                   (cond (and (not self-require?) (sequential? opt))
                          (let [;; undo referred-all when using :only with :use
                                m (if (and use? (= :only child-k))
                                    (do (findings/reg-finding!

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -154,7 +154,8 @@
                                    (str "require with " (str child-k))))))
                   (recur
                    (nnext children)
-                   (cond (and (not self-require?) (sequential? opt))
+                   (cond (and (not self-require?) (sequential? opt)
+                              (not (contains? (set (get-in ctx [:config :linters :use :exclude])) ns-name)))
                          (let [;; undo referred-all when using :only with :use
                                m (if (and use? (= :only child-k))
                                    (do (findings/reg-finding!


### PR DESCRIPTION
This PR adds a new configuration option to the `:use` linter to permit excluding certain nses from the lint.

As it stands, on my machine there are two tests that fail, but they fail on my machine even without my changes, so this PR adds no failing tests.

The implementation I have here is very simplistic, just a one-liner, and I'd like some input on if this matches about what you'd like.

Before I mark this PR ready for merge I'll want to finish all the following tasks.
- [x] Add documentation in linters.md
- [ ] Update the changelog
- [ ] 