### PR TITLE
Update setup-clj-kondo example

### DIFF
--- a/doc/ci-integration.md
+++ b/doc/ci-integration.md
@@ -73,10 +73,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup clj-kondo
-      uses: DeLaGuardo/setup-clj-kondo@822352b8aa37d5c94135e67f7b4e2f46c08008a8
+    - name: Install clj-kondo
+      uses: DeLaGuardo/setup-clj-kondo@afc83dbbf4e7e32e04649e29dbf30668d30e9e3e
       with:
-        version: '2020.04.05'
+        version: '2022.01.15'
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
The commit referenced in the example points to an old version of setup-clj-kondo.

Since https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
the old version of the Action no longer runs, but the updated version does run.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
