### PR TITLE
Lint bb.edn :deps

### DIFF
--- a/src/clj_kondo/impl/linters/deps_edn.clj
+++ b/src/clj_kondo/impl/linters/deps_edn.clj
@@ -119,7 +119,7 @@
        (node->line (:filename ctx)
                    node
                    :deps.edn
-                   (str "Expected map, found: " (.getName (class form)))))
+                   (str "Expected map, found: " (name-for-type form))))
       (or (when-let [version (:mvn/version form)]
             (when (or (= "RELEASE" version)
                       (= "LATEST" version))
@@ -227,7 +227,8 @@
 (defn lint-bb-edn [ctx expr]
   (try
     (let [bb-edn (sexpr-keys expr)]
-      (lint-bb-edn-paths ctx (:paths bb-edn)))
+      (lint-bb-edn-paths ctx (:paths bb-edn))
+      (lint-deps ctx (-> bb-edn :deps deps-map)))
     ;; Due to ubiquitous use of sexpr, we're catching coercion errors here and let them slide.
     (catch Exception e
       (binding [*out* *err*]

--- a/test/clj_kondo/deps_edn_test.clj
+++ b/test/clj_kondo/deps_edn_test.clj
@@ -55,8 +55,8 @@
                    :aliases {:foo {:extra-deps {foobar/baz "2020.20"}}}}
         deps-edn (binding [*print-namespace-maps* false] (str deps-edn))]
     (assert-submaps
-     '({:file "deps.edn", :row 1, :col 20, :level :warning, :message "Expected map, found: java.lang.String"}
-       {:file "deps.edn", :row 1, :col 72, :level :warning, :message "Expected map, found: java.lang.String"})
+     '({:file "deps.edn", :row 1, :col 20, :level :warning, :message "Expected map, found: string"}
+       {:file "deps.edn", :row 1, :col 72, :level :warning, :message "Expected map, found: string"})
      (lint! (str deps-edn)
             "--filename" "deps.edn"))))
 
@@ -112,6 +112,16 @@
        {:file "deps.edn", :row 1, :col 85, :level :warning, :message "Non-determistic version."})
      (lint! (str deps-edn)
             "--filename" "deps.edn"))))
+
+(deftest spot-check-deps-linting-enabled-for-bb-edn-test
+  (let [bb-edn '{:deps {clj-kondo {:mvn/version "LATEST"}
+                        foo/baz1 "OOPS"}}]
+    (assert-submaps
+     '({:file "bb.edn", :row 1, :col 9, :level :warning, :message "Libs must be qualified, change clj-kondo => clj-kondo/clj-kondo"}
+       {:file "bb.edn", :row 1, :col 19, :level :warning, :message "Non-determistic version."}
+       {:file "bb.edn", :row 1, :col 53, :level :warning, :message "Expected map, found: string"})
+     (lint! (str bb-edn)
+            "--filename" "bb.edn"))))
 
 (deftest alias-keyword-names-test
   (let [deps-edn '{:aliases {foo {:extra-deps {foo/bar1 {:mvn/version "..."}}}}}

--- a/test/clj_kondo/deps_edn_test.clj
+++ b/test/clj_kondo/deps_edn_test.clj
@@ -119,7 +119,7 @@
     (assert-submaps
      '({:file "bb.edn", :row 1, :col 9, :level :warning, :message "Libs must be qualified, change clj-kondo => clj-kondo/clj-kondo"}
        {:file "bb.edn", :row 1, :col 19, :level :warning, :message "Non-determistic version."}
-       {:file "bb.edn", :row 1, :col 53, :level :warning, :message "Expected map, found: string"})
+       {:file "bb.edn", :row 1, :col 54, :level :warning, :message "Expected map, found: string"})
      (lint! (str bb-edn)
             "--filename" "bb.edn"))))
 


### PR DESCRIPTION
Apply current deps.edn :deps linting to bb.edn.

Also, instead of:

  Expected map, found: java.lang.String

We now report:

  Expect map, found: string

Closes #1357