### PR TITLE
match on :depends instead of defaulting to last element.

### DIFF
--- a/src/clj_kondo/impl/linters/deps_edn.clj
+++ b/src/clj_kondo/impl/linters/deps_edn.clj
@@ -188,14 +188,16 @@
   (let [tasks (edn-utils/sexpr-keys expr)
         known-task? (set (keys tasks))]
     (doseq [[_ t-def] tasks
-            dep-task   (:children (last (:children t-def)))
+            [td-key td-body]   (partition 2 (:children t-def))
+            t-dep              (:children td-body)
             :when (and (identical? :map (:tag t-def))
-                       (not (known-task? (:value dep-task))))]
+                       (identical? (:k td-key) :depends)
+                       (not (known-task? (:value t-dep))))]
       (findings/reg-finding! ctx
                              (node->line (:filename ctx)
-                                         dep-task
+                                         t-dep
                                          :bb.edn
-                                         (str "Depending on undefined task: " (:value dep-task)))))))
+                                         (str "Depending on undefined task: " (:value t-dep)))))))
 
 (defn lint-bb-edn [ctx expr]
   (try

--- a/src/clj_kondo/impl/linters/deps_edn.clj
+++ b/src/clj_kondo/impl/linters/deps_edn.clj
@@ -189,15 +189,15 @@
         known-task? (set (keys tasks))]
     (doseq [[_ t-def] tasks
             [td-key td-body]   (partition 2 (:children t-def))
-            t-dep              (:children td-body)
+            dep-task              (:children td-body)
             :when (and (identical? :map (:tag t-def))
                        (identical? (:k td-key) :depends)
-                       (not (known-task? (:value t-dep))))]
+                       (not (known-task? (:value dep-task))))]
       (findings/reg-finding! ctx
                              (node->line (:filename ctx)
-                                         t-dep
+                                         dep-task
                                          :bb.edn
-                                         (str "Depending on undefined task: " (:value t-dep)))))))
+                                         (str "Depending on undefined task: " (:value dep-task)))))))
 
 (defn lint-bb-edn [ctx expr]
   (try

--- a/test/clj_kondo/deps_edn_test.clj
+++ b/test/clj_kondo/deps_edn_test.clj
@@ -172,10 +172,13 @@
 
 (deftest depend-on-undefined-task-test
   (let [bb-edn '{:tasks
-                 {run {:depends [compile]}
-                  cleanup {:depends [run]}
+                 {run {:paths ["script"]
+                       :depends [compile]
+                       :task (call/fn)}
+                  cleanup {:depends [run]
+                           :paths ["script"]}
                   init (println "init")}}]
     (assert-submaps
-     '({:file "bb.edn", :row 1, :col 25, :level :warning, :message "Depending on undefined task: compile"})
+     '({:file "bb.edn", :row 1, :col 44, :level :warning, :message "Depending on undefined task: compile"})
      (lint! (str bb-edn)
             "--filename" "bb.edn"))))


### PR DESCRIPTION

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

This was caused by an insufficient test case. The task maps only contained one element each, so the `last` used on the task definition entries always chose a entry for `:depends`. Fixed by extending the conditions in `doseq` to do a proper match.
