### PR TITLE
Safe get resource cache on lein process

### DIFF
--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -11,10 +11,11 @@
 (set! *warn-on-reflection* true)
 
 (defn built-in-cache-resource [lang ns-sym]
-  (io/resource (str "clj_kondo/impl/cache/built_in/"
-                    (name lang) "/" (str ns-sym ".transit.json"))
-               ;; workaround for https://github.com/oracle/graal/issues/1287
-               (.getClassLoader clojure.lang.RT)))
+  (let [path (str "clj_kondo/impl/cache/built_in/" (name lang) "/" (str ns-sym ".transit.json"))]
+    (if-let [loader (.getClassLoader clojure.lang.RT)]
+      ;; workaround for https://github.com/oracle/graal/issues/1287
+      (io/resource path loader)
+      (io/resource path))))
 
 (defn cache-file ^java.io.File [cache-dir lang ns-sym]
   (io/file cache-dir (name lang) (str ns-sym ".transit.json")))


### PR DESCRIPTION
When running clojure-lsp from a lein plugin (yet to be released), for some reason `(.getClassLoader clojure.lang.RT)` returns `nil`, throwing a NPE during clj-kondo analysis. I'm not sure if lein uses a different classloader or something like that, but my suggestion probably make the cache access safe working for both lein, jvm and graalvm cases

Exception:
```clojure
#error {
 :cause nil
 :via
 [{:type java.lang.NullPointerException
   :message nil
   :at [clojure.java.io$resource invokeStatic io.clj 451]}]
 :trace
 [[clojure.java.io$resource invokeStatic io.clj 451]
  [clojure.java.io$resource invoke io.clj 446]
  [clj_kondo.impl.cache$built_in_cache_resource invokeStatic cache.clj 16]
  [clj_kondo.impl.cache$built_in_cache_resource invoke cache.clj 13]
  [clj_kondo.impl.cache$from_cache_1 invokeStatic cache.clj 31]
  [clj_kondo.impl.cache$from_cache_1 invoke cache.clj 24]
  [clj_kondo.impl.cache$load_when_missing invokeStatic cache.clj 105]
  [clj_kondo.impl.cache$load_when_missing invoke cache.clj 98]
  [clj_kondo.impl.cache$sync_cache_STAR_$fn__197$fn__198$fn__199 invoke cache.clj 151]
  [clojure.core.protocols$iter_reduce invokeStatic protocols.clj 49]
  [clojure.core.protocols$fn__8140 invokeStatic protocols.clj 75]
  [clojure.core.protocols$fn__8140 invoke protocols.clj 75]
  [clojure.core.protocols$fn__8088$G__8083__8101 invoke protocols.clj 13]
  [clojure.core$reduce invokeStatic core.clj 6828]
  [clojure.core$reduce invoke core.clj 6810]
  [clj_kondo.impl.cache$sync_cache_STAR_$fn__197$fn__198 invoke cache.clj 151]
  [clojure.lang.PersistentVector reduce PersistentVector.java 343]
  [clojure.core$reduce invokeStatic core.clj 6827]
  [clojure.core$reduce invoke core.clj 6810]
  [clj_kondo.impl.cache$sync_cache_STAR_$fn__197 invoke cache.clj 150]
  [clojure.lang.PersistentVector reduce PersistentVector.java 343]
  [clojure.core$reduce invokeStatic core.clj 6827]
  [clojure.core$reduce invoke core.clj 6810]
  [clj_kondo.impl.cache$sync_cache_STAR_ invokeStatic cache.clj 148]
  [clj_kondo.impl.cache$sync_cache_STAR_ invoke cache.clj 141]
  [clj_kondo.impl.cache$sync_cache invokeStatic cache.clj 172]
  [clj_kondo.impl.cache$sync_cache invoke cache.clj 168]
  [clj_kondo.core$run_BANG_ invokeStatic core.clj 160]
  [clj_kondo.core$run_BANG_ invoke core.clj 53]
  [clojure_lsp.kondo$run_kondo_on_paths_BANG_ invokeStatic kondo.clj 101]
  [clojure_lsp.kondo$run_kondo_on_paths_BANG_ invoke kondo.clj 97]
  [clojure_lsp.crawler$analyze_paths_BANG_ invokeStatic crawler.clj 75]
  [clojure_lsp.crawler$analyze_paths_BANG_ invoke crawler.clj 71]
  [clojure_lsp.crawler$analyze_project_BANG_ invokeStatic crawler.clj 119]
  [clojure_lsp.crawler$analyze_project_BANG_ invoke crawler.clj 113]
  [clojure_lsp.crawler$initialize_project invokeStatic crawler.clj 145]
  [clojure_lsp.crawler$initialize_project invoke crawler.clj 121]
  [clojure_lsp.internal_api$setup_analysis_BANG_$fn__33581$state_machine__5652__auto____33600$fn__33603 invoke internal_api.clj 61]
  [clojure_lsp.internal_api$setup_analysis_BANG_$fn__33581$state_machine__5652__auto____33600 invoke internal_api.clj 56]
  [clojure.core.async.impl.ioc_macros$run_state_machine invokeStatic ioc_macros.clj 978]
  [clojure.core.async.impl.ioc_macros$run_state_machine invoke ioc_macros.clj 977]
  [clojure.core.async.impl.ioc_macros$run_state_machine_wrapped invokeStatic ioc_macros.clj 982]
  [clojure.core.async.impl.ioc_macros$run_state_machine_wrapped invoke ioc_macros.clj 980]
  [clojure_lsp.internal_api$setup_analysis_BANG_$fn__33581 invoke internal_api.clj 56]
  [clojure.lang.AFn run AFn.java 22]
  [java.util.concurrent.ThreadPoolExecutor runWorker ThreadPoolExecutor.java 1128]
  [java.util.concurrent.ThreadPoolExecutor$Worker run ThreadPoolExecutor.java 628]
  [clojure.core.async.impl.concurrent$counted_thread_factory$reify__394$fn__395 invoke concurrent.clj 29]
  [clojure.lang.AFn run AFn.java 22]
  [java.lang.Thread run Thread.java 829]]}

```