### PR TITLE
Expose ns-analysis fn in hooks api

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -24,6 +24,7 @@
            me.raynes.conch/let-programs clojure.core/let
            datalog.parser.type/deftrecord clojure.core/defrecord
            clj-kondo.impl.rewrite-clj.potemkin/defprotocol+ clojure.core/defprotocol
-           clj-kondo.impl.rewrite-clj.potemkin/import-vars potemkin/import-vars}
+           clj-kondo.impl.rewrite-clj.potemkin/import-vars potemkin/import-vars
+           clj-kondo.test-utils/with-temp-dir clojure.core/let}
  :output {:exclude-files ["src/clj_kondo/impl/rewrite_clj_patch.clj"]}
  :hooks {:analyze-call {clj-kondo.impl.utils/one-of macroexpand.one-of/one-of}}}

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -76,6 +76,9 @@
          (map-vals #(select-keys % selected-keys)))))
 
 (defn- ns-analysis*
+  "Adapt from-cache-1 to provide a uniform return format.
+  Unifies the format of cached information provided for each source
+  language."
   [lang ns-sym]
   (if (= lang :cljc)
     (->> (dissoc
@@ -89,8 +92,9 @@
 
 (defn ns-analysis
   "Return any cached analysis for the namespace identified by ns-sym.
-  Returns a map keyed by language keyword with values being var definitions
-  as output by the top level :analysis option."
+  Returns a map keyed by language keyword with values being maps of var
+  definitions keyed by defined symbol. The value for each symbol is a
+  subset of the values provide by the top level :analysis option."
   ([ns-sym] (ns-analysis ns-sym {}))
   ([ns-sym {:keys [lang]}]
    (if lang

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -73,8 +73,7 @@
                        :fixed-arities :varargs-min-arity
                        :private :macro]]
     (->> (dissoc analysis :filename :source)
-         vals
-         (mapv #(select-keys % selected-keys)))))
+         (map-vals #(select-keys % selected-keys)))))
 
 (defn- ns-analysis*
   [lang ns-sym]

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -94,12 +94,11 @@
   as output by the top level :analysis option."
   ([ns-sym] (ns-analysis ns-sym {}))
   ([ns-sym {:keys [lang]}]
-   (->>
-    (if lang
-      (ns-analysis* lang ns-sym)
-      (reduce
-       merge
-       (map #(ns-analysis* % ns-sym) [:cljc :clj :cljs]))))))
+   (if lang
+     (ns-analysis* lang ns-sym)
+     (reduce
+      merge
+      (map #(ns-analysis* % ns-sym) [:cljc :clj :cljs])))))
 
 (defn annotate [node meta]
   (walk/postwalk (fn [node]

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -1,6 +1,7 @@
 (ns clj-kondo.impl.hooks
   {:no-doc true}
-  (:require [clj-kondo.impl.findings :as findings]
+  (:require [clj-kondo.impl.cache :as cache]
+            [clj-kondo.impl.findings :as findings]
             [clj-kondo.impl.metadata :as meta]
             [clj-kondo.impl.rewrite-clj.node :as node]
             [clj-kondo.impl.utils :as utils :refer [assoc-some vector-node list-node
@@ -65,6 +66,12 @@
 (defn coerce [s-expr]
   (node/coerce s-expr))
 
+(defn ns-analysis [lang ns-sym]
+  (cache/from-cache-1
+   (:cache-dir *ctx*)
+   lang
+   ns-sym))
+
 (defn annotate [node meta]
   (walk/postwalk (fn [node]
                    (if (map? node)
@@ -105,6 +112,7 @@
    'reg-finding! reg-finding!
    'reg-keyword! reg-keyword!
    'coerce coerce
+   'ns-analysis ns-analysis
    })
 
 (def sci-ctx

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -72,7 +72,7 @@
   (let [selected-keys [:ns :name
                        :fixed-arities :varargs-min-arity
                        :private :macro]]
-    (->> analysis
+    (->> (dissoc analysis :filename :source)
          vals
          (mapv #(select-keys % selected-keys)))))
 
@@ -84,8 +84,9 @@
           :filename
           :source)
          (map-vals var-definitions))
-    {lang (-> (cache/from-cache-1 (:cache-dir *ctx*) lang ns-sym)
-              var-definitions)}))
+    (some->> (cache/from-cache-1 (:cache-dir *ctx*) lang ns-sym)
+             var-definitions
+             (hash-map lang))))
 
 (defn ns-analysis
   "Return any cached analysis for the namespace identified by ns-sym.
@@ -98,7 +99,7 @@
       (ns-analysis* lang ns-sym)
       (reduce
        merge
-       (map #(ns-analysis* % ns-sym) [:clj :cljc :cljs]))))))
+       (map #(ns-analysis* % ns-sym) [:cljc :clj :cljs]))))))
 
 (defn annotate [node meta]
   (walk/postwalk (fn [node]

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -67,13 +67,11 @@
   (node/coerce s-expr))
 
 (defn- var-definitions
-  "Project cached analysis as public var-definitions."
+  "Project cached analysis as a subset of public var-definitions."
   [analysis]
-  (let [selected-keys [:filename :row :col :end-row :end-col
-                       :ns :name :definied-by
+  (let [selected-keys [:ns :name
                        :fixed-arities :varargs-min-arity
-                       :private :macro :deprecated :doc :added
-                       :lang :arglists-str]]
+                       :private :macro]]
     (->> analysis
          vals
          (mapv #(select-keys % selected-keys)))))

--- a/test/clj_kondo/impl/hooks_test.clj
+++ b/test/clj_kondo/impl/hooks_test.clj
@@ -42,30 +42,30 @@ there
         ;; populate cache
         (lint! test-source-dir "--cache" "true" "--cache-dir" test-cache-dir)
         (let [full-cache-dir (io/file test-cache-dir core/version)]
-          (is (= {:clj [{:ns   'foo
-                         :name 'foo :fixed-arities #{1}}
-                        {:ns                'foo
-                         :name              'foo-p
-                         :varargs-min-arity 1
-                         :private           true}
-                        {:ns            'foo :name 'foo-m
-                         :fixed-arities #{1}
-                         :macro         true}]}
+          (is (= {:clj {'foo {:ns   'foo
+                              :name 'foo :fixed-arities #{1}}
+                        'foo-p {:ns                'foo
+                                :name              'foo-p
+                                :varargs-min-arity 1
+                                :private           true}
+                        'foo-m {:ns            'foo :name 'foo-m
+                                :fixed-arities #{1}
+                                :macro         true}}}
                  (binding [*ctx* {:cache-dir full-cache-dir}]
                    (hooks-api/ns-analysis 'foo))
                  (binding [*ctx* {:cache-dir full-cache-dir}]
                    (hooks-api/ns-analysis 'foo {:lang :clj}))))
-          (is (= {:clj [{:ns 'bar
-                         :name 'bar-clj
-                         :fixed-arities #{0}}]
-                  :cljs [{:ns 'bar
-                          :name 'bar-cljs
-                          :fixed-arities #{0}}]}
+          (is (= {:clj  {'bar-clj {:ns            'bar
+                                   :name          'bar-clj
+                                   :fixed-arities #{0}}}
+                  :cljs {'bar-cljs {:ns            'bar
+                                    :name          'bar-cljs
+                                    :fixed-arities #{0}}}}
                  (binding [*ctx* {:cache-dir full-cache-dir}]
                    (hooks-api/ns-analysis 'bar))
                  (binding [*ctx* {:cache-dir full-cache-dir}]
                    (hooks-api/ns-analysis 'bar {:lang :cljc}))))
-          (is (= {:cljs [{:ns 'baz, :name 'baz, :fixed-arities #{1}}]}
+          (is (= {:cljs {'baz {:ns 'baz, :name 'baz, :fixed-arities #{1}}}}
                  (binding [*ctx* {:cache-dir full-cache-dir}]
                    (hooks-api/ns-analysis 'baz))
                  (binding [*ctx* {:cache-dir full-cache-dir}]

--- a/test/clj_kondo/impl/hooks_test.clj
+++ b/test/clj_kondo/impl/hooks_test.clj
@@ -1,8 +1,11 @@
 (ns clj-kondo.impl.hooks-test
   (:require
+   [clj-kondo.impl.core :as core]
    [clj-kondo.impl.hooks :as hooks-api]
-   [clj-kondo.impl.utils :as utils :refer [parse-string]]
-   [clojure.test :as t :refer [deftest is]]))
+   [clj-kondo.impl.utils :as utils :refer [parse-string *ctx*]]
+   [clj-kondo.test-utils :refer [lint! make-dirs with-temp-dir]]
+   [clojure.java.io :as io]
+   [clojure.test :as t :refer [deftest is testing]]))
 
 (deftest predicates-test
   (is (hooks-api/keyword-node? (parse-string ":foo")))
@@ -16,3 +19,54 @@ there
   (is (hooks-api/vector-node? (parse-string "[1]")))
   (is (hooks-api/list-node? (parse-string "(+ 1 2 3)")))
   #_(is (hooks-api/map-node? (parse-string "{:a 1}"))))
+
+
+(deftest ns-analysis-test
+  (testing "ns-analysis is loaded from cache"
+    (with-temp-dir [tmp-dir "ns-analysis-test"]
+      (let [test-cache-dir  (.getPath (io/file tmp-dir "test-cache-dir"))
+            test-source-dir (io/file tmp-dir "test-source-dir")
+            foo-clj (io/file test-source-dir "foo.clj")
+            bar-cljc (io/file test-source-dir "bar.cljc")
+            baz-cljs (io/file test-source-dir (str "baz.cljs"))]
+        (make-dirs test-cache-dir)
+        (make-dirs test-source-dir)
+        (io/copy
+         "(ns foo) (defn foo [x]) (defn- foo-p [x & _]) (defmacro foo-m [x])"
+         foo-clj)
+        (io/copy
+         "(ns bar) #?(:clj (defn bar-clj [])) #?(:cljs (defn bar-cljs []))"
+         bar-cljc)
+        (io/copy "(ns baz) (defn baz [x])" baz-cljs)
+
+        ;; populate cache
+        (lint! test-source-dir "--cache" "true" "--cache-dir" test-cache-dir)
+        (let [full-cache-dir (io/file test-cache-dir core/version)]
+          (is (= {:clj [{:ns   'foo
+                         :name 'foo :fixed-arities #{1}}
+                        {:ns                'foo
+                         :name              'foo-p
+                         :varargs-min-arity 1
+                         :private           true}
+                        {:ns            'foo :name 'foo-m
+                         :fixed-arities #{1}
+                         :macro         true}]}
+                 (binding [*ctx* {:cache-dir full-cache-dir}]
+                   (hooks-api/ns-analysis 'foo))
+                 (binding [*ctx* {:cache-dir full-cache-dir}]
+                   (hooks-api/ns-analysis 'foo {:lang :clj}))))
+          (is (= {:clj [{:ns 'bar
+                         :name 'bar-clj
+                         :fixed-arities #{0}}]
+                  :cljs [{:ns 'bar
+                          :name 'bar-cljs
+                          :fixed-arities #{0}}]}
+                 (binding [*ctx* {:cache-dir full-cache-dir}]
+                   (hooks-api/ns-analysis 'bar))
+                 (binding [*ctx* {:cache-dir full-cache-dir}]
+                   (hooks-api/ns-analysis 'bar {:lang :cljc}))))
+          (is (= {:cljs [{:ns 'baz, :name 'baz, :fixed-arities #{1}}]}
+                 (binding [*ctx* {:cache-dir full-cache-dir}]
+                   (hooks-api/ns-analysis 'baz))
+                 (binding [*ctx* {:cache-dir full-cache-dir}]
+                   (hooks-api/ns-analysis 'baz {:lang :cljs})))))))))

--- a/test/clj_kondo/test_utils.clj
+++ b/test/clj_kondo/test_utils.clj
@@ -184,6 +184,18 @@
     (.renameTo (io/file old-path) (io/file new-path))
     (mv old-path new-path)))
 
+(defmacro with-temp-dir
+  [[binding dir-name] & body]
+  `(let [tmp-dir#  (System/getProperty "java.io.tmpdir")
+         test-dir# (.getPath (io/file tmp-dir# ~dir-name))
+         ~binding  test-dir#]
+     (remove-dir test-dir#)
+     (make-dirs test-dir#)
+     (try
+       ~@body
+       (finally
+         (remove-dir test-dir#)))))
+
 ;;;; Scratch
 
 (comment


### PR DESCRIPTION
Allow hooks to obtain ns analysis, when cached.

This is useful, for example, to rewrite macros that make implicit use of some symbols from other namespaces.

The implementation provides `hooks-api/ns-analysis`, which takes a  namespace symbol and returns any cached analysis for that namespace.  The returned map is keyed by language keyword (`:cl` and `:cljs`) and each value is a map keyed by a defined symbol.  The value for each  symbol is a subset of the information provided in the [analysis var-definitions](https://github.com/clj-kondo/clj-kondo/blob/master/analysis/README.md#data)

The function can also take an option map, with `:lang` specifying the source file language (`:clj`, `:cljs`, or `:cljc`)for which analysis should be returned. The default is to return analysis for all available source files for the given namespace.
