### PR TITLE
[analysis] Add :refer to var-usages when inside a require

### DIFF
--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -22,6 +22,7 @@
                                :fixed-arities
                                :varargs-min-arity
                                :deprecated
+                               :refer
                                :alias
                                :name-row
                                :name-col

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -175,6 +175,7 @@
                                                                      :name (with-meta (sexpr %) m)
                                                                      :resolved-ns ns-name
                                                                      :ns current-ns-name
+                                                                     :refer true
                                                                      :lang lang
                                                                      :base-lang base-lang
                                                                      :filename filename

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -313,6 +313,7 @@
                                            in-def
                                            (assoc called-fn
                                                   :alias (:alias call)
+                                                  :refer (:refer call)
                                                   :name-row name-row
                                                   :name-col name-col
                                                   :name-end-row name-end-row

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -680,6 +680,24 @@
     (is (= 'clojure.set (:to (first namespace-usages))))
     (is (= 'clojure.set (:to (first var-usages))))))
 
+(deftest refer-var-usages-test
+  (testing "from require"
+    (let [{:keys [:namespace-usages :var-usages]}
+          (analyze "(ns foo (:require [clojure [set :refer [union]]])) (union #{1 2 3} #{3 4 5})")]
+      (is (= 'clojure.set (:to (first namespace-usages))))
+      (assert-submaps
+       '[{:name union :to clojure.set :name-col 41 :refer true}
+         {:name union :to clojure.set :name-col 53}]
+       var-usages)))
+  (testing "from use"
+    (let [{:keys [:namespace-usages :var-usages]}
+          (analyze "(ns foo (:use [clojure [set :only [union]]])) (union #{1 2 3} #{3 4 5})")]
+      (is (= 'clojure.set (:to (first namespace-usages))))
+      (assert-submaps
+       '[{:name union :to clojure.set :name-col 36 :refer true}
+         {:name union :to clojure.set :name-col 48}]
+       var-usages))))
+
 (deftest standalone-require-test
   (let [{:keys [:namespace-usages :var-usages]}
         (analyze "(require '[clojure [set :refer [union]]])")]


### PR DESCRIPTION
This should help differ var-usages that are inside a :refer from a var-usage elsewhere in the code:

```clojure
(ns a
  (:require
   [clojjure.string :refer [split-lines]]))

split-lines
```

the first `split-lines` should has a `:refer true` while the other one should not.