### PR TITLE
Pass constant metadata thorugh the analysis phase

### DIFF
--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -38,7 +38,7 @@
     (let [attrs (select-keys attrs [:private :macro :fixed-arities :varargs-min-arity
                                     :doc :added :deprecated :test :export :defined-by
                                     :name-row :name-col :name-end-col :name-end-row
-                                    :arglist-strs :end-row :end-col])]
+                                    :arglist-strs :end-row :end-col :meta])]
       (swap! analysis update :var-definitions conj
              (assoc-some
               (merge {:filename filename


### PR DESCRIPTION
This PR adds in an additional key to the analysis of `:var-definitions`, `:meta`, which contains the unedited metadata from the original code. Currently the plan is to only support "constant" metadata which does not include an expression evaluating to anything other than itself.

TODO:
- [ ] Filter metadata to only pass through "const" metadata
- [ ] Maybe tests?

Related: #1280