### PR TITLE
Update instructions for running on M1 Macs [1622]

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -62,10 +62,13 @@ To upgrade:
 
     brew upgrade clj-kondo
     
-Apple's new M1 Silicon computers use the ARM architecture, instead of Intel. To use clj-kondo, you'll need to install Rosetta2 and then run homebrew via that:
+Apple's new M1 Silicon computers use the ARM architecture, instead of Intel. To use clj-kondo, you'll need to install Rosetta2:
 
     softwareupdate --install-rosetta
     <accept the prompt>
+    
+Once Rosetta2 is installed, try the ordinary `brew install`; if that doesn't work, it's possible that you'll instead need to:
+
     arch -x86_64 brew install borkdude/brew/clj-kondo
 
 <!-- ## NPM (Linux, MacOS, Windows) -->


### PR DESCRIPTION
As per https://github.com/clj-kondo/clj-kondo/issues/1622, I found that I didn't need to use `arch -x86_64` to `brew install`. Leaving both possibilities present in the docs.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ n/a ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ n/a ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
