### PR TITLE
Add Sublime Text instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 -  Stabilize cache version independent from kondo version [#1520](https://github.com/clj-kondo/clj-kondo/issues/1520)
 - `:output {:progress true}` should print to stderr [#1523](https://github.com/clj-kondo/clj-kondo/issues/1523)
 - Only print informative messages when `--debug` is enabled. [#1514](https://github.com/clj-kondo/clj-kondo/issues/1514)
+- Add Sublime Text instructions [#827](https://github.com/clj-kondo/clj-kondo/issues/827)
 
 ## 2021.12.19
 

--- a/doc/editor-integration.md
+++ b/doc/editor-integration.md
@@ -365,3 +365,7 @@ and error counts on the message line:
 ```kak
 define-command -hidden -override lint-show-counters %{}
 ```
+
+## Sublime Text
+
+Requires Sublime Text 3 or 4. Install [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) and [SublimeLinter-contrib-clj-kondo](https://github.com/ToxicFrog/SublimeLinter-contrib-clj-kondo) with Package Control. clj-kondo must be available on the `$PATH` to work.


### PR DESCRIPTION
This pull request corresponds to #827. With Clojure support for Sublime Text (e.g. tonsky's [Clojure Sublimed](https://github.com/tonsky/Clojure-Sublimed)), it would be useful to add instructions on how to get support for using clj-kondo in the editor.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.