### PR TITLE
Make reg-finding! return the finding if it was applied/not ignored

### DIFF
--- a/src/clj_kondo/impl/findings.clj
+++ b/src/clj_kondo/impl/findings.clj
@@ -52,8 +52,8 @@
     (when (and level (not (identical? :off level)) (not dependencies))
       (when-not (ignored? ctx m tp)
         (let [m (assoc m :level level)]
-          (swap! findings conj m)))))
-  nil)
+          (swap! findings conj m)
+          m)))))
 
 ;;;; Scratch
 


### PR DESCRIPTION
This fixes https://github.com/clojure-lsp/clojure-lsp/issues/554

During the call of `:custom-lint-fn` when clojure-lsp is starting, clojure-lsp async reg-finding! to not block the project initialization, this can cause outdated findings later on that will only be fixed if user manually go to the file or edit the file.

With this PR the `:custom-lint-fn` return the finding if it was really applied/not ignored by any ignore or some configuration, then clojure-lsp can ignore the finding if not applied.

I didn't find any issues on changing the `reg-finding!` to not always return `nil` but let me know if you see any problems with that.