### PR TITLE
split `:bb.edn` linter and set default levels to `:error`

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -246,26 +246,50 @@ A regex is also permitted, e.g. to exclude all test namespaces:
 Expected map, found: java.lang.String
 ```
 
-### Bb.edn
+### Bb.edn dependency on undefined task
 
 *Keyword:* `:bb.edn`
 
-*Description:* warn on common errors in `bb.edn` files.
+*Description:* warn on taks undefined task dependencies in `bb.edn` files.
 
-*Default level:* `:warning`
+*Default level:* `:error`
 
 *Example trigger:*
 
 `bb.edn`:
 
 ``` clojure
-{:tasks {run {:depends [compile}}}
+{:tasks {run {:depends [compile]}}}
 ```
 
 *Example message:*
 
 ```
 Depending on undefined task: compile
+```
+
+### Bb.edn cyclic task dependency
+
+*Keyword:* `:bb.edn/cyclic-task-dependency`
+
+*Description:* warn on cyclic dependencies `bb.edn` files.
+
+*Default level:* `:error`
+
+*Example trigger:*
+
+`bb.edn`:
+
+``` clojure
+{:tasks {a {:depends [b]
+            :task (println "a")}
+         b {:depends [a]}}}
+```
+
+*Example message:*
+
+```
+Cyclic task dependency: a -> b -> a
 ```
 
 ### Docstring blank

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -108,7 +108,8 @@
                              #_#_:exclude [frequencies]
                              #_#_:include [name]}
               :deps.edn {:level :warning}
-              :bb.edn {:level :warning}
+              :bb.edn/depends-on-undefined-task {:level :error}
+              :bb.edn/cyclic-task-dependency {:level :error}
               :clj-kondo-config {:level :warning}
               :redundant-expression {:level :warning}
               :loop-without-recur {:level :warning}

--- a/src/clj_kondo/impl/linters/deps_edn.clj
+++ b/src/clj_kondo/impl/linters/deps_edn.clj
@@ -217,13 +217,13 @@
         (findings/reg-finding! ctx
                                (node->line (:filename ctx)
                                            dep-task
-                                           :bb.edn
+                                           :bb.edn/cyclic-task-dependency
                                            (str "Cyclic task dependency: "
                                                 (apply str (interpose " -> " (conj (rotate cycle-idx) t-key))))))
         (findings/reg-finding! ctx
                                (node->line (:filename ctx)
                                            dep-task
-                                           :bb.edn
+                                           :bb.edn/depends-on-undefined-task
                                            (str "Depending on undefined task: " (:value dep-task))))))))
 
 (defn lint-bb-edn [ctx expr]

--- a/test/clj_kondo/deps_edn_test.clj
+++ b/test/clj_kondo/deps_edn_test.clj
@@ -179,7 +179,7 @@
                            :paths ["script"]}
                   init (println "init")}}]
     (assert-submaps
-     '({:file "bb.edn", :row 1, :col 44, :level :warning, :message "Depending on undefined task: compile"})
+     '({:file "bb.edn", :row 1, :col 44, :level :error, :message "Depending on undefined task: compile"})
      (lint! (str bb-edn)
             "--filename" "bb.edn"))))
 
@@ -192,7 +192,7 @@
                   init {:depends [cleanup]
                         :task (println "init")}}}]
     (assert-submaps
-     '({:file "bb.edn", :row 1, :col 71, :level :warning, :message "Cyclic task dependency: cleanup -> init -> cleanup"}
-       {:file "bb.edn", :row 1, :col 114, :level :warning, :message "Cyclic task dependency: init -> cleanup -> init"})
+     '({:file "bb.edn", :row 1, :col 71, :level :error, :message "Cyclic task dependency: cleanup -> init -> cleanup"}
+       {:file "bb.edn", :row 1, :col 114, :level :error, :message "Cyclic task dependency: init -> cleanup -> init"})
      (lint! (str bb-edn)
             "--filename" "bb.edn"))))


### PR DESCRIPTION
- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions