### PR TITLE
fix #1598: Give multi-arity fn args scope-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+### New
+
+### Fixed
+
+- [#1598](https://github.com/clj-kondo/clj-kondo/issues/1598): `:scope-end-row` is missing on multi-arity fn args ([@mainej](https://github.com/mainej))
+
 ## 2022.02.09
 
 ### New

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -355,7 +355,7 @@
                                            body
                                            :syntax
                                            "Function arguments should be wrapped in vector."))
-        (let [arg-bindings (extract-bindings ctx arg-vec (:fn-body body) {:fn-args? true})
+        (let [arg-bindings (extract-bindings ctx arg-vec (or (:fn-body body) body) {:fn-args? true})
               {return-tag :tag
                arg-tags :tags} (meta arg-bindings)
               arg-list (sexpr arg-vec)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -355,7 +355,7 @@
                                            body
                                            :syntax
                                            "Function arguments should be wrapped in vector."))
-        (let [arg-bindings (extract-bindings ctx arg-vec (:fn-body body) {:fn-args? true})
+        (let [arg-bindings (extract-bindings ctx arg-vec body {:fn-args? true})
               {return-tag :tag
                arg-tags :tags} (meta arg-bindings)
               arg-list (sexpr arg-vec)
@@ -451,8 +451,8 @@
       (let [expr (meta/lift-meta-content2 ctx expr)
             t (tag expr)]
         (case t
-          :vector [{:children exprs :fn-body body}]
-          :list (map (fn [expr] (assoc expr :fn-body expr)) exprs)
+          :vector [(assoc body :children exprs)]
+          :list exprs
           (recur rest-exprs))))))
 
 (defn extract-arity-info [ctx parsed-bodies]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -355,7 +355,7 @@
                                            body
                                            :syntax
                                            "Function arguments should be wrapped in vector."))
-        (let [arg-bindings (extract-bindings ctx arg-vec (or (:fn-body body) body) {:fn-args? true})
+        (let [arg-bindings (extract-bindings ctx arg-vec (:fn-body body) {:fn-args? true})
               {return-tag :tag
                arg-tags :tags} (meta arg-bindings)
               arg-list (sexpr arg-vec)
@@ -452,7 +452,7 @@
             t (tag expr)]
         (case t
           :vector [{:children exprs :fn-body body}]
-          :list exprs
+          :list (map (fn [expr] (assoc expr :fn-body expr)) exprs)
           (recur rest-exprs))))))
 
 (defn extract-arity-info [ctx parsed-bodies]

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -207,6 +207,15 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use) (:id third-use)))
     (is (= (:id second-a) (:id second-use))))
+  (let [a (analyze "(defn x ([a] a) ([b] b))" {:config {:output {:analysis {:locals true}}}})
+        [first-a first-b] (:locals a)
+        [a-use b-use] (:local-usages a)]
+    (assert-submaps
+     [{:end-col 12 :scope-end-col 16}
+      {:end-col 20 :scope-end-col 24}]
+     (:locals a))
+    (is (= (:id first-a) (:id a-use)))
+    (is (= (:id first-b) (:id b-use))))
   (let [a (analyze "(as-> {} $ $)" {:config {:output {:analysis {:locals true}}}})
         [first-a] (:locals a)
         [first-use] (:local-usages a)]

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -207,15 +207,17 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use) (:id third-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(defn x ([a] a) ([b] b))" {:config {:output {:analysis {:locals true}}}})
-        [first-a first-b] (:locals a)
-        [a-use b-use] (:local-usages a)]
+  (let [a (analyze "(defn x ([a] a) ([b c] (+ b c)))" {:config {:output {:analysis {:locals true}}}})
+        [first-a first-b first-c] (:locals a)
+        [a-use b-use c-use] (:local-usages a)]
     (assert-submaps
      [{:end-col 12 :scope-end-col 16}
-      {:end-col 20 :scope-end-col 24}]
+      {:end-col 20 :scope-end-col 32}
+      {:end-col 22 :scope-end-col 32}]
      (:locals a))
     (is (= (:id first-a) (:id a-use)))
-    (is (= (:id first-b) (:id b-use))))
+    (is (= (:id first-b) (:id b-use)))
+    (is (= (:id first-c) (:id c-use))))
   (let [a (analyze "(as-> {} $ $)" {:config {:output {:analysis {:locals true}}}})
         [first-a] (:locals a)
         [first-use] (:local-usages a)]
@@ -232,6 +234,19 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
+  (let [a (analyze "(letfn [(a ([b] b) ([c d] (+ c d)))] a)" {:config {:output {:analysis {:locals true}}}})
+        [first-a first-b first-c first-d] (:locals a)
+        [first-use second-use third-use fourth-use] (:local-usages a)]
+    (assert-submaps
+     [{:end-col 11 :scope-end-col 40}
+      {:end-col 15 :scope-end-col 19}
+      {:end-col 23 :scope-end-col 35}
+      {:end-col 25 :scope-end-col 35}]
+     (:locals a))
+    (is (= (:id first-a) (:id first-use)))
+    (is (= (:id first-b) (:id second-use)))
+    (is (= (:id first-c) (:id third-use)))
+    (is (= (:id first-d) (:id fourth-use))))
   (let [a (analyze "(let [a 0] (let [a a] a))" {:config {:output {:analysis {:locals true}}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]


### PR DESCRIPTION
This gives args defined in multi arity fns the `:scope-end-col` and `:scope-end-row` properties, which args in single arity fns also have. Fixes #1598.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).
- [x] This PR correponds to #1598.
- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
