### PR TITLE
re-frame events and subscriptions like vars in keyword analysis

### DIFF
--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -29,7 +29,8 @@
                                :name-end-row
                                :name-end-col
                                :end-row
-                               :end-col]))
+                               :end-col
+                               :reg]))
                 :arity arity
                 :lang lang
                 :from-var in-def))))))
@@ -105,11 +106,14 @@
                        :lang (when (= :cljc (:base-lang ctx)) (:lang ctx))
                        :id (:id binding)))))
 
-(defn reg-keyword-usage! [ctx filename usage]
+(defn reg-keyword-usage! [{:keys [in-subs in-disp] :as ctx} filename usage]
   (when (:analyze-keywords? ctx)
     (when-let [analysis (:analysis ctx)]
       (swap! analysis update :keywords conj
              (assoc-some (select-keys usage [:row :col :end-row :end-col :alias :ns :keys-destructuring :reg :auto-resolved :namespace-from-prefix])
                          :name (name (:name usage))
                          :filename filename
-                         :lang (when (= :cljc (:base-lang ctx)) (:lang ctx)))))))
+                         :lang (when (= :cljc (:base-lang ctx)) (:lang ctx))
+                         :from-reg (and (or in-subs in-disp) (when (not (:reg usage)) (get-in ctx [:in-reg :reg])))
+                         :from-var (and (or in-subs in-disp) (or (:in-def ctx) (when-let [k (and (not (:reg usage)) (:k (:in-reg ctx)))] (name k))))
+                         :from-ns (get-in ctx [:ns :name]))))))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1873,13 +1873,20 @@
                         [babashka.process $]
                         (babashka/analyze-$ ctx expr)
                         ([re-frame.core reg-event-db]
-                         [re-frame.core reg-event-fx]
                          [re-frame.core reg-event-ctx]
-                         [re-frame.core reg-sub]
                          [re-frame.core reg-sub-raw]
                          [re-frame.core reg-fx]
                          [re-frame.core reg-cofx])
                         (re-frame/analyze-reg ctx expr (symbol (str resolved-namespace) (str resolved-name)))
