### PR TITLE
Lint bb.edn and deps.edn :paths for data type

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -199,7 +199,7 @@ A regex is also permitted, e.g. to exclude all test namespaces:
 
 *Keyword:* `:deps.edn`
 
-*Description:* warn on common errors in a `deps.edn`.
+*Description:* warn on common errors in `deps.edn` and `bb.edn` files.
 
 *Default level:* `:warning`
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2178,8 +2178,10 @@
           ;; analyze-expressions should go first in order to process ignores
           (when (identical? :edn lang)
             (let [fn (.getName (io/file filename))]
-              (when (= fn "deps.edn")
-                (deps-edn/lint-deps-edn ctx (first (:children parsed)))))))))
+              (condp = fn
+                "deps.edn" (deps-edn/lint-deps-edn ctx (first (:children parsed)))
+                "bb.edn"   (deps-edn/lint-bb-edn ctx (first (:children parsed)))
+                nil))))))
     (catch Exception e
       (if dev?
         (throw e)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2177,8 +2177,8 @@
           (analyze-expressions ctx (:children parsed))
           ;; analyze-expressions should go first in order to process ignores
           (when (identical? :edn lang)
-            (let [fn (.getName (io/file filename))]
-              (condp = fn
+            (let [fname (.getName (io/file filename))]
+              (case fname
                 "deps.edn" (deps-edn/lint-deps-edn ctx (first (:children parsed)))
                 "bb.edn"   (deps-edn/lint-bb-edn ctx (first (:children parsed)))
                 nil))))))


### PR DESCRIPTION
We recognize that deps.edn and bb.edn differ slightly in what elem types
they support for :paths.
- deps.edn - strings or keywords
- bb.edn - strings onlys

When reporting on data type errors, I've favoured generic English words
over specific class names. For example instead of:

 Expected vector, found: clojure.lang.PersistentHashMap

We report:

 Expected vector, found: map

Closes #1353