### PR TITLE
Support nested ^:replace overrides in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+- [#1611](https://github.com/clj-kondo/clj-kondo/pull/1611): support `^:replace` override for nested config values
+
 ## 2022.03.09
 
 - [#1607](https://github.com/clj-kondo/clj-kondo/issues/1607): disable `:namespace-name-mismatch` until further notice due to problems on Windows

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -153,9 +153,7 @@
        (let [cfg (cond-> cfg
                    (contains? (:linters cfg) :if)
                    (assoc-in [:linters :missing-else-branch] (:if (:linters cfg))))]
-         (if (:replace (meta cfg))
-           cfg
-           (deep-merge cfg* cfg))))))
+         (deep-merge cfg* cfg)))))
 
 (defn fq-sym->vec [fq-sym]
   (if-let [ns* (namespace fq-sym)]

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -142,7 +142,8 @@
   ([])
   ([a] a)
   ([a b]
-   (cond (and (map? a) (map? b))
+   (cond (:replace (meta b)) b
+         (and (map? a) (map? b))
          (merge-with deep-merge a b)
          (and (sequential? a) (sequential? b))
          (into a b)

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -142,7 +142,7 @@
   ([])
   ([a] a)
   ([a b]
-   (cond (:replace (meta b)) b
+   (cond (some-> (meta b) :replace) b
          (and (map? a) (map? b))
          (merge-with deep-merge a b)
          (and (sequential? a) (sequential? b))

--- a/test/clj_kondo/impl/config_test.clj
+++ b/test/clj_kondo/impl/config_test.clj
@@ -1,0 +1,20 @@
+(ns clj-kondo.impl.config-test
+  (:require [clj-kondo.impl.config :refer [merge-config!]]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest merge-config-test
+  (testing "^:replace top-level value"
+    (is (= {:linters {:b 2}
+            :lint-as {'b 'y}}
+           (merge-config! {:linters {:a 1}
+                           :lint-as {'a 'x}}
+                          ^:replace {:linters {:b 2}
+                                     :lint-as {'b 'y}}))))
+
+  (testing "^:replace merging supports nested values"
+    (is (= {:linters {:b 2}
+            :lint-as {'a 'x 'b 'y}}
+           (merge-config! {:linters {:a 1}
+                           :lint-as {'a 'x}}
+                          {:linters ^:replace {:b 2}
+                           :lint-as {'b 'y}})))))


### PR DESCRIPTION
Based on a [slack conversation](https://clojurians.slack.com/archives/CHY97NXE2/p1647025453421829)

Allows a workflow when one needs to replace linters, but keep default paths for custom hooks to be found.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
