### PR TITLE
Allow override finding level

### DIFF
--- a/src/clj_kondo/impl/analyzer/datalog.clj
+++ b/src/clj_kondo/impl/analyzer/datalog.clj
@@ -22,5 +22,5 @@
         (catch Exception e
           (findings/reg-finding! ctx
                                  (node->line (:filename ctx) query-raw
-                                             :error :datalog-syntax
+                                             :datalog-syntax
                                              (.getMessage e))))))))

--- a/src/clj_kondo/impl/analyzer/jdbc.clj
+++ b/src/clj_kondo/impl/analyzer/jdbc.clj
@@ -23,12 +23,12 @@
     (when-not (<= 2 (count binding-forms) 3)
       (findings/reg-finding!
        ctx
-       (node->line filename bindings :error :syntax
+       (node->line filename bindings :syntax
                    (format "%s binding form requires exactly 2 or 3 forms" call))))
     (when-not (utils/symbol-token? sym)
       (findings/reg-finding!
        ctx
-       (node->line filename sym :error :syntax
+       (node->line filename sym :syntax
                    (format "%s binding form requires a symbol" call))))
     (let [opts-analyzed (analyze-expression** ctx opts)
           ;; a normal binding vector with just these two forms:

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -44,7 +44,6 @@
           (do (when prefix
                 (findings/reg-finding! ctx (node->line (:filename ctx)
                                                        libspec-expr
-                                                       :error
                                                        :syntax
                                                        "Prefix lists can only have two levels.")))
               (mapcat (fn [f]
@@ -65,7 +64,6 @@
               (findings/reg-finding! ctx
                                      (node->line (:filename ctx)
                                                  libspec-expr
-                                                 :error
                                                  :syntax
                                                  (format "found lib name '%s' containing period with prefix '%s'. lib names inside prefix lists must not contain periods."
                                                          form prefix))))
@@ -87,7 +85,7 @@
       (when-not (= expected-alias alias)
         (findings/reg-finding!
          ctx
-         (node->line (:filename ctx) alias :warning
+         (node->line (:filename ctx) alias
                      :consistent-alias
                      (str "Inconsistent alias. Expected " expected-alias " instead of " alias ".")))))))
 
@@ -149,7 +147,6 @@
                        ctx
                        (node->line (:filename ctx)
                                    child-expr
-                                   :warning
                                    :refer
                                    (str "require with " (str child-k))))))
                   (recur
@@ -162,7 +159,6 @@
                                         (node->line
                                          filename
                                          (:referred-all m)
-                                         :warning
                                          :use
                                          (format "use %srequire with alias or :refer with [%s]"
                                                  (if require-sym
@@ -246,7 +242,7 @@
       (meta node))
     (findings/reg-finding!
      ctx
-     (node->line (:filename ctx) node :error :syntax "Expected: class symbol"))))
+     (node->line (:filename ctx) node :syntax "Expected: class symbol"))))
 
 (defn analyze-import [ctx _ns-name libspec-expr]
   (utils/handle-ignore ctx libspec-expr)
@@ -262,7 +258,7 @@
                          ctx
                          (node->line
                           (:filename ctx) java-package-name-node
-                          :error :syntax "Expected: package name followed by classes.")))
+                          :syntax "Expected: package name followed by classes.")))
                       (into {} (for [i imported]
                                  [i java-package])))
     :token (let [package+class (:value libspec-expr)
@@ -395,7 +391,6 @@
                         ctx
                         (node->line (:filename ctx)
                                     ns-name-expr
-                                    :error
                                     :syntax
                                     "namespace name expected"))))
                  'user)

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -16,7 +16,6 @@
         (findings/reg-finding! ctx
                                (utils/node->line (:filename ctx)
                                                  sym-expr
-                                                 :error
                                                  :syntax
                                                  "expected symbol"))
         (let [{resolved-ns :ns}
@@ -27,7 +26,6 @@
             (findings/reg-finding! ctx
                                    (utils/node->line (:filename ctx)
                                                      sym-expr
-                                                     :error
                                                      :unresolved-symbol
                                                      (str "Unresolved symbol: " sym)))))))
     (analyze-children ctx body)))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -243,7 +243,6 @@
                                                     when-some future]))]
                          (when redundant?
                            (findings/reg-finding! ctx (assoc (meta expr)
-                                                             :level :warning
                                                              :type :redundant-expression
                                                              :message (str "Redundant expression: " (str expr))
                                                              :filename (:filename ctx))))))))

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -358,8 +358,7 @@
     (catch Throwable e
       (if dev?
         (throw e)
-        (findings/reg-finding! ctx {:level :warning
-                                    :filename (if canonical?
+        (findings/reg-finding! ctx {:filename (if canonical?
                                                 (.getCanonicalPath (io/file path))
                                                 path)
                                     :type :file

--- a/src/clj_kondo/impl/findings.clj
+++ b/src/clj_kondo/impl/findings.clj
@@ -47,7 +47,8 @@
         findings (:findings ctx)
         config (:config ctx)
         tp (:type m)
-        level (-> config :linters tp :level)]
+        level (or (:level m)
+                  (-> config :linters tp :level))]
     (when (and level (not (identical? :off level)) (not dependencies))
       (when-not (ignored? ctx m tp)
         (let [m (assoc m :level level)]

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -24,12 +24,12 @@
             (when (not= :else v)
               (findings/reg-finding!
                ctx
-               (node->line (:filename ctx) condition :warning :cond-else
+               (node->line (:filename ctx) condition :cond-else
                            "use :else as the catch-all test expression in cond")))
             (when (seq rest-conditions)
               (findings/reg-finding!
                ctx
-               (node->line (:filename ctx) (first rest-conditions) :warning
+               (node->line (:filename ctx) (first rest-conditions)
                            :unreachable-code "unreachable code"))))))
       (recur rest-conditions))))
 
@@ -66,7 +66,7 @@
   (when-not (even? (count (rest (:children expr))))
     (findings/reg-finding!
      ctx
-     (node->line (:filename ctx) expr :error :syntax
+     (node->line (:filename ctx) expr :syntax
                  (format "cond requires even number of forms")))
     true))
 
@@ -92,7 +92,7 @@
 (defn lint-missing-test-assertion [ctx call]
   (when (expected-test-assertion? (next (:callstack call)))
     (findings/reg-finding! ctx
-                           (node->line (:filename ctx) (:expr call) :warning
+                           (node->line (:filename ctx) (:expr call)
                                        :missing-test-assertion "missing test assertion"))))
 
 (defn lint-missing-else-branch
@@ -105,7 +105,7 @@
             args (rest children)]
         (when (= (count args) 2)
           (findings/reg-finding! ctx
-                                 (node->line (:filename ctx) expr level :missing-else-branch
+                                 (node->line (:filename ctx) expr :missing-else-branch
                                              (format "Missing else branch."))))))))
 
 (defn lint-single-key-in [ctx called-name call]
@@ -114,7 +114,7 @@
       (when (and keyvec (= :vector (tag keyvec)) (= 1 (count (:children keyvec))))
         (findings/reg-finding!
          ctx
-         (node->line (:filename ctx) keyvec :warning :single-key-in
+         (node->line (:filename ctx) keyvec :single-key-in
                      (format "%s with single key" called-name)))))))
 
 (defn lint-specific-calls! [ctx call called-fn]
@@ -180,7 +180,6 @@
           (node->line
            (:filename call)
            (:expr call)
-           :warning
            :single-operand-comparison
            (format "Single operand use of %s is always %s"
                    (str ns-nm "/" fn-name)
@@ -196,7 +195,6 @@
         (node->line
          (:filename call)
          (:expr call)
-         :warning
          :single-logical-operand
          (format "Single arg use of %s always returns the arg itself" call-name))))))
 
