### PR TITLE
Importing: clarify clj-kondo/config is an ex.

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -327,7 +327,7 @@ For example, if the `claypoole` library itself wanted to export config, it would
 ### Importing
 
 When invoked with the appropriate arguments, clj-kondo will inform you of any inactive imported clj-kondo configs from your project dependencies and instruct you how to activate them.
-Let's invoke clj-kondo with [clj-kondo/config](#sample-exports) as a dependency to demonstrate:
+As an example, let's add [clj-kondo/config](#sample-exports) that has some clj-kondo exports as a dependency to demonstrate:
 
 1. Include `clj-kondo/config` in your `deps.edn`:
     ```Clojure


### PR DESCRIPTION
I have tried to make it very explicit, very clear that clj-kondo/config is just an example of a repo with exports and is not required - some users might misinterpret the previous text, I think.