### PR TITLE
[#1638] Test to catch lint regressions caused by re-frame analysis

### DIFF
--- a/test/clj_kondo/re_frame_test.clj
+++ b/test/clj_kondo/re_frame_test.clj
@@ -1,7 +1,40 @@
 (ns clj-kondo.re-frame-test
   (:require
+   [clj-kondo.core :as clj-kondo]
    [clj-kondo.test-utils :refer [lint!]]
-   [clojure.test :as t :refer [deftest is testing]]))
+   [clojure.string :as str]
+   [clojure.test :as t :refer [deftest is testing]]
+   [clojure.tools.deps.alpha :as deps]))
+
+(deftest re-frame-athens-lint-test
+  (let [deps '{:deps {com.github.athensresearch/athens {:git/sha "0866af62c00b1b026db5f7a6b8083e9c1da38385"}}
+               :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
+                           "clojars" {:url "https://repo.clojars.org/"}}}
+        paths (->> ((deps/resolve-deps deps nil) 'com.github.athensresearch/athens)
+                   :paths
+                   (filter #(str/ends-with? % "src/cljs")))
+        lint-result (clj-kondo/run! {:lang :cljs
+                                     :lint paths
+                                     :config ;; linters and lint-as as athens' clj-kondo config
+                                     '{:linters {:unresolved-namespace         {:exclude [clojure.string]}
+                                                 :unresolved-symbol            {:exclude [random-uuid
+                                                                                          goog.DEBUG
+                                                                                          (com.rpl.specter/recursive-path)]}
+                                                 :unused-referred-var          {:exclude {clojure.test [is deftest testing]}}
+                                                 :unsorted-required-namespaces {:level :warning}}
+                                       :lint-as {day8.re-frame.tracing/fn-traced   clojure.core/fn
+                                                 day8.re-frame.tracing/defn-traced clojure.core/defn
+                                                 reagent.core/with-let             clojure.core/let
+                                                 instaparse.core/defparser         clojure.core/def
+                                                 athens.common.sentry/defntrace    clojure.core/defn}
+                                       ;; trigger full re-frame analysis to test it for lint regressions
+                                       :output {:analysis {:context [:re-frame.core]
+                                                           :keywords true}}}})]
+    (println "paths analyzed ----")
+    (println (str/join ", " paths))
+    (println "summary ----")
+    (prn (:summary lint-result))
+    (is (empty? (:findings lint-result)))))
 
 (deftest subscribe-arguments-are-used-test
   (is (empty? (lint! "


### PR DESCRIPTION
add https://github.com/athensresearch/athens cljs code snapshot as is
now to lint against

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).


- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
