### PR TITLE
Add simple docstring formatting linters.

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -220,6 +220,42 @@ A regex is also permitted, e.g. to exclude all test namespaces:
 Expected map, found: java.lang.String
 ```
 
+### Docstring blank
+
+*Keyword:* `:docstring-blank`.
+
+*Description:* warn on blank docstring.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(defn foo "" [a b] 1)`
+
+*Example message:* `Docstring should not be blank.`.
+
+### Docstring no summary
+
+*Keyword:* `:docstring-no-summary`.
+
+*Description:* warn when first line of docstring is not a complete sentence.
+
+*Default level:* `:off`.
+
+*Example trigger:* `(defn foo "not a sentence" [a b] 1)`
+
+*Example message:* `First line of the docstring should be a capitalized sentence ending with punctuation.`
+
+### Docstring leading trailing whitespace
+
+*Keyword:* `:docstring-leading-trailing-whitespace`.
+
+*Description:* warn when docstring has leading or trailing whitespace
+
+*Default level:* `:off`.
+
+*Example trigger:* `(defn foo "Has trailing whitespace.\n" [a b] 1)`
+
+*Example message:* `Docstring should not have leading or trailing whitespace.`
+
 ### Duplicate map key
 
 *Keyword:* `:duplicate-map-key`.

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -453,6 +453,7 @@
   (let [ns-name (-> ctx :ns :name)
         ;; "my-fn docstring" {:no-doc true} [x y z] x
         [name-node & children] (next (:children expr))
+        name-node-meta-nodes (:meta name-node)
         name-node (when name-node (meta/lift-meta-content2 ctx name-node))
         fn-name (:value name-node)
         call (name (symbol-call expr))
@@ -501,9 +502,8 @@
                      (:private var-meta))
         [doc-node docstring] (if docstring
                                [doc-node docstring]
-                               ;; TODO: too late to get raw var-leading-meta node
-                               (when-let [doc (some-> var-leading-meta :doc str)]
-                                 [expr doc]))
+                               (when (some-> var-leading-meta :doc str)
+                                 (some docstring/docs-from-meta name-node-meta-nodes)))
         bodies (fn-bodies ctx children expr)
         _ (when (empty? bodies)
             (findings/reg-finding! ctx

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -474,10 +474,14 @@
         ;; use dorun to force evaluation, we don't use the result!
         _ (when meta-node (dorun (analyze-expression** ctx meta-node)))
         _ (when meta-node2 (dorun (analyze-expression** ctx meta-node2)))
-        [doc-node docstring] (or (docstring/docs-from-meta meta-node) [doc-node docstring])
         meta-node-meta (when meta-node (sexpr meta-node))
-        [doc-node docstring] (or (docstring/docs-from-meta meta-node2) [doc-node docstring])
+        [doc-node docstring] (or (and (:doc meta-node-meta)
+                                      (docstring/docs-from-meta meta-node))
+                                 [doc-node docstring])
         meta-node2-meta (when meta-node2 (sexpr meta-node2))
+        [doc-node docstring] (or (and (:doc meta-node2)
+                                      (docstring/docs-from-meta meta-node2))
+                              [doc-node docstring])
         var-meta (if meta-node-meta
                    (merge var-leading-meta meta-node-meta)
                    var-leading-meta)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -475,11 +475,13 @@
         _ (when meta-node (dorun (analyze-expression** ctx meta-node)))
         _ (when meta-node2 (dorun (analyze-expression** ctx meta-node2)))
         meta-node-meta (when meta-node (sexpr meta-node))
-        [doc-node docstring] (or (and (:doc meta-node-meta)
+        [doc-node docstring] (or (and meta-node-meta
+                                      (:doc meta-node-meta)
                                       (docstring/docs-from-meta meta-node))
                                  [doc-node docstring])
         meta-node2-meta (when meta-node2 (sexpr meta-node2))
-        [doc-node docstring] (or (and (:doc meta-node2)
+        [doc-node docstring] (or (and meta-node2-meta
+                                      (:doc meta-node2-meta)
                                       (docstring/docs-from-meta meta-node2))
                               [doc-node docstring])
         var-meta (if meta-node-meta

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -553,8 +553,7 @@
                    :varargs-min-arity varargs-min-arity
                    :doc docstring
                    :added (:added var-meta))))
-    (when docstring
-      (docstring/lint-docstring! ctx doc-node docstring))
+    (docstring/lint-docstring! ctx doc-node docstring)
     (mapcat :parsed parsed-bodies)))
 
 (defn analyze-case [ctx expr]

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -365,6 +365,7 @@
         col (:col m)
         children (next (:children expr))
         ns-name-expr (first children)
+        ns-name-metas (:meta ns-name-expr)
         ns-name-expr (meta/lift-meta-content2 ctx ns-name-expr)
         metadata (meta ns-name-expr)
         children (next children) ;; first = docstring, attr-map or libspecs
@@ -385,13 +386,14 @@
         ns-meta (if meta-node-meta
                   (merge metadata meta-node-meta)
                   metadata)
-        [doc-node docstring] (or (docstring/docs-from-meta meta-node)
+        [doc-node docstring] (or (and meta-node-meta
+                                      (:doc meta-node-meta)
+                                      (docstring/docs-from-meta meta-node))
                                  [doc-node docstring])
         [doc-node docstring] (if docstring
                                [doc-node docstring]
-                               ;; TODO: too late to get raw metadata-node
-                               (when-let [docstring (some-> metadata :doc str)]
-                                 [expr docstring]))
+                               (when (some-> metadata :doc str)
+                                 (some docstring/docs-from-meta ns-name-metas)))
         global-config (:global-config ctx)
         local-config (-> ns-meta :clj-kondo/config)
         local-config (if (and (seq? local-config) (= 'quote (first local-config)))

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -83,6 +83,9 @@
               :duplicate-case-test-constant {:level :error}
               :type-mismatch {:level :error}
               :missing-docstring {:level :off}
+              :docstring-blank {:level :warning}
+              :docstring-no-summary {:level :off}
+              :docstring-leading-trailing-whitespace {:level :off}
               :consistent-alias {:level :warning
                                  ;; warn when alias for clojure.string is
                                  ;; different from str

--- a/src/clj_kondo/impl/docstring.clj
+++ b/src/clj_kondo/impl/docstring.clj
@@ -1,0 +1,53 @@
+(ns clj-kondo.impl.docstring
+  (:require [clj-kondo.impl.findings :as findings]
+            [clj-kondo.impl.utils :refer [node->line tag node->keyword string-from-token]]
+            [clojure.string :as str]))
+
+(defn docstring-messages
+  "Return a sequence of linting messages for the given `docstring`."
+  [docstring]
+  (cond-> nil
+    (str/blank? docstring)
+    (conj {:message "Docstring should not be blank."
+           :type :docstring-blank})
+
+    (not (re-find #"^\s*[A-Z].*[.!?]\s*$" docstring))
+    (conj {:message "First line of the docstring should be a capitalized sentence ending with punctuation."
+           :type :docstring-no-summary})
+
+    (or (re-find #"^\s" docstring)
+        (re-find #"\s$" docstring))
+    (conj {:message "Docstring should not have leading or trailing whitespace."
+           :type :docstring-leading-trailing-whitespace})))
+
+(defn lint-docstring!
+  "Lint `docstring` for styling issues.
+
+  `node` is the node reported when docstring has findings, so ideally
+  it should be the text node for `docstring`."
+  [{:keys [filename config] :as ctx} node docstring]
+  (when (some? docstring)
+    (doseq [{:keys [type message]} (docstring-messages docstring)]
+      (when-not (identical? :off (-> config :linters type :level))
+        (findings/reg-finding!
+         ctx
+         (node->line filename
+                     node
+                     type
+                     message))))))
+
+(defn docs-from-meta
+  "Return a tuple of `[doc-node docstring]` given `meta-node`.
+
+  If `meta-node` is not a map node or does not contain a :doc entry,
+  return nil."
+  [meta-node]
+  (when meta-node
+    (when-let [doc-node (when (= :map (tag meta-node))
+                          (->> meta-node
+                               :children
+                               (partition 2)
+                               (some (fn [[k v]]
+                                       (when (= :doc (node->keyword k)) v)))))]
+      (when-let [docstring (string-from-token doc-node)]
+        [doc-node docstring]))))

--- a/test/clj_kondo/docstring_format_test.clj
+++ b/test/clj_kondo/docstring_format_test.clj
@@ -1,0 +1,97 @@
+(ns clj-kondo.docstring-format-test
+  (:require
+   [clj-kondo.test-utils :refer [lint! assert-submaps]]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+
+(def linter-config
+  {:linters
+   {:docstring-blank {:level :warning}
+    :docstring-no-summary {:level :warning}
+    :docstring-leading-trailing-whitespace {:level :warning}}})
+
+(deftest docstring-format-test
+  (testing "all linters with def"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 10,
+        :level :warning,
+        :message "Docstring should not be blank."}
+       {:file "<stdin>",
+        :row 1,
+        :col 10,
+        :level :warning,
+        :message "First line of the docstring should be a capitalized sentence ending with punctuation."})
+     (lint! "(def foo \"\" 1)" linter-config))
+
+    (assert-submaps
+     '({:message "Docstring should not have leading or trailing whitespace."
+        :row 1
+        :col 10})
+     (lint! "(def foo \" Some leading whitespace.\" 1)" linter-config))
+
+    (assert-submaps
+     ;; Dont't test row/col here; points to `def` expression instead of metadata map
+     '({:message "Docstring should not have leading or trailing whitespace."})
+     (lint! "(def ^{:doc \" Some leading whitespace.\"} foo 1)" linter-config)))
+
+  (testing "defn"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 11,
+        :level :warning,
+        :message "First line of the docstring should be a capitalized sentence ending with punctuation."})
+     (lint! "(defn foo \"not capitalized.\" [])" linter-config))
+
+    (assert-submaps
+     '({:message "Docstring should not have leading or trailing whitespace."
+        :row 1
+        :col 17})
+     (lint! "(defn foo {:doc \"Some trailing whitespace. \"} [] 1)" linter-config))
+
+    (assert-submaps
+     ;; Dont't test row/col here; points to `defn` expression instead of metadata map
+     '({:message "First line of the docstring should be a capitalized sentence ending with punctuation."})
+     (lint! "(defn ^{:doc \"meta\"} foo [] 1)" linter-config)))
+
+  (testing "defprotocol and ns"
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1,
+        :col 9,
+        :message "First line of the docstring should be a capitalized sentence ending with punctuation."}
+       {:message "Docstring should not have leading or trailing whitespace."
+        :row 3
+        :col 14}
+       {:file "<stdin>",
+        :row 5,
+        :col 17,
+        :message "First line of the docstring should be a capitalized sentence ending with punctuation."})
+     (lint! "(ns foo \"no sentence\")
+           (defprotocol Foo
+             \"Foo trailing whitespace. \"
+             (foo [this x y z]
+                \"foo method docstring.\"))" linter-config)))
+
+  (testing "defmulti"
+    (assert-submaps
+     ;; don't test for row/col here. points to `defmulti` expr instead of entry in metadata.
+     '({:file "<stdin>",
+        :message "First line of the docstring should be a capitalized sentence ending with punctuation."})
+     (lint! "(defmulti ^{:doc \"lead\"} mult :dispatch)" linter-config))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1
+        :col 22
+        :message "First line of the docstring should be a capitalized sentence ending with punctuation."})
+     (lint! "(defmulti mult {:doc \"attr\"} :dispatch)" linter-config))
+
+    (assert-submaps
+     '({:file "<stdin>",
+        :row 1
+        :col 16
+        :message "First line of the docstring should be a capitalized sentence ending with punctuation."})
+     (lint! "(defmulti mult \"doc\" :dispatch)" linter-config))))


### PR DESCRIPTION
This PR is in response to #805 

It adds basic formatting checks on docstrings; leading and trailing whitespace, blank docstrings and summaries (first line of docstring should be a complete sentence).

Some notes on the implementation

 - These only lint existing docstrings; use the existing `:missing-docstring` linter to check that docstrings exist at all.
 - The naming of the linters is taken from the [clojure styleguide](https://guide.clojure.style/#documentation).
 - All linters except "blank docstring" are off by default - there is a blank docstring in `clojure/core_deftype.clj` which triggers the `script/diff` check.
 - This patch also modifies the analyser to find docstrings in `defprotocol` and set `:doc` in the resulting vars metadata.
 - `:doc` entries in metadata on symbols are linted but the resulting findings point to the wrapping expression (def* form) because of technical difficulties.

For future improvements, I'm thinking of checking that function/method arguments are mentioned and correctly quoted in the docstring. The current PR is already large enough though.

---

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
