### PR TITLE
Issue 426 warning for a loop without a recur

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -819,7 +819,6 @@
                               )) expr)]
 
         (let [[before children] (split-with #(not= expr (:expr %)) @loop-recur-stack)]
-          (println x)
           (when-not ((set (map :type children)) :recur)
           (findings/reg-finding!
             ctx

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -10,9 +10,9 @@
     :skip-comments false ;; convenient shorthand for :skip-args [clojure.core/comment cljs.core/comment]
     ;; linter level can be tweaked by setting :level to :error, :warn or :info (or any other keyword)
     ;; all linters are enabled by default, but can be turned off by setting :level to :off.
-    :linters       {:missing-recur?                {:level :warning}
-              :invalid-arity {:level :error
+    :linters {:invalid-arity {:level :error
                               :skip-args [#_riemann.test/test-stream]}
+                    :missing-recur?                {:level :warning}
               :not-a-function {:level :error
                                :skip-args [#_user/foo]}
               :private-call {:level :error}

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -10,7 +10,7 @@
     :skip-comments false ;; convenient shorthand for :skip-args [clojure.core/comment cljs.core/comment]
     ;; linter level can be tweaked by setting :level to :error, :warn or :info (or any other keyword)
     ;; all linters are enabled by default, but can be turned off by setting :level to :off.
-    :linters {:loop-missing-recur {:level :warning}
+    :linters       {:missing-recur?                {:level :warning}
               :invalid-arity {:level :error
                               :skip-args [#_riemann.test/test-stream]}
               :not-a-function {:level :error

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -12,7 +12,7 @@
     ;; all linters are enabled by default, but can be turned off by setting :level to :off.
     :linters {:invalid-arity {:level :error
                               :skip-args [#_riemann.test/test-stream]}
-                    :missing-recur?                {:level :warning}
+                    :missing-recur                 {:level :warning}
               :not-a-function {:level :error
                                :skip-args [#_user/foo]}
               :private-call {:level :error}

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -10,7 +10,8 @@
     :skip-comments false ;; convenient shorthand for :skip-args [clojure.core/comment cljs.core/comment]
     ;; linter level can be tweaked by setting :level to :error, :warn or :info (or any other keyword)
     ;; all linters are enabled by default, but can be turned off by setting :level to :off.
-    :linters {:invalid-arity {:level :error
+    :linters {:loop-missing-recur {:level :warning}
+              :invalid-arity {:level :error
                               :skip-args [#_riemann.test/test-stream]}
               :not-a-function {:level :error
                                :skip-args [#_user/foo]}

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1074,6 +1074,11 @@ foo/foo ;; this does use the private var
   (is (empty? (lint! "(in-ns 'foo) (clojure.core/let [x 1])"
                      '{:linters {:unresolved-symbol {:level :error}}}))))
 
+(deftest loop-missing-recur-test
+  ;;TODO I'm not sure yet how the test works here e.g  how and why are the other tests looking at row and col for stdin strings?
+  (lint! "(loop [x 2]  (recur 1))")
+  (lint! "(loop [x 2])"))
+
 (deftest recur-test
   (assert-submaps
    '({:file "<stdin>",


### PR DESCRIPTION
This request should solve issue #426 , though there might be some minor clean-up (I store more in the atom than necessary, names, code organization) that should be considered before accepting it. But it's probably worth getting some feedback before I try doing any of that. 

The solution must include a stack or at least a pseudo stack so that nested loops are handled correctly. 

My primary worry is the logic is very disjoint, but given the nature of the problem that might be unavoidable. 

Here is the output from running the diff script. I'm not entirely sure what it's telling me:

```
➜  clj-kondo git:(issue-426-warning-for-a-loop-without-a-recur) ✗ ./script/diff
Linting and writing output to /tmp/clj-kondo-diff/branch.txt
Cloning into 'clj-kondo'...
remote: Enumerating objects: 12375, done.
remote: Counting objects: 100% (1399/1399), done.
remote: Compressing objects: 100% (598/598), done.
remote: Total 12375 (delta 764), reused 1173 (delta 696), pack-reused 10976
Receiving objects: 100% (12375/12375), 11.82 MiB | 44.18 MiB/s, done.
Resolving deltas: 100% (7145/7145), done.
Linting and writing output to /tmp/clj-kondo-diff/master.txt
DEPRECATED: Libs must be qualified, change refactor-nrepl => refactor-nrepl/refactor-nrepl (/home/drewverlee/.clojure/deps.edn)
1923c1923
< clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> clojure/tools/reader.clj:18:53: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2173c2173
< inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? reader-conditional second' tagged-literal whitespace?]
---
> inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader.clj:16:87: warning: use alias or :refer [char desugar-meta ex-info? namespace-keys numeric? second' whitespace?]
2558c2558
< linting took 8622ms, errors: 264, warnings: 2293
---
> linting took 8732ms, errors: 264, warnings: 2293
```
