### PR TITLE
Bump zlib to version 1.2.12

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Please answer the following questions and leave the below in as part of your PR.
 
 - [ ] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).
 
-- [ ] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
+- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
 
 - [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
 

--- a/script/setup-musl
+++ b/script/setup-musl
@@ -19,12 +19,12 @@ fi
 
 apt-get update -y && apt-get install musl-tools -y
 
-ZLIB_VERSION="1.2.11"
+ZLIB_VERSION="1.2.12"
+ZLIB_SHA256="91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
 
-curl -O -sL "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
+curl -O -sL --fail --show-error "https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz"
 
-echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1 zlib-${ZLIB_VERSION}.tar.gz" |
-    sha256sum --check
+echo "${ZLIB_SHA256} zlib-${ZLIB_VERSION}.tar.gz" | sha256sum --check
 tar xf "zlib-${ZLIB_VERSION}.tar.gz"
 
 arch=${CLJ_KONDO_ARCH:-"x86_64"}


### PR DESCRIPTION
zlib is used during Linux static builds using musl.

Upstream released a new version and removed the old one (1.2.11). This PR bumps it to the latest version, and also add `--fail` flag to `curl` to make it easier to debug another similar error in the future.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
