### PR TITLE
[analysis] Add scope-end-row and scope-end-col to var-usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - Update built-in cache to clojure 1.11.0-alpha2 [#1382](https://github.com/clj-kondo/clj-kondo/issues/1382)
+- Add `:end-row`, `:end-col` to `:var-usages` analysis element [#1387](https://github.com/clj-kondo/clj-kondo/pull/1387)
+- BREAKING: Change `:row` and `:col` for `:var-usages` to use the start location of the call instead of the name location [#1170](https://github.com/clj-kondo/clj-kondo/issues/1170)
 
 ## 2021.09.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,10 @@ Details about releases prior to v2020.09.09 can be found
 
 ## Breaking changes
 
+### Unreleased
+
+- Change `:row` and `:col` for `:var-usages` to use the start location of the call instead of the name location [#1170](https://github.com/clj-kondo/clj-kondo/issues/1170)
+
 ### 2020.10.10
 
 - Base Docker image on Ubuntu latest instead of Alpine [#1026](https://github.com/clj-kondo/clj-kondo/issues/1026)

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -62,8 +62,12 @@ The analysis output consists of a map with:
   - `:arglists-str`: a list of each set of args as written
 
 - `:var-usages`, a list of maps with:
-  - `:filename`, `:row`, `:col`
+  - `:filename`
   - `:name`: the name of the used var
+  - `:row`, `col`: the start position of this usage, the parenthesis start location if a function call
+  - `:end-row`, `end-col`: the end position of this usage, the parenthesis end location if a function call
+  - `:name-row`, `:name-col`: the start position of the name of this usage
+  - `:name-end-row`, `:name-end-col`: the end position of the name of this usage
   - `:from`: the namespace from which the var was used
   - `:to`: the namespace of the used var
   - `:from-var`: the function name from which the var was used

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -28,8 +28,8 @@
                                :name-col
                                :name-end-row
                                :name-end-col
-                               :scope-end-row
-                               :scope-end-col]))
+                               :end-row
+                               :end-col]))
                 :arity arity
                 :lang lang
                 :from-var in-def))))))

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -27,7 +27,9 @@
                                :name-row
                                :name-col
                                :name-end-row
-                               :name-end-col]))
+                               :name-end-col
+                               :scope-end-row
+                               :scope-end-col]))
                 :arity arity
                 :lang lang
                 :from-var in-def))))))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1816,8 +1816,6 @@
                                     :end-row (:end-row expr-meta)
                                     :col col
                                     :end-col (:end-col expr-meta)
-                                    :scope-end-row (:end-row expr-meta)
-                                    :scope-end-col (:end-col expr-meta)
                                     :base-lang base-lang
                                     :lang lang
                                     :filename (:filename ctx)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1523,7 +1523,6 @@
                                                    :config config
                                                    :ns ns-name})
                                          (catch Exception e
-                                           ;;TODOAQUI
                                            (findings/reg-finding!
                                             ctx
                                             (merge
@@ -1817,6 +1816,8 @@
                                     :end-row (:end-row expr-meta)
                                     :col col
                                     :end-col (:end-col expr-meta)
+                                    :scope-end-row (:end-row expr-meta)
+                                    :scope-end-col (:end-col expr-meta)
                                     :base-lang base-lang
                                     :lang lang
                                     :filename (:filename ctx)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -229,8 +229,6 @@
                   col (:col call)
                   end-row (:end-row call)
                   end-col (:end-col call)
-                  scope-end-row (:scope-end-row call)
-                  scope-end-col (:scope-end-col call)
                   ;; _ (prn :used (:used-namespaces idacs))
                   #_#__ (prn (keys (:defs (:clj idacs))))
                   called-fn (utils/resolve-call idacs call call-lang
@@ -320,8 +318,8 @@
                                                   :name-col name-col
                                                   :name-end-row name-end-row
                                                   :name-end-col name-end-col
-                                                  :scope-end-row scope-end-row
-                                                  :scope-end-col scope-end-col)))]
+                                                  :end-row end-row
+                                                  :end-col end-col)))]
             :when valid-call?
             :let [fn-name (:name called-fn)
                   _ (when (and  ;; unresolved?

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -229,6 +229,8 @@
                   col (:col call)
                   end-row (:end-row call)
                   end-col (:end-col call)
+                  scope-end-row (:scope-end-row call)
+                  scope-end-col (:scope-end-col call)
                   ;; _ (prn :used (:used-namespaces idacs))
                   #_#__ (prn (keys (:defs (:clj idacs))))
                   called-fn (utils/resolve-call idacs call call-lang
@@ -317,7 +319,9 @@
                                                   :name-row name-row
                                                   :name-col name-col
                                                   :name-end-row name-end-row
-                                                  :name-end-col name-end-col)))]
+                                                  :name-end-col name-end-col
+                                                  :scope-end-row scope-end-row
+                                                  :scope-end-col scope-end-col)))]
             :when valid-call?
             :let [fn-name (:name called-fn)
                   _ (when (and  ;; unresolved?

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -302,10 +302,8 @@
                   _ (when output-analysis?
                       (analysis/reg-usage! ctx
                                            filename
-                                           (if call? name-row
-                                               row)
-                                           (if call? name-col
-                                               col)
+                                           row
+                                           col
                                            caller-ns-sym
                                            resolved-ns fn-name arity
                                            (when (= :cljc base-lang)

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -365,15 +365,15 @@
                         :name-end-col 22
                         :name-end-row 1
                         :name-row 1
-                        :end-row 1
+                        :name-col 19
                         :name foo
-                        :end-col 25
                         :filename "<stdin>"
                         :from user
-                        :col 19
-                        :name-col 19
                         :arity 1
                         :row 1
+                        :col 18
+                        :end-row 1
+                        :end-col 25
                         :to user})
                 var-usages))))
   (testing "when the var-usage is not called as function"
@@ -403,7 +403,7 @@
                         :from user
                         :arity 1
                         :row 1
-                        :col 19
+                        :col 18
                         :end-row 1
                         :end-col 25
                         :to :clj-kondo/unknown-namespace})