@@ -440,7 +438,7 @@
                 filename (:filename m)]
             (findings/reg-finding!
              ctx
-             (-> (node->line filename ns-sym :warning :unused-namespace
+             (-> (node->line filename ns-sym :unused-namespace
                              (format "namespace %s is required but never used" ns-sym))
                  (assoc :ns (export-ns-sym ns-sym)))))))
       (doseq [[k v] referred-vars]
@@ -451,7 +449,7 @@
                   (contains? refer-all-nss var-ns))
             (findings/reg-finding!
              ctx
-             (-> (node->line filename k :warning :unused-referred-var (str "#'" var-ns "/" (:name v) " is referred but never used"))
+             (-> (node->line filename k :unused-referred-var (str "#'" var-ns "/" (:name v) " is referred but never used"))
                  (assoc :ns (export-ns-sym var-ns)
                         :refer (:name v)))))))
       (doseq [[referred-all-ns {:keys [:referred :node]}] refer-alls
@@ -470,7 +468,7 @@
           (findings/reg-finding!
            ctx
            (node->line filename node
-                       :warning finding-type msg)))))))
+                       finding-type msg)))))))
 
 (defn lint-unused-bindings!
   [ctx]
@@ -606,7 +604,7 @@
           :when (not (contains? used-imports import))]
     (findings/reg-finding!
      ctx
-     (-> (node->line filename import :warning :unused-import (str "Unused import " import))
+     (-> (node->line filename import :unused-import (str "Unused import " import))
          (assoc :class (symbol (str package "." import)))))))
 
 (defn lint-unresolved-namespaces!

--- a/src/clj_kondo/impl/linters/deps_edn.clj
+++ b/src/clj_kondo/impl/linters/deps_edn.clj
@@ -36,7 +36,6 @@
        ctx
        (node->line (:filename ctx)
                    node
-                   :warning
                    :deps.edn
                    #_{:clj-kondo/ignore[:format]} ;; fixed on master
                    (format "Libs must be qualified, change %s => %<s/%<s" form)))
@@ -62,7 +61,6 @@
        ctx
        (node->line (:filename ctx)
                    node
-                   :warning
                    :deps.edn
                    (str "Expected map, found: " (.getName (class form)))))
       (or (when-let [version (:mvn/version form)]
@@ -72,7 +70,6 @@
                ctx
                (node->line (:filename ctx)
                            node
-                           :warning
                            :deps.edn
                            (str "Non-determistic version."))))
             true)
