### PR TITLE
Avoid local test failure caused by personal clj-kondo settings

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -34,6 +34,8 @@ If you wish to add a new linter, do not forget to add the appropriate keyword in
 
 This is necessary because only the linters with a keyword in the default config appear in the report.
 
+If you're adding a new option to an existing linter, please add the option with its default value in `clj-kondo.impl.config/default-config`. This ensures that the option is not overridden by personal settings when running the test suite locally.
+
 ## Workflow
 
 ### Start with an issue before writing code

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -33,15 +33,15 @@
               :unbound-destructuring-default {:level :warning}
               :used-underscored-binding {:level :off}
               :unused-binding {:level :warning
-                               ;;:exclude-destructured-keys-in-fn-args false
-                               ;;:exclude-destructured-as false
-                               ;;:exclude-defmulti-args false
+                               :exclude-destructured-keys-in-fn-args false
+                               :exclude-destructured-as false
+                               :exclude-defmulti-args false
                                ,}
               :unsorted-required-namespaces {:level :off}
               :unused-namespace {:level :warning
                                  ;; don't warn about these namespaces:
                                  :exclude [#_clj-kondo.impl.var-info-gen]}
-                                 ;; :simple-libspec true
+                                 :simple-libspec false
 
               :unresolved-symbol {:level :error
                                   :exclude [;; ignore globally:

--- a/test/clj_kondo/test_utils.clj
+++ b/test/clj_kondo/test_utils.clj
@@ -1,6 +1,7 @@
 (ns clj-kondo.test-utils
   (:require
    [clj-kondo.impl.utils :refer [deep-merge]]
+   [clj-kondo.impl.config :as conf]
    [clj-kondo.main :as main :refer [main]]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -81,7 +82,7 @@
            (if (map? m)
              [m (rest args)]
              [nil args]))
-         config (str (deep-merge base-config config))
+         config (str (deep-merge conf/default-config base-config config))
          res (with-out-str
                (try
                  (cond


### PR DESCRIPTION
When running the test suite locally, non-default settings in the user's home may cause tests to fail.
The changes address this by:
- explicitly setting default values for linter options that a user may want to adapt
- using the default config as a base for the tests to merge into