+                        ([re-frame.core reg-sub])
+                        (re-frame/analyze-reg-sub ctx expr (symbol (str resolved-namespace) (str resolved-name)))
+                        ([re-frame.core subscribe])
+                        (re-frame/analyze-subscribe ctx (next (:children expr)))
+                        ([re-frame.core dispatch]
+                         [re-frame.core dispatch-sync])
+                        (re-frame/analyze-dispatch ctx (next (:children expr)))
+                        ([re-frame.core reg-event-fx])
+                        (re-frame/analyze-reg-event-fx ctx expr (symbol (str resolved-namespace) (str resolved-name)))
                         ;; catch-all
                         (let [next-ctx (cond-> ctx
                                          (one-of [resolved-namespace resolved-name]
@@ -1894,6 +1901,7 @@
                 (if (= 'ns resolved-as-clojure-var-name)
                   analyzed
                   (let [in-def (:in-def ctx)
+                        in-reg (:in-reg ctx)
                         id (:id expr)
                         m (meta analyzed)
                         proto-call {:type :call
@@ -1927,6 +1935,7 @@
                         call (cond-> proto-call
                                id (assoc :id id)
                                in-def (assoc :in-def in-def)
+                               in-reg (assoc :in-reg in-reg)
                                ret-tag (assoc :ret ret-tag))]
                     (when id (reg-call ctx call id))
                     (namespace/reg-var-usage! ctx ns-name call)

--- a/src/clj_kondo/impl/analyzer/re_frame.clj
+++ b/src/clj_kondo/impl/analyzer/re_frame.clj
@@ -2,11 +2,43 @@
   {:no-doc true}
   (:require
      [clj-kondo.impl.analyzer.common :as common]
-     [clj-kondo.impl.utils :as utils]))
+     [clojure.walk :as w]))
+
+(defn- assoc-reg-maybe [ctx name-expr fq-def]
+  (if-let [kw (:k name-expr)]
+    [(assoc name-expr :reg fq-def) (assoc ctx :in-reg {:k kw :reg fq-def})]
+    [name-expr ctx]))
 
 (defn analyze-reg [ctx expr fq-def]
   (let [[name-expr & body] (next (:children expr))
-        reg-val (if (:k name-expr)
-                  (assoc name-expr :reg fq-def)
-                  name-expr)]
+        [reg-val ctx] (assoc-reg-maybe ctx name-expr fq-def)]
+    (common/analyze-children ctx (cons reg-val body))))
+
+(defn analyze-subscribe [ctx expr]
+  (common/analyze-children (assoc ctx :in-subs true) expr))
+
+(defn analyze-dispatch [ctx expr]
+  (common/analyze-children (assoc ctx :in-disp true) expr))
+
+(defn analyze-reg-sub [ctx expr fq-def]
+  (let [[name-expr & body] (next (:children expr))
+        arrow-subs (map last (filter #(= :<- (:k (first %))) (partition-all 2 body)))]
+    (if (seq arrow-subs)
+      (let [[reg-val ctx] (assoc-reg-maybe ctx name-expr fq-def)]
+        (doseq [s arrow-subs]
+          (analyze-subscribe ctx [s]))
+        (common/analyze-children ctx (cons reg-val (last body))))
+      (analyze-reg ctx expr fq-def))))
+
+(defn analyze-reg-event-fx [ctx expr fq-def]
+  (let [[name-expr & body] (next (:children expr))
+        [reg-val ctx] (assoc-reg-maybe ctx name-expr fq-def)
+        body (w/postwalk
+              (fn [x]
+                (if (and (coll? x) (#{:dispatch :dispatch-n :dispatch-later} (:k (first x))))
+                  (let [[disp-kw & disp-coll] x]
+                    (analyze-dispatch ctx disp-coll)
+                    [disp-kw])
+                  x))
+              body)]
     (common/analyze-children ctx (cons reg-val body))))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -218,6 +218,7 @@
                                                   :callstack (:callstack ctx)
                                                   :config (:config ctx)
                                                   :in-def (:in-def ctx)
+                                                  :in-reg (:in-reg ctx)
                                                   :simple? simple?
                                                   :interop? interop?
                                                   ;; save some memory

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -296,6 +296,7 @@
                   resolved-ns (or fn-ns resolved-ns)
                   arity (:arity call)
                   in-def (:in-def call)
+                  in-reg (:in-reg call)
                   recursive? (and
                               (= fn-ns caller-ns-sym)
                               (= fn-name in-def))
@@ -308,8 +309,9 @@
                                            resolved-ns fn-name arity
                                            (when (= :cljc base-lang)
                                              call-lang)
-                                           in-def
+                                           (or in-def (when-let [k (:k in-reg)] (name k)))
                                            (assoc called-fn
+                                                  :reg (:reg in-reg)
                                                   :alias (:alias call)
                                                   :refer (:refer call)
                                                   :name-row name-row

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -99,14 +99,145 @@
                       (rf/reg-cofx ::g (constantly {}))"
                      {:config {:output {:analysis {:keywords true}}}})]
       (assert-submaps
-       '[{:name "a" :reg re-frame.core/reg-event-db}
-         {:name "b" :reg re-frame.core/reg-event-fx}
-         {:name "c" :reg re-frame.core/reg-event-ctx}
-         {:name "d" :reg re-frame.core/reg-sub}
-         {:name "e" :reg re-frame.core/reg-sub-raw}
-         {:name "f" :reg re-frame.core/reg-fx}
-         {:name "g" :reg re-frame.core/reg-cofx}]
+        '[{:name "a" :reg re-frame.core/reg-event-db}
+          {:name "b" :reg re-frame.core/reg-event-fx}
+          {:name "c" :reg re-frame.core/reg-event-ctx}
+          {:name "d" :reg re-frame.core/reg-sub}
+          {:name "e" :reg re-frame.core/reg-sub-raw}
+          {:name "f" :reg re-frame.core/reg-fx}
+          {:name "g" :reg re-frame.core/reg-cofx}]
+        (:keywords a))))
+  (testing "calls in re-frame.core/reg-event-db body register reg"
+    (let [a (analyze "(require '[re-frame.core :as rf])
+                      (rf/reg-event-db ::a (constantly {}))"
+                     {:config {:output {:analysis {:keywords true}}}})]
+      (assert-submaps
+        '[{:name require}
+          {:name constantly :from-var "a" :reg re-frame.core/reg-event-db}
+          {:name reg-event-db}]
+        (:var-usages a))))
+  (testing "keyword usages records from-var from-ns with subscriptions"
+    (let [a (analyze "(ns foo (:require [re-frame.core :as rf]))
+                      (rf/reg-sub :a (constantly {}))
+
+                      (ns bar (:require [re-frame.core :as rf]))
+                      (rf/reg-sub :b :<- [:a] (fn [a _] a))
+                      (rf/reg-sub :c (fn [] [(rf/subscribe [:a]) (rf/subscribe [:b])]) (fn [[a b]] (vector a b)))
+                      (defn foo-a [] @(rf/subscribe [:a]))"
+                     {:config {:output {:analysis {:keywords true}}}})]
+      (assert-submaps
+        '[{:name "a"
+           :from-ns foo
+           :reg re-frame.core/reg-sub}
+          {:name "a"
+           :from-var "b"
+           :from-ns bar
+           :from-reg re-frame.core/reg-sub}
+          {:name "b"
+           :from-ns bar
+           :reg re-frame.core/reg-sub}
+          {:name "c"
+           :from-ns bar
+           :reg re-frame.core/reg-sub}
+          {:name "a"
+           :from-var "c"
+           :from-reg re-frame.core/reg-sub}
+          {:name "b"
+           :from-var "c"
+           :from-reg re-frame.core/reg-sub}
+          {:name "a"
+           :from-var foo-a
+           :from-ns bar}]
+        (:keywords a))
+      (is (every? #(and (not (:from-var %)) (not (:from-reg %))) (filter :reg (:keywords a))) "from-var and from-reg should not be there for regs")))
+  (testing "keyword usages records from-var from-ns with dispatches"
+    (let [a (analyze "(ns foo (:require [re-frame.core :as rf]))
+                      (rf/reg-event-db :foo (fn [db [_ arg1]] (dissoc db arg1)))
+                      (rf/reg-event-db :other-foo (fn [db [_ arg1 arg2]] (assoc db arg1 arg2)))
+
+                      (ns bar (:require [re-frame.core :as rf]))
+                      (defn bar-fn [] (rf/dispatch [:foo :some-key]))
+                      (rf/reg-event-fx :simple-dispatch (fn [{:keys [db]} [_ arg1]] {:dispatch [:foo arg1]}))
+                      (rf/reg-event-fx :fx-dispatch (fn [{:keys [db]} [_ arg1]] {:fx [[:dispatch [:foo arg1]]]}))
+                      (rf/reg-event-fx :later-dispatch (fn [{:keys [db]} [_ arg1]] {:fx [[:dispatch-later {:ms 10 :dispatch [:foo arg1]}]]}))
+                      (rf/reg-event-fx :multiple-dispatch (fn [{:keys [db]} [_ arg1 arg2]] {:fx [[:dispatch-n [[:foo arg1] [:other-foo arg1 arg2]]]]}))"
+                     {:config {:output {:analysis {:keywords true}}}})]
+      (assert-submaps
+       '[{:reg re-frame.core/reg-event-db,
+          :name "foo",
+          :from-ns foo}
+         {:reg re-frame.core/reg-event-db,
+          :name "other-foo",
+          :from-ns foo}
+         {:name "foo",
+          :from-ns bar
+          :from-var bar-fn}
+         {}
+         {:reg re-frame.core/reg-event-fx,
+          :name "simple-dispatch",
+          :from-ns bar}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {:name "foo",
+          :from-var "simple-dispatch"
+          :from-ns bar}
+         {:reg re-frame.core/reg-event-fx,
+          :name "fx-dispatch",
+          :from-ns bar}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {:name "foo",
+          :from-var "fx-dispatch"
+          :from-ns bar}
+         {:reg re-frame.core/reg-event-fx,
+          :name "later-dispatch",
+          :from-ns bar}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {:name "foo",
+          :from-var "later-dispatch"
+          :from-ns bar}
+         {:reg re-frame.core/reg-event-fx,
+          :name "multiple-dispatch",
+          :from-ns bar}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {}
+         {:name "foo",
+          :from-var "multiple-dispatch"
+          :from-ns bar}
+         {:name "other-foo",
+          :from-var "multiple-dispatch"
+          :from-ns bar}]
        (:keywords a))))
+  (testing "keyword usages indifferent of order"
+    (let [a (analyze "(ns foo (:require [re-frame.core :as rf]))
+                      (rf/reg-sub :b :<- [:a] (fn [a _] a))
+                      (rf/reg-sub :a (constantly {}))"
+                     {:config {:output {:analysis {:keywords true}}}})]
+      (assert-submaps
+        '[{:name "b"}
+          {:name "a"
+           :from-var "b"
+           :from-reg re-frame.core/reg-sub}
+          {:name "a"}]
+        (:keywords a))))
   (testing ":lint-as re-frame.core function will add :reg with the source full qualified ns"
     (let [a (analyze "(user/mydef ::kw (constantly {}))"
                      {:config {:output {:analysis {:keywords true}}
@@ -155,14 +286,14 @@
     (testing "no namespace for key :a"
       (let [a (analyze "#:xml{:_/a 1}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>"}]
+        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>" :from-ns user}]
                (:keywords a)))))
     ;; Don't use assertmap here to make sure ns is absent
     (testing "no namespace for key :b"
       (let [a (analyze "#:xml{:a {:b 1}}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>" :namespace-from-prefix true}
-                 {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>"}]
+        (is (= '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>" :namespace-from-prefix true :from-ns user}
+                 {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>" :from-ns user}]
                (:keywords a)))))
     (testing "auto-resolved and namespace-from-prefix"
       (let [a (analyze "(ns foo (:require [clojure.set :as set]))
@@ -171,18 +302,18 @@
                         {:j/k 5 :l 6 ::m 7}
                         #::set{:a 1}"
                        {:config {:output {:analysis {:keywords true}}}})]
-        (is (= '[{:row 2 :col 25 :end-row 2 :end-col 27 :name "a" :filename "<stdin>"}
-                 {:row 2 :col 28 :end-row 2 :end-col 31 :ns foo :auto-resolved true :name "b" :filename "<stdin>"}
-                 {:row 2 :col 32 :end-row 2 :end-col 38 :ns bar :name "c" :filename "<stdin>"}
-                 {:row 3 :col 29 :end-row 3 :end-col 31 :ns d :namespace-from-prefix true :name "e" :filename "<stdin>"}
-                 {:row 3 :col 34 :end-row 3 :end-col 38 :name "f" :filename "<stdin>"}
-                 {:row 3 :col 41 :end-row 3 :end-col 45 :ns g :name "h" :filename "<stdin>"}
-                 {:row 3 :col 48 :end-row 3 :end-col 51 :ns foo :auto-resolved true :name "i" :filename "<stdin>"}
-                 {:row 4 :col 26 :end-row 4 :end-col 30 :ns j :name "k" :filename "<stdin>"}
-                 {:row 4 :col 33 :end-row 4 :end-col 35 :name "l" :filename "<stdin>"}
-                 {:row 4 :col 38 :end-row 4 :end-col 41 :ns foo :auto-resolved true :name "m" :filename "<stdin>"}
+        (is (= '[{:row 2 :col 25 :end-row 2 :end-col 27 :name "a" :filename "<stdin>" :from-ns foo}
+                 {:row 2 :col 28 :end-row 2 :end-col 31 :ns foo :auto-resolved true :name "b" :filename "<stdin>" :from-ns foo}
+                 {:row 2 :col 32 :end-row 2 :end-col 38 :ns bar :name "c" :filename "<stdin>" :from-ns foo}
+                 {:row 3 :col 29 :end-row 3 :end-col 31 :ns d :namespace-from-prefix true :name "e" :filename "<stdin>" :from-ns foo}
+                 {:row 3 :col 34 :end-row 3 :end-col 38 :name "f" :filename "<stdin>" :from-ns foo}
+                 {:row 3 :col 41 :end-row 3 :end-col 45 :ns g :name "h" :filename "<stdin>" :from-ns foo}
+                 {:row 3 :col 48 :end-row 3 :end-col 51 :ns foo :auto-resolved true :name "i" :filename "<stdin>" :from-ns foo}
+                 {:row 4 :col 26 :end-row 4 :end-col 30 :ns j :name "k" :filename "<stdin>" :from-ns foo}
+                 {:row 4 :col 33 :end-row 4 :end-col 35 :name "l" :filename "<stdin>" :from-ns foo}
+                 {:row 4 :col 38 :end-row 4 :end-col 41 :ns foo :auto-resolved true :name "m" :filename "<stdin>"  :from-ns foo}
                  {:row 5, :col 32, :end-row 5, :end-col 34, :ns clojure.set, :namespace-from-prefix true,
-                  :name "a", :filename "<stdin>"}]
+                  :name "a", :filename "<stdin>" :from-ns foo}]
                (:keywords a)))))))
 
 (deftest locals-analysis-test


### PR DESCRIPTION
- var usages in re-frame body register reg as from-var
- keyword usages record from-ns, from-var, from-reg (if they occur in a dispatch or subscription)
- from-var and in-def records keywords as string instead of keyword
  and test to prove the order of keywords is indifferent to detect usages
- analyze re-frame subscriptions, dispatches
 only add `from-var`, `from-reg` if we are in a subscription or a dispatch
 analyze subscriptions
 -- direct `subscribe` calls
 --  signal fns in reg-subs
 -- `:<-` constructs in reg-subs
 analyze dispatches
 -- direct `dispatch` and `dispatch-sync` calls
 -- analyze `reg-event-fx` to add from-var, from-reg for only those
  keywords that show up in the vector/map of `:dispatch` kw and its variations