@@ -82,7 +79,6 @@
                ctx
                (node->line (:filename ctx)
                            node
-                           :warning
                            :deps.edn
                            (str "Conflicting keys :git/sha and :sha."))))
             (when (and (:git/tag form) (:tag form))
@@ -90,7 +86,6 @@
                ctx
                (node->line (:filename ctx)
                            node
-                           :warning
                            :deps.edn
                            (str "Conflicting keys :git/tag and :tag."))))
             (when-not (or (:git/sha form) (:sha form))
@@ -98,7 +93,6 @@
                ctx
                (node->line (:filename ctx)
                            node
-                           :warning
                            :deps.edn
                            (str "Missing required key :git/sha."))))
             true)
@@ -114,7 +108,6 @@
            ctx
            (node->line (:filename ctx)
                        node
-                       :warning
                        :deps.edn
                        (str "Missing required key: :mvn/version, :git/url or :local/root.")))))))
 
@@ -131,7 +124,6 @@
                ctx
                (node->line (:filename ctx)
                            node
-                           :warning
                            :deps.edn
                            (str "Prefer keyword for alias.")))
               (when (contains? #{:deps :extra-deps :jvm-opts} form)
@@ -139,7 +131,6 @@
                  ctx
                  (node->line (:filename ctx)
                              node
-                             :warning
                              :deps.edn
                              (str "Suspicious alias name: " (name form))))))))
         nodes))
@@ -154,7 +145,6 @@
                  ctx
                  (node->line (:filename ctx)
                              jvm-opts-node
-                             :warning
                              :deps.edn
                              (str "JVM opts should be seqable of strings.")))))))
         alias-nodes))
@@ -169,7 +159,6 @@
                  ctx
                  (node->line (:filename ctx)
                              repo-map-node
-                             :warning
                              :deps.edn
                              (str "Expected: map with :url."))))))
           repo-map-nodes)))

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -50,13 +50,13 @@
               (findings/reg-finding!
                ctx
                (node->line filename
-                           key-expr :error :duplicate-map-key
+                           key-expr :duplicate-map-key
                            (str "duplicate key " key-expr))))
             (when-not (known-key? k)
               (findings/reg-finding!
                ctx
                (node->line filename
-                           key-expr :error :syntax
+                           key-expr :syntax
                            (str "unknown option " key-expr))))
             (update acc :seen conj k))
           acc))
@@ -66,7 +66,7 @@
        (let [last-child (last children)]
          (findings/reg-finding!
           ctx
-          (node->line filename last-child :error :missing-map-value
+          (node->line filename last-child :missing-map-value
                       (str "missing value for key " last-child))))))))
 
 ;;;; end map linter
@@ -81,7 +81,7 @@
          (do (when (contains? seen k)
                (findings/reg-finding!
                 ctx
-                (node->line (:filename ctx) set-element :error :duplicate-set-key
+                (node->line (:filename ctx) set-element :duplicate-set-key
                             (str "duplicate set element " k))))
              (update acc :seen conj k))
          acc))

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -22,7 +22,6 @@
                    ctx
                    (node->line (:filename ctx)
                                ns
-                               :warning
                                :duplicate-require
                                (str "duplicate require of " ns)))
                  required)
@@ -43,7 +42,6 @@
               ctx
               (node->line (:filename ctx)
                           as
-                          :warning
                           :conflicting-alias
                           (str "Conflicting alias for " ns))))
           (when (seq (rest ns-maps))
@@ -75,7 +73,6 @@
                    ctx
                    (node->line (:filename ctx)
                                ns
-                               level
                                :unsorted-required-namespaces
                                (str "Unsorted namespace: " ns)))
                   :else (recur raw-ns
@@ -147,7 +144,7 @@
                     (findings/reg-finding!
                      ctx
                      (node->line filename
-                                 expr :warning
+                                 expr
                                  :redefined-var
                                  (if (= ns-sym redefined-ns)
                                    (str "redefined var #'" redefined-ns "/" var-sym)
@@ -170,7 +167,7 @@
                     (findings/reg-finding!
                      ctx
                      (node->line filename
-                                 expr :warning
+                                 expr
                                  :missing-docstring
                                  "Missing docstring."))))
                 (update ns :vars assoc
@@ -387,7 +384,6 @@
                           message)]
             (findings/reg-finding! ctx (node->line (:filename ctx)
                                                    expr
-                                                   :warning
                                                    :shadowed-var
                                                    message))))))))
 

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -100,14 +100,13 @@
   (when-let [processed (process-reader-conditional node lang)]
     (select-lang-children processed lang)))
 
-(defn node->line [filename node level t message]
+(defn node->line [filename node t message]
   #_(when (and (= type :missing-docstring)
              (not (:row (meta node))))
     (prn node))
   (let [m (meta node)]
     {:type t
      :message message
-     :level level
      :row (:row m)
      :end-row (:end-row m)
      :end-col (:end-col m)


### PR DESCRIPTION
- Allow pass a `:level` to `reg-finding!`.
- Remove unused `:level` from `reg-finding!` calls