@@ -429,7 +429,9 @@
     (assert-submaps
      '[{:filename "<stdin>",
         :row 1,
-        :col 2,
+        :col 1,
+        :name-row 1,
+        :name-col 2,
         :from user,
         :to clojure.core,
         :name defn,
@@ -532,7 +534,9 @@
     (assert-submaps
      '[{:filename "<stdin>",
         :row 2,
-        :col 31,
+        :col 30,
+        :name-row 2,
+        :name-col 31,
         :from foo,
         :to clojure.core,
         :name inc,
@@ -545,13 +549,17 @@
         :filename "<stdin>",
         :from foo,
         :macro true,
-        :col 20,
+        :col 19,
+        :name-row 2,
+        :name-col 20,
         :arity 3,
         :row 2,
         :to clojure.core}
        {:filename "<stdin>",
         :row 2,
-        :col 31,
+        :col 30,
+        :name-row 2,
+        :name-col 31,
         :from foo,
         :to cljs.core,
         :name inc,
@@ -564,7 +572,9 @@
         :filename "<stdin>",
         :from foo,
         :macro true,
-        :col 20,
+        :col 19,
+        :name-row 2,
+        :name-col 20,
         :arity 3,
         :row 2,
         :to cljs.core}]
@@ -577,19 +587,25 @@
     (assert-submaps
      '[{:filename "<stdin>",
         :row 2,
-        :col 20,
+        :col 19,
+        :name-row 2,
+        :name-col 20,
         :name fn,
         :from foo,
         :to clojure.core}
        {:filename "<stdin>",
         :row 3,
-        :col 20,
+        :col 19,
+        :name-row 3,
+        :name-col 20,
         :name fn*,
         :from foo,
         :to clojure.core}
        {:filename "<stdin>",
         :row 4,
-        :col 20,
+        :col 19,
+        :name-row 4,
+        :name-col 20,
         :name bound-fn,
         :from foo,
         :to clojure.core}]

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -361,34 +361,53 @@
 (deftest scope-usage-test
   (testing "when the var-usage is called as function"
     (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (foo 2)" {:config {:output {:analysis true}}})]
-      (assert-submaps
-       '[{:name foo
-          :name-row 1 :name-col 19 :name-end-row 1 :name-end-col 22
-          :row 1 :col 19 :scope-end-row 1 :scope-end-col 25}
-         {}]
-       var-usages)))
+      (is (some #(= % '{:fixed-arities #{1}
+                        :name-end-col 22
+                        :name-end-row 1
+                        :name-row 1
+                        :end-row 1
+                        :name foo
+                        :end-col 25
+                        :filename "<stdin>"
+                        :from user
+                        :col 19
+                        :name-col 19
+                        :arity 1
+                        :row 1
+                        :to user})
+                var-usages))))
   (testing "when the var-usage is not called as function"
     (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) foo" {:config {:output {:analysis true}}})]
       (is (some #(= % '{:fixed-arities #{1}
                         :name-end-col 21
                         :name-end-row 1
                         :name-row 1
+                        :name-col 18
                         :name foo
                         :filename "<stdin>"
                         :from user
-                        :col 18
-                        :name-col 18
                         :row 1
+                        :col 18
+                        :end-row 1
+                        :end-col 21
                         :to user})
                 var-usages))))
   (testing "when the var-usage call is unknown"
     (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (bar 2)" {:config {:output {:analysis true}}})]
-      (assert-submaps
-       '[{:name bar
-          :name-row 1 :name-col 19 :name-end-row 1 :name-end-col 22
-          :row 1 :col 19 :scope-end-row 1 :scope-end-col 25}
-         {}]
-       var-usages))))
+      (is (some #(= % '{:name-end-row 1
+                        :name-end-col 22
+                        :name-row 1
+                        :name-col 19
+                        :name bar
+                        :filename "<stdin>"
+                        :from user
+                        :arity 1
+                        :row 1
+                        :col 19
+                        :end-row 1
+                        :end-col 25
+                        :to :clj-kondo/unknown-namespace})
+                var-usages)))))
 
 (deftest analysis-test
   (let [{:keys [:var-definitions
@@ -429,7 +448,7 @@
         :defined-by clojure.core/defn,
         :fixed-arities #{0},
         :doc "docstring with\n \"escaping\""}]
-     var-definitions))  
+     var-definitions))
 
   (let [{:keys [:var-definitions]} (analyze "(def ^:deprecated x \"docstring\" 1)")]
     (assert-submaps

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -109,7 +109,7 @@
 (deftest custom-lint-fn-test
   (testing "custom-lint reg a new finding and reg-finding! return the new finding"
     (let [res (custom-linter "(eval '(+ 1 2 3))" #(is %))]
-      (is (= [{:filename "<stdin>", :row 1, :col 2, :end-row 1, :end-col 6,
+      (is (= [{:filename "<stdin>", :row 1, :col 1, :end-row 1, :end-col 6,
                :type :org.acme/forbidden-var, :level :error}]
              (:findings res)))))
   (testing "ignore hints return nil during reg-finding!"


### PR DESCRIPTION
- Add `:end-row` and `:end-col` for all var-usages when using as a function call
- rollback https://github.com/clj-kondo/clj-kondo/commit/4f74945fb050210e82f76d9a9e5293a633a23b22 as we already have `:name-*` for var-usage name location


Related to https://github.com/clojure-lsp/clojure-lsp/issues/569