### PR TITLE
ignore missing doc string on private tasks

### DIFF
--- a/src/clj_kondo/impl/linters/deps_edn.clj
+++ b/src/clj_kondo/impl/linters/deps_edn.clj
@@ -206,9 +206,12 @@
                         (map-indexed #(do [%2 %1]))
                         (into {}))]
     (doseq [[t-key t-def]    tasks
-            :let  [t-map (edn-utils/sexpr-keys t-def)]
+            :let  [t-map (edn-utils/sexpr-keys t-def)
+                   private? (or (:private t-map)
+                                (= \- (first (name t-key))))]
             :when (identical? :map (:tag t-def))]
-      (when-not (:doc t-map)
+      (when-not (or (:doc t-map)
+                    private?)
         (findings/reg-finding! ctx
                                (node->line (:filename ctx)
                                            t-def

--- a/test/clj_kondo/deps_edn_test.clj
+++ b/test/clj_kondo/deps_edn_test.clj
@@ -211,13 +211,14 @@
   (let [bb-edn '{:tasks
                  {run {:paths ["script"]
                        :task (call/fn)}
-                  -hidden {:task (call/another)}
+                  docd {:doc "meaningful description"
+                        :task (call/docd)}
+                  -hidden {:task (call/another)
+                           :doc "is ignored"}
                   private {:task (call/yet-another)
                            :private true}}}]
     (assert-submaps
-     '({:file "bb.edn", :row 1, :col 14, :level :warning, :message "Docstring missing for task: run"}
-       {:file "bb.edn", :row 1, :col 60, :level :warning, :message "Docstring missing for task: -hidden"}
-       {:file "bb.edn", :row 1, :col 92, :level :warning, :message "Docstring missing for task: private"})
+     '({:file "bb.edn", :row 1, :col 14, :level :warning, :message "Docstring missing for task: run"})
      (lint! (str bb-edn)
             '{:linters {:bb.edn-task-missing-docstring {:level :warning}}}
             "--filename" "bb.edn"))))


### PR DESCRIPTION
don't lint presence of doc strings in private tasks since they currently have no function in babashka.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
