### PR TITLE
Limit var analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+- [#1674](https://github.com/clj-kondo/clj-kondo/pull/1674): config options to limit analysis of var-usages and bodies of var-definitions. Can be used to get a quick overview of a project's namespaces and vars, without analyzing their details.
+
 ## 2022.04.25
 
 - [#1669](https://github.com/clj-kondo/clj-kondo/issues/1669): fix re-frame analysis problem causing file to be not parsed

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -45,11 +45,29 @@ select certain keys using `:context [:re-frame.core]`.
 
 ## Limited analysis
 
-Similarly, analysis can be limited when using clj-kondo to conduct quick scans.
-When using these expert options, you should not expect linters to behave
-correctly anymore.
+Similarly, analysis can be limited to use clj-kondo to conduct quick scans. When
+using these expert options, you should not expect linters to behave correctly
+anymore.
 
 - `:var-usages`: when falsy skip `:var-usages` described below
+- `:var-definitions`
+  - `:shallow true`: analyze `:var-definitions`, but skip their bodies
+
+If you analyze var definitions shallowly, anything within the body of a form
+listed below will be skipped. That means that if you define a var within another
+`defn` (a [discouraged](https://guide.clojure.style/#dont-def-vars-inside-fns)
+practice), it won't be analyzed.
+
+- def
+- defn
+- defrecord
+- defmethod
+- plumatic schema: fn, def, defn, defmethod, defrecord
+- protocol-impls
+- fn
+- letfn
+- fn*
+- bound-fn
 
 # Data
 

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -5,7 +5,7 @@ writing tools and linters that are not yet in clj-kondo itself. To get this
 data, use the following configuration:
 
 ``` shellsession
-{:output {:analysis true}}
+{:analysis true}
 ```
 
 When using clj-kondo from the command line, the analysis data will be exported
@@ -16,7 +16,7 @@ with `{:output {:format ...}}` set to `:json` or `:edn`.
 Further analysis can be returned by providing `:analysis` with a map of options:
 
 ``` shellsession
-{:output {:analysis {... ...}}
+{:analysis {... ...}
 ```
 
 - `:locals`: when truthy return `:locals` and `:local-usages` described below
@@ -197,7 +197,7 @@ Example output after linting this code:
 ```
 
 ``` clojure
-$ clj-kondo --lint /tmp/foo.clj --config '{:output {:analysis true :format :edn}}'
+$ clj-kondo --lint /tmp/foo.clj --config '{:output {:format :edn}, :analysis true}'
 | jet --pretty --query ':analysis'
 
 {:namespace-definitions [{:filename "/tmp/foo.clj",

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -45,9 +45,9 @@ select certain keys using `:context [:re-frame.core]`.
 
 ## Limited analysis
 
-Similarly, analysis can be limited to use clj-kondo to conduct quick scans. When
-using these expert options, you should not expect linters to behave correctly
-anymore.
+Similarly, analysis can be limited. This is useful to quickly scan a file or
+project. When using these expert options, you should not expect linters to
+behave correctly. As such, consider using them with `:skip-lint true`.
 
 - `:var-usages`: when falsy skip `:var-usages` described below
 - `:var-definitions`

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -43,6 +43,14 @@ Built-in and custom hook can add arbitrary data to the analysis using a
 `:keywords`. You can opt-in to the entire context map using `:context true` or
 select certain keys using `:context [:re-frame.core]`.
 
+## Limited analysis
+
+Similarly, analysis can be limited when using clj-kondo to conduct quick scans.
+When using these expert options, you should not expect linters to behave
+correctly anymore.
+
+- `:var-usages`: when falsy skip `:var-usages` described below
+
 # Data
 
 The analysis output consists of a map with:

--- a/analysis/script/private_vars.cljs
+++ b/analysis/script/private_vars.cljs
@@ -6,7 +6,7 @@
             [clojure.set :as set]))
 
 (defn -main [& paths]
-  (let [out (:out (apply sh "clj-kondo" "--config" "{:output {:analysis true :format :edn}}"
+  (let [out (:out (apply sh "clj-kondo" "--config" "{:output {:format :edn}, :analysis true}"
                          "--lint" paths))
         analysis (:analysis (edn/read-string out))
         {:keys [:var-definitions :var-usages]} analysis

--- a/analysis/script/unused_vars.cljs
+++ b/analysis/script/unused_vars.cljs
@@ -7,7 +7,7 @@
             [planck.shell :refer [sh]]))
 
 (defn -main [& paths]
-  (let [out (:out (apply sh "clj-kondo" "--config" "{:output {:analysis true :format :edn}}"
+  (let [out (:out (apply sh "clj-kondo" "--config" "{:output {:format :edn}, :analysis true}"
                          "--lint" paths))
         analysis (:analysis (edn/read-string out))
         {:keys [:var-definitions :var-usages]} analysis

--- a/analysis/src/clj_kondo/tools/circular_dependencies.clj
+++ b/analysis/src/clj_kondo/tools/circular_dependencies.clj
@@ -4,7 +4,9 @@
 
 (defn -main [& paths]
   (let [analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:analysis true}}))
+                                             :config {:analysis {:var-usages false
+                                                                 :var-definitions {:shallow true}}}
+                                             :skip-lint true}))
         {:keys [:namespace-usages]} analysis]
     (reduce (fn [graph {:keys [:from :to :filename :row :col]}]
               (try (dep/depend graph from to)

--- a/analysis/src/clj_kondo/tools/circular_dependencies.clj
+++ b/analysis/src/clj_kondo/tools/circular_dependencies.clj
@@ -4,7 +4,7 @@
 
 (defn -main [& paths]
   (let [analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:output {:analysis true}}}))
+                                             :config {:analysis true}}))
         {:keys [:namespace-usages]} analysis]
     (reduce (fn [graph {:keys [:from :to :filename :row :col]}]
               (try (dep/depend graph from to)

--- a/analysis/src/clj_kondo/tools/find_var.clj
+++ b/analysis/src/clj_kondo/tools/find_var.clj
@@ -6,7 +6,7 @@
 (defn -main [var & paths]
   (let [[var-ns var-name] (map symbol (str/split var #"/"))
         analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:output {:analysis true}}}))
+                                             :config {:analysis true}}))
         {:keys [var-definitions var-usages]} analysis
         defined (keep (fn [{:keys [ns name] :as d}]
                         (when (and (= var-ns ns)

--- a/analysis/src/clj_kondo/tools/missing_docstrings.clj
+++ b/analysis/src/clj_kondo/tools/missing_docstrings.clj
@@ -3,7 +3,8 @@
 
 (defn -main [& paths]
   (let [analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:analysis true}}))
+                                             :config {:analysis {:var-usages false}}
+                                             :skip-lint true}))
         {:keys [:var-definitions]} analysis]
     (doseq [{:keys [:ns :name :private :doc]} var-definitions]
       (when (and (not private)

--- a/analysis/src/clj_kondo/tools/missing_docstrings.clj
+++ b/analysis/src/clj_kondo/tools/missing_docstrings.clj
@@ -3,7 +3,7 @@
 
 (defn -main [& paths]
   (let [analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:output {:analysis true}}}))
+                                             :config {:analysis true}}))
         {:keys [:var-definitions]} analysis]
     (doseq [{:keys [:ns :name :private :doc]} var-definitions]
       (when (and (not private)

--- a/analysis/src/clj_kondo/tools/namespace_graph.clj
+++ b/analysis/src/clj_kondo/tools/namespace_graph.clj
@@ -5,7 +5,9 @@
 
 (defn -main [& paths]
   (let [analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:analysis true}}))
+                                             :config {:analysis {:var-usages false
+                                                                 :var-definitions {:shallow true}}}
+                                             :skip-lint true}))
         {:keys [:namespace-definitions :namespace-usages]} analysis
         nodes (map :name namespace-definitions)
         edges (map (juxt :from :to) namespace-usages)

--- a/analysis/src/clj_kondo/tools/namespace_graph.clj
+++ b/analysis/src/clj_kondo/tools/namespace_graph.clj
@@ -5,10 +5,10 @@
 
 (defn -main [& paths]
   (let [analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:output {:analysis true}}}))
+                                             :config {:analysis true}}))
         {:keys [:namespace-definitions :namespace-usages]} analysis
         nodes (map :name namespace-definitions)
         edges (map (juxt :from :to) namespace-usages)
-        g (apply digraph (concat nodes edges ))]
+        g (apply digraph (concat nodes edges))]
     ;; install GraphViz, e.g. with brew install graphviz
     (view g)))

--- a/analysis/src/clj_kondo/tools/popular_vars.clj
+++ b/analysis/src/clj_kondo/tools/popular_vars.clj
@@ -4,7 +4,7 @@
 (defn -main [n & paths]
   (let [n (Integer. n)
         analysis (:analysis (clj-kondo/run! {:lint paths
-                                             :config {:output {:analysis true}}}))
+                                             :config {:analysis true}}))
         {:keys [:var-usages]} analysis
         vars (map (juxt :to :name) var-usages)
         freqs (frequencies vars)

--- a/analysis/src/clj_kondo/tools/pprint.clj
+++ b/analysis/src/clj_kondo/tools/pprint.clj
@@ -13,7 +13,7 @@
     (let [format (case format "edn" :edn "table" :table)
           analysis (:analysis (clj-kondo/run!
                                {:lint paths :config
-                                {:output {:analysis true}}}))
+                                {:analysis true}}))
           {:keys [:namespace-definitions
                   :namespace-usages
                   :var-definitions

--- a/analysis/src/clj_kondo/tools/private_vars.clj
+++ b/analysis/src/clj_kondo/tools/private_vars.clj
@@ -3,11 +3,11 @@
             [clj-kondo.core :as clj-kondo]))
 
 (defn -main [& paths]
-  (let [analysis (:analysis (clj-kondo/run! {:lint paths :config {:output {:analysis true}}}))
+  (let [analysis (:analysis (clj-kondo/run! {:lint paths :config {:analysis true}}))
         {:keys [:var-definitions :var-usages]} analysis
         private-var-defs (->> var-definitions
-                               (filter :private)
-                               (group-by (juxt :ns :name)))
+                              (filter :private)
+                              (group-by (juxt :ns :name)))
         private-var-usages (->> var-usages
                                 (filter (fn [{:keys [:to :name]}]
                                           (contains? private-var-defs [to name])))

--- a/analysis/src/clj_kondo/tools/unused_vars.clj
+++ b/analysis/src/clj_kondo/tools/unused_vars.clj
@@ -7,7 +7,7 @@
   (if (empty? paths)
     (println "Provide paths for analysis.")
     (let [analysis (:analysis (clj-kondo/run! {:lint paths
-                                               :config {:output {:analysis true}}}))
+                                               :config {:analysis true}}))
           {:keys [:var-definitions :var-usages]} analysis
           defined-vars (set (map (juxt :ns :name) var-definitions))
           used-vars (set (map (juxt :to :name) var-usages))

--- a/script/analysis-test
+++ b/script/analysis-test
@@ -4,7 +4,7 @@ echo "Analysis test (emit readable EDN)"
 rm -rf /tmp/kondo-test-analysis
 mkdir -p /tmp/kondo-test-analysis
 
-clojure -M:clj-kondo --config '{:output {:analysis {:locals true :keywords true :arglists true} :format :edn}}' --lint "$(clojure -Spath -A:cljs)" > /tmp/kondo-test-analysis/out.edn
+clojure -M:clj-kondo --config '{:output {:format :edn} :analysis {:locals true :keywords true :arglists true}}' --lint "$(clojure -Spath -A:cljs)" > /tmp/kondo-test-analysis/out.edn
 
 set -eo pipefail
 

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -119,6 +119,7 @@
         files (atom 0)
         findings (atom [])
         analysis-cfg (get-in config [:output :analysis])
+        analyze-var-usages? (get analysis-cfg :var-usages true)
         analyze-locals? (get analysis-cfg :locals)
         analyze-keywords? (get analysis-cfg :keywords)
         analyze-protocol-impls? (get analysis-cfg :protocol-impls)
@@ -132,8 +133,8 @@
                             (not skip-lint))
                    (atom (cond-> {:namespace-definitions []
                                   :namespace-usages []
-                                  :var-definitions []
-                                  :var-usages []}
+                                  :var-definitions []}
+                           analyze-var-usages? (assoc :var-usages [])
                            analyze-locals? (assoc :locals []
                                                   :local-usages [])
                            analyze-keywords? (assoc :keywords [])
@@ -163,6 +164,7 @@
              :used-namespaces used-nss
              :ignores (atom {})
              :id-gen (when analyze-locals? (atom 0))
+             :analyze-var-usages? analyze-var-usages?
              :analyze-locals? analyze-locals?
              :analyze-protocol-impls? analyze-protocol-impls?
              :analyze-keywords? analyze-keywords?

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -18,12 +18,7 @@
   subject to change."
   [{:keys [:config :findings :summary :analysis]}]
   (let [output-cfg (:output config)
-        fmt (or (:format output-cfg) :text)
-        output (cond-> {:findings findings}
-                 (:summary output-cfg)
-                 (assoc :summary summary)
-                 analysis
-                 (assoc :analysis analysis))]
+        fmt (or (:format output-cfg) :text)]
     (case fmt
       :text
       (do
@@ -40,9 +35,19 @@
               (println (format "errors: %s, warnings: %s" error warning))))))
       ;; avoid loading clojure.pprint or bringing in additional libs for printing to EDN for now
       :edn
-      (prn output)
+      (let [output (cond-> {:findings findings}
+                     (:summary output-cfg)
+                     (assoc :summary summary)
+                     analysis
+                     (assoc :analysis analysis))]
+        (prn output))
       :json
-      (println (cheshire/generate-string output))))
+      (println (cheshire/generate-string
+                (cond-> {:findings findings}
+                  (:summary output-cfg)
+                  (assoc :summary summary)
+                  analysis
+                  (assoc :analysis analysis))))))
   (flush)
   nil)
 

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -120,6 +120,7 @@
         findings (atom [])
         analysis-cfg (get-in config [:output :analysis])
         analyze-var-usages? (get analysis-cfg :var-usages true)
+        analyze-var-defs-shallowly? (get-in analysis-cfg [:var-definitions :shallow])
         analyze-locals? (get analysis-cfg :locals)
         analyze-keywords? (get analysis-cfg :keywords)
         analyze-protocol-impls? (get analysis-cfg :protocol-impls)
@@ -174,6 +175,7 @@
              :analysis-var-meta analysis-var-meta
              :analysis-ns-meta analysis-ns-meta
              :analyze-meta? analyze-meta?
+             :analyze-var-defs-shallowly? analyze-var-defs-shallowly?
              :analysis-context analysis-context
              ;; set of files which should not be flushed into cache
              ;; most notably hook configs, as they can conflict with original sources

--- a/src/clj_kondo/impl/analysis/java.clj
+++ b/src/clj_kondo/impl/analysis/java.clj
@@ -47,7 +47,7 @@
   (-> ctx :config ))
 
 (defn analyze-class-defs? [ctx]
-  (:analyze-java-class-defs? ctx))
+  (and (:analysis ctx) (:analyze-java-class-defs? ctx)))
 
 (defn reg-class-def! [ctx {:keys [jar entry file]}]
   (when (analyze-class-defs? ctx)
@@ -67,7 +67,8 @@
                             (str jar ":" entry))}))))
 
 (defn analyze-class-usages? [ctx]
-  (and (:analyze-java-class-usages? ctx)
+  (and (:analysis ctx)
+       (:analyze-java-class-usages? ctx)
        (identical? :clj (:lang ctx))))
 
 (defn reg-class-usage!

--- a/src/clj_kondo/impl/analysis/java.clj
+++ b/src/clj_kondo/impl/analysis/java.clj
@@ -47,7 +47,7 @@
   (-> ctx :config ))
 
 (defn analyze-class-defs? [ctx]
-  (and (:analysis ctx) (:analyze-java-class-defs? ctx)))
+  (:analyze-java-class-defs? ctx))
 
 (defn reg-class-def! [ctx {:keys [jar entry file]}]
   (when (analyze-class-defs? ctx)
@@ -67,8 +67,7 @@
                             (str jar ":" entry))}))))
 
 (defn analyze-class-usages? [ctx]
-  (and (:analysis ctx)
-       (:analyze-java-class-usages? ctx)
+  (and (:analyze-java-class-usages? ctx)
        (identical? :clj (:lang ctx))))
 
 (defn reg-class-usage!

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2603,8 +2603,9 @@
   [{:keys [:base-lang :lang :config] :as ctx}
    expressions]
   (let [init-ns (when-not (= :edn lang)
-                  (analyze-ns-decl (assoc-in ctx
-                                             [:config :output :analysis] false)
+                  (analyze-ns-decl (-> ctx
+                                       (assoc-in [:config :analysis] false)
+                                       (assoc :output-analysis? false))
                                    (parse-string "(ns user)")))
         init-ctx (assoc ctx
                         :ns init-ns

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -424,6 +424,9 @@
         ctx (-> ctx
                 (assoc :fn-args (:children arg-vec))
                 (assoc :body-children-count (count children)))
+        children (if (:analyze-var-defs-shallowly? ctx)
+                   []
+                   children)
         [parsed return-tag]
         (if (or macro? return-tag)
           [(analyze-children ctx children) return-tag]
@@ -1056,6 +1059,9 @@
                                (when (some-> metadata :doc str)
                                  (some docstring/docs-from-meta var-name-node-meta-nodes)))
         ctx (assoc ctx :in-def var-name :def-meta metadata :defmulti? defmulti?)
+        children (if (:analyze-var-defs-shallowly? ctx)
+                   []
+                   children)
         def-init (when (and (or (= 'clojure.core/def defined-by)
                                 (= 'cljs.core/def defined-by))
                             (= 1 (count children)))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2605,7 +2605,7 @@
   (let [init-ns (when-not (= :edn lang)
                   (analyze-ns-decl (-> ctx
                                        (assoc-in [:config :analysis] false)
-                                       (assoc :output-analysis? false))
+                                       (dissoc :analysis))
                                    (parse-string "(ns user)")))
         init-ctx (assoc ctx
                         :ns init-ns

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -501,7 +501,7 @@
              (identical? :cljs lang) (update :qualify-ns
                                              #(assoc % 'cljs.core 'cljs.core
                                                      'clojure.core 'cljs.core)))]
-    (when (-> ctx :config :output :analysis)
+    (when (:output-analysis? ctx)
       (when (java/analyze-class-usages? ctx)
         (doseq [[k v] imports]
           (java/reg-class-usage! ctx (str v "." k) (assoc (meta k) :import true))))
@@ -558,7 +558,7 @@
     (let [analyzed
           (analyze-require-clauses ctx ns-name [[require-node libspecs]])]
       (namespace/reg-required-namespaces! ctx ns-name analyzed)
-      (when (-> ctx :config :output :analysis)
+      (when (:output-analysis? ctx)
         (doseq [req (:required analyzed)]
           (let [{:keys [row col end-row end-col alias]} (meta req)
                 meta-alias (meta alias)]

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -501,7 +501,7 @@
              (identical? :cljs lang) (update :qualify-ns
                                              #(assoc % 'cljs.core 'cljs.core
                                                      'clojure.core 'cljs.core)))]
-    (when (:output-analysis? ctx)
+    (when (:analysis ctx)
       (when (java/analyze-class-usages? ctx)
         (doseq [[k v] imports]
           (java/reg-class-usage! ctx (str v "." k) (assoc (meta k) :import true))))
@@ -558,7 +558,7 @@
     (let [analyzed
           (analyze-require-clauses ctx ns-name [[require-node libspecs]])]
       (namespace/reg-required-namespaces! ctx ns-name analyzed)
-      (when (:output-analysis? ctx)
+      (when (:analysis ctx)
         (doseq [req (:required analyzed)]
           (let [{:keys [row col end-row end-col alias]} (meta req)
                 meta-alias (meta alias)]

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -172,20 +172,21 @@
                                    m)
                                opt-expr-children (:children opt-expr)]
                            (run! #(utils/handle-ignore ctx %) opt-expr-children)
-                           (run! #(namespace/reg-var-usage! ctx current-ns-name
-                                                            (let [m (meta %)]
-                                                              (assoc m
-                                                                     :type :use
-                                                                     :name (with-meta (sexpr %) m)
-                                                                     :resolved-ns ns-name
-                                                                     :ns current-ns-name
-                                                                     :refer true
-                                                                     :lang lang
-                                                                     :base-lang base-lang
-                                                                     :filename filename
-                                                                     :config config
-                                                                     :expr %)))
-                                 opt-expr-children)
+                           (when (:analyze-var-usages? ctx)
+                             (run! #(namespace/reg-var-usage! ctx current-ns-name
+                                                              (let [m (meta %)]
+                                                                (assoc m
+                                                                       :type :use
+                                                                       :name (with-meta (sexpr %) m)
+                                                                       :resolved-ns ns-name
+                                                                       :ns current-ns-name
+                                                                       :refer true
+                                                                       :lang lang
+                                                                       :base-lang base-lang
+                                                                       :filename filename
+                                                                       :config config
+                                                                       :expr %)))
+                                   opt-expr-children))
                            (swap! (:used-namespaces ctx) update (:base-lang ctx) conj ns-name)
                            (update m :referred into
                                    (map #(with-meta (sexpr %)

--- a/src/clj_kondo/impl/analyzer/re_frame.clj
+++ b/src/clj_kondo/impl/analyzer/re_frame.clj
@@ -148,13 +148,11 @@
 (comment
   (require '[clj-kondo.core :as clj-kondo])
   (-> (with-in-str "(require '[re-frame.core :as re-frame]) (re-frame/reg-sub ::foo (fn [_]))"
-        (clj-kondo/run! {:lang :cljs :lint ["-"] :config {:output {:analysis {:context true
-                                                                              :keywords true}}}}))
+        (clj-kondo/run! {:lang :cljs :lint ["-"] :config {:analysis {:context true
+                                                                     :keywords true}}}))
       :analysis :keywords)
 
   (-> (with-in-str "(require '[re-frame.core :as re-frame]) (re-frame/reg-sub ::foo (fn [x] (inc x)))"
-        (clj-kondo/run! {:lang :cljs :lint ["-"] :config {:output {:analysis {:context true
-                                                                              :keywords true}}}}))
-      :analysis :var-usages)
-
-  )
+        (clj-kondo/run! {:lang :cljs :lint ["-"] :config {:analysis {:context true
+                                                                     :keywords true}}}))
+      :analysis :var-usages))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -200,39 +200,40 @@
                        (namespace/reg-used-namespace! ctx
                                                       ns-name
                                                       resolved-ns)
-                       (namespace/reg-var-usage! ctx ns-name
-                                                 {:type :use
-                                                  :name (with-meta
-                                                          resolved-name
-                                                          m)
-                                                  :resolved-ns resolved-ns
-                                                  :ns ns-name
-                                                  :alias resolved-alias
-                                                  :defmethod (:defmethod ctx)
-                                                  :unresolved? unresolved?
-                                                  :clojure-excluded? clojure-excluded?
-                                                  :row row
-                                                  :end-row end-row
-                                                  :col col
-                                                  :end-col end-col
-                                                  :base-lang (:base-lang ctx)
-                                                  :lang (:lang ctx)
-                                                  :top-ns (:top-ns ctx)
-                                                  :filename (:filename ctx)
-                                                  :unresolved-symbol-disabled?
-                                                  (or syntax-quote?
-                                                      ;; e.g. usage of clojure.core, clojure.string, etc in (:require [...])
-                                                      (= symbol-val (get (:qualify-ns ns) symbol-val)))
-                                                  :private-access? (or syntax-quote? (:private-access? ctx))
-                                                  :callstack (:callstack ctx)
-                                                  :config (:config ctx)
-                                                  :in-def (:in-def ctx)
-                                                  :context (:context ctx)
-                                                  :simple? simple?
-                                                  :interop? interop?
-                                                  ;; save some memory
-                                                  :expr (when-not dependencies expr)
-                                                  :resolved-core? resolved-core?})))))
+                       (when (:analyze-var-usages? ctx)
+                         (namespace/reg-var-usage! ctx ns-name
+                                                   {:type :use
+                                                    :name (with-meta
+                                                            resolved-name
+                                                            m)
+                                                    :resolved-ns resolved-ns
+                                                    :ns ns-name
+                                                    :alias resolved-alias
+                                                    :defmethod (:defmethod ctx)
+                                                    :unresolved? unresolved?
+                                                    :clojure-excluded? clojure-excluded?
+                                                    :row row
+                                                    :end-row end-row
+                                                    :col col
+                                                    :end-col end-col
+                                                    :base-lang (:base-lang ctx)
+                                                    :lang (:lang ctx)
+                                                    :top-ns (:top-ns ctx)
+                                                    :filename (:filename ctx)
+                                                    :unresolved-symbol-disabled?
+                                                    (or syntax-quote?
+                                                        ;; e.g. usage of clojure.core, clojure.string, etc in (:require [...])
+                                                        (= symbol-val (get (:qualify-ns ns) symbol-val)))
+                                                    :private-access? (or syntax-quote? (:private-access? ctx))
+                                                    :callstack (:callstack ctx)
+                                                    :config (:config ctx)
+                                                    :in-def (:in-def ctx)
+                                                    :context (:context ctx)
+                                                    :simple? simple?
+                                                    :interop? interop?
+                                                    ;; save some memory
+                                                    :expr (when-not dependencies expr)
+                                                    :resolved-core? resolved-core?}))))))
                (do
                  ;; (prn (type (utils/sexpr expr)) (:callstack ctx) (:len ctx) (:idx ctx))
                  (when-let [idx (:idx ctx)]

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -134,10 +134,9 @@
               compojure.core/defroutes clojure.core/def
               compojure.core/let-routes clojure.core/let}
     ;; :auto-load-configs true
-    :output {:format :text ;; or :edn
-             :summary true ;; outputs summary at end, only applicable to output :text
-             ;; outputs analyzed var definitions and usages of them
-             :analysis false
+    ;; :analysis ;; what to analyze and whether to output it
+    :output {:format :text ;; or :edn, or :json
+             :summary true ;; include summary in output
              ;; set to truthy to print progress while linting, only applicable to output :text
              :progress false
              ;; output can be filtered and removed by regex on filename. empty options leave the output untouched.

--- a/src/clj_kondo/impl/findings.clj
+++ b/src/clj_kondo/impl/findings.clj
@@ -51,11 +51,12 @@
   [ctx m]
   (let [dependencies (:dependencies ctx)
         findings (:findings ctx)
+        skip-lint? (:skip-lint ctx)
         config (:config ctx)
         tp (:type m)
         level (or (:level m)
                   (-> config :linters tp :level))]
-    (when (and level (not (identical? :off level)) (not dependencies))
+    (when (and level (not (identical? :off level)) (not dependencies) (not skip-lint?))
       (when-not (ignored? ctx m tp)
         (let [m (assoc m :level level)]
           (swap! findings conj m)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -297,7 +297,7 @@
                   recursive? (and
                               (= fn-ns caller-ns-sym)
                               (= fn-name in-def))
-                  _ (when (:output-analysis? ctx)
+                  _ (when (:analysis ctx)
                       (when-not (:interop? call)
                         (analysis/reg-usage! (assoc ctx :context (:context call))
                                              filename

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -204,7 +204,6 @@
   to call-specific linters."
   [ctx idacs]
   (let [config (:config ctx)
-        output-analysis? (-> config :output :analysis)
         linted-namespaces (:linted-namespaces idacs)]
     ;; (prn :from-cache from-cache)
     (doseq [ns (namespace/list-namespaces ctx)
@@ -298,7 +297,7 @@
                   recursive? (and
                               (= fn-ns caller-ns-sym)
                               (= fn-name in-def))
-                  _ (when output-analysis?
+                  _ (when (:output-analysis? ctx)
                       (when-not (:interop? call)
                         (analysis/reg-usage! (assoc ctx :context (:context call))
                                              filename

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -115,7 +115,7 @@
          path [base-lang lang ns-sym]
          temp? (:temp metadata)
          config (:config ctx)]
-     (when (and (:output-analysis? ctx)
+     (when (and (:analysis ctx)
                 (not temp?))
        (analysis/reg-var! ctx filename expr-row expr-col
                           ns-sym var-sym

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -115,7 +115,7 @@
          path [base-lang lang ns-sym]
          temp? (:temp metadata)
          config (:config ctx)]
-     (when (and (-> config :output :analysis)
+     (when (and (:output-analysis? ctx)
                 (not temp?))
        (analysis/reg-var! ctx filename expr-row expr-col
                           ns-sym var-sym

--- a/test/clj_kondo/analysis/java_test.clj
+++ b/test/clj_kondo/analysis/java_test.clj
@@ -14,9 +14,9 @@
    (:analysis
     (clj-kondo/run! (merge
                      {:lint paths
-                      :config {:output {:canonical-paths true
-                                        :analysis {:java-class-definitions true
-                                                   :java-class-usages true}}}}
+                      :config {:output {:canonical-paths true}
+                               :analysis {:java-class-definitions true
+                                          :java-class-usages true}}}
                      config)))))
 
 (deftest jar-classes-test

--- a/test/clj_kondo/analysis/keywords_test.clj
+++ b/test/clj_kondo/analysis/keywords_test.clj
@@ -11,14 +11,14 @@
    (:analysis
     (with-in-str code
       (clj-kondo/run! (merge {:lint ["-"]
-                              :config {:output {:canonical-paths true
-                                                :analysis {:keywords true}}}}
+                              :config {:output {:canonical-paths true}
+                                       :analysis {:keywords true}}}
                              config))))))
 
 (deftest keyword-analysis-test
   (testing "standalone keywords with top-level require"
     (let [a (analyze "(require '[bar :as b]) :kw :x/xkwa ::x/xkwb ::fookwa :foo/fookwb ::foo/fookwc :bar/barkwa ::b/barkwb ::bar/barkwc"
-                     {:config {:output {:analysis {:keywords true}}}})]
+                     {:config {:analysis {:keywords true}}})]
       (assert-submaps
        '[{:name "as"}
          {:name "kw"}
@@ -33,7 +33,7 @@
        (:keywords a))))
   (testing "standalone keywords"
     (let [a (analyze "(ns foo (:require [bar :as b])) :kw :2foo :x/xkwa ::x/xkwb ::fookwa :foo/fookwb ::foo/fookwc :bar/barkwa ::b/barkwb ::bar/barkwc"
-                     {:config {:output {:analysis {:keywords true}}}})]
+                     {:config {:analysis {:keywords true}}})]
       (assert-submaps
        '[{:name "require"}
          {:name "as"}
@@ -55,7 +55,7 @@
                           "       :bar/keys [e :f]\n"
                           "       :keys [g :h ::i :foo/j :bar/k ::b/l ::bar/m :x/n ::y/o foo/j]\n"
                           "       p :p q ::q r ::b/r s :bar/s t :x/t} {}])")
-                     {:config {:output {:analysis {:keywords true}}}})]
+                     {:config {:analysis {:keywords true}}})]
       (assert-submaps
        '[{:name "require"}
          {:name "as"}
@@ -87,7 +87,7 @@
        (:keywords a))))
   (testing "clojure.spec.alpha/def can add :reg"
     (let [a (analyze "(require '[clojure.spec.alpha :as s]) (s/def ::kw (inc))"
-                     {:config {:output {:analysis {:keywords true}}}})]
+                     {:config {:analysis {:keywords true}}})]
       (assert-submaps
        '[{:name "as"}
          {:name "kw" :reg clojure.spec.alpha/def}]
@@ -101,7 +101,7 @@
                       (rf/reg-sub-raw ::e (constantly {}))
                       (rf/reg-fx ::f (constantly {}))
                       (rf/reg-cofx ::g (constantly {}))"
-                     {:config {:output {:analysis {:keywords true}}}})]
+                     {:config {:analysis {:keywords true}}})]
       (assert-submaps
        '[{:name "as"}
          {:name "a" :reg re-frame.core/reg-event-db}
@@ -114,14 +114,14 @@
        (:keywords a))))
   (testing ":lint-as re-frame.core function will add :reg with the source full qualified ns"
     (let [a (analyze "(user/mydef ::kw (constantly {}))"
-                     {:config {:output {:analysis {:keywords true}}
+                     {:config {:analysis {:keywords true}
                                :lint-as '{user/mydef re-frame.core/reg-event-fx}}})]
       (assert-submaps
        '[{:name "kw" :reg user/mydef}]
        (:keywords a))))
   (testing "hooks can add :reg"
     (let [a (analyze "(user/mydef ::kw (inc))"
-                     {:config {:output {:analysis {:keywords true}}
+                     {:config {:analysis {:keywords true}
                                :hooks {:__dangerously-allow-string-hooks__ true
                                        :analyze-call
                                        {'user/mydef
@@ -139,13 +139,13 @@
     (let [a (analyze "(ns foo (:require [clojure.data.xml :as xml]))
                       (xml/alias-uri 'pom \"http://maven.apache.org/POM/4.0.0\")
                       ::pom/foo"
-                     {:config {:output {:analysis {:keywords true}}}})]
+                     {:config {:analysis {:keywords true}}})]
       (is (edn/read-string (str a)))))
   (testing "namespaced maps"
     (testing "auto-resolved namespace"
       (let [a (analyze "(ns foo (:require [clojure.data.xml :as xml]))
                       #::xml{:a 1}"
-                       {:config {:output {:analysis {:keywords true}}}})]
+                       {:config {:analysis {:keywords true}}})]
         (assert-submaps
          '[{:name "require"}
            {:name "as"}
@@ -154,7 +154,7 @@
     (testing "non-autoresolved namespace"
       (let [a (analyze "(ns foo (:require [clojure.data.xml :as xml]))
                       #:xml{:a 1}"
-                       {:config {:output {:analysis {:keywords true}}}})]
+                       {:config {:analysis {:keywords true}}})]
         (assert-submaps
          '[{:name "require"}
            {:name "as"}
@@ -163,13 +163,13 @@
     ;; Don't use assertmap here to make sure ns is absent
     (testing "no namespace for key :a"
       (let [a (analyze "#:xml{:_/a 1}"
-                       {:config {:output {:analysis {:keywords true}}}})]
+                       {:config {:analysis {:keywords true}}})]
         (is (= '[{:row 1, :col 7, :end-row 1, :end-col 11, :name "a", :filename "<stdin>" :from user}]
                (:keywords a)))))
     ;; Don't use assertmap here to make sure ns is absent
     (testing "no namespace for key :b"
       (let [a (analyze "#:xml{:a {:b 1}}"
-                       {:config {:output {:analysis {:keywords true}}}})]
+                       {:config {:analysis {:keywords true}}})]
         (is (= '[{:row 1, :col 7, :end-row 1, :end-col 9, :ns xml, :name "a", :filename "<stdin>" :namespace-from-prefix true :from user}
                  {:row 1, :col 11, :end-row 1, :end-col 13, :name "b", :filename "<stdin>" :from user}]
                (:keywords a)))))
@@ -179,7 +179,7 @@
                         #:d{:e 1 :_/f 2 :g/h 3 ::i 4}
                         {:j/k 5 :l 6 ::m 7}
                         #::set{:a 1}"
-                       {:config {:output {:analysis {:keywords true}}}})]
+                       {:config {:analysis {:keywords true}}})]
         (assert-submaps
          '[{:name "require"}
            {:name "as"}

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -15,13 +15,13 @@
       input
       (clj-kondo/run! (merge
                        {:lint ["-"]
-                        :config {:output {:analysis true}}}
+                        :config {:analysis true}}
                        config))))))
 
 (deftest locals-analysis-test
-  (let [a (analyze "#(inc %1 %&)" {:config {:output {:analysis {:locals true}}}})]
+  (let [a (analyze "#(inc %1 %&)" {:config {:analysis {:locals true}}})]
     (is (= [] (:locals a) (:local-usages a))))
-  (let [a (analyze "(areduce [] i j 0 (+ i j))" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(areduce [] i j 0 (+ i j))" {:config {:analysis {:locals true}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -30,7 +30,7 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(defn x [a] (let [a a] a) a)" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(defn x [a] (let [a a] a) a)" {:config {:analysis {:locals true}}})
         [first-a second-a] (:locals a)
         [first-use second-use third-use] (:local-usages a)]
     (assert-submaps
@@ -39,7 +39,7 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use) (:id third-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(defn x ([a] a) ([b c] (+ b c)))" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(defn x ([a] a) ([b c] (+ b c)))" {:config {:analysis {:locals true}}})
         [first-a first-b first-c] (:locals a)
         [a-use b-use c-use] (:local-usages a)]
     (assert-submaps
@@ -50,14 +50,14 @@
     (is (= (:id first-a) (:id a-use)))
     (is (= (:id first-b) (:id b-use)))
     (is (= (:id first-c) (:id c-use))))
-  (let [a (analyze "(as-> {} $ $)" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(as-> {} $ $)" {:config {:analysis {:locals true}}})
         [first-a] (:locals a)
         [first-use] (:local-usages a)]
     (assert-submaps
      [{:end-col 11 :scope-end-col 14}]
      (:locals a))
     (is (= (:id first-a) (:id first-use))))
-  (let [a (analyze "(letfn [(a [b] b)] a)" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(letfn [(a [b] b)] a)" {:config {:analysis {:locals true}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -66,7 +66,7 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(letfn [(a ([b] b) ([c d] (+ c d)))] a)" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(letfn [(a ([b] b) ([c d] (+ c d)))] a)" {:config {:analysis {:locals true}}})
         [first-a first-b first-c first-d] (:locals a)
         [first-use second-use third-use fourth-use] (:local-usages a)]
     (assert-submaps
@@ -79,7 +79,7 @@
     (is (= (:id first-b) (:id second-use)))
     (is (= (:id first-c) (:id third-use)))
     (is (= (:id first-d) (:id fourth-use))))
-  (let [a (analyze "(let [a 0] (let [a a] a))" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(let [a 0] (let [a a] a))" {:config {:analysis {:locals true}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -88,7 +88,7 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(let [a 0 a a] a)" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(let [a 0 a a] a)" {:config {:analysis {:locals true}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -97,7 +97,7 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use))))
-  (let [a (analyze "(if-let [a 0] a a)" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(if-let [a 0] a a)" {:config {:analysis {:locals true}}})
         [first-a second-a] (:locals a)
         [first-use second-use] (:local-usages a)]
     (assert-submaps
@@ -105,7 +105,7 @@
      (:locals a))
     (is (= (:id first-a) (:id first-use)))
     (is (= nil second-a second-use)))
-  (let [a (analyze "(for [a [123] :let [a a] :when a] a)" {:config {:output {:analysis {:locals true}}}})
+  (let [a (analyze "(for [a [123] :let [a a] :when a] a)" {:config {:analysis {:locals true}}})
         [first-a second-a] (:locals a)
         [first-use second-use third-use] (:local-usages a)]
     (assert-submaps
@@ -116,7 +116,7 @@
     (is (= (:id first-a) (:id first-use)))
     (is (= (:id second-a) (:id second-use) (:id third-use))))
   (testing "local usages are reported with correct positions"
-    (let [ana (analyze "(let [x (set 1 2 3)] (+ x 1))" {:config {:output {:analysis {:locals true}}}})
+    (let [ana (analyze "(let [x (set 1 2 3)] (+ x 1))" {:config {:analysis {:locals true}}})
           [x] (:locals ana)]
       (assert-submaps
        [{:row 1, :col 25,
@@ -128,7 +128,7 @@
          :id 1}]
        (:local-usages ana))))
   (testing "Names are reported in binding usages when called as fn"
-    (let [ana (analyze "(let [x #(set 1 2 3)] (x 1))" {:config {:output {:analysis {:locals true}}}})
+    (let [ana (analyze "(let [x #(set 1 2 3)] (x 1))" {:config {:analysis {:locals true}}})
           [x] (:locals ana)]
       (assert-submaps
        [{:row 1, :col 23,
@@ -140,17 +140,17 @@
          :id 1}]
        (:local-usages ana))))
   (testing "generated nodes should not be included on analysis"
-    (let [ana (analyze "(cond-> {:a 1 :b 2} true (merge {}))" {:config {:output {:analysis {:locals true}}}})]
+    (let [ana (analyze "(cond-> {:a 1 :b 2} true (merge {}))" {:config {:analysis {:locals true}}})]
       (is (empty? (:locals ana)))
       (is (empty? (:local-usages ana))))
-    (let [ana (analyze "(doto {:a 1 :b 2} (merge {}))" {:config {:output {:analysis {:locals true}}}})]
+    (let [ana (analyze "(doto {:a 1 :b 2} (merge {}))" {:config {:analysis {:locals true}}})]
       (is (empty? (:locals ana)))
       (is (empty? (:local-usages ana))))))
 
 (deftest deftype-locals-test
   (let [{:keys [:locals :local-usages]}
         (analyze "(deftype Foo [a b c] clojure.lang.IFn (invoke [_] [a b]))"
-                 {:config {:output {:analysis {:locals true}}}})]
+                 {:config {:analysis {:locals true}}})]
     ;; (clj-kondo.impl.utils/stderr :locals (pr-str locals))
     (assert-submaps '[{:end-row 1, :scope-end-row 1, :name a, :scope-end-col 58, :filename "<stdin>", :str "a", :col 15, :id 1, :end-col 16, :row 1}
                       {:end-row 1, :scope-end-row 1, :name b, :scope-end-col 58, :filename "<stdin>", :str "b", :col 17, :id 2, :end-col 18, :row 1} {:end-row 1, :scope-end-row 1, :name c, :scope-end-col 58, :filename "<stdin>", :str "c", :col 19, :id 3, :end-col 20, :row 1}
@@ -169,7 +169,7 @@
 
   (^Bla other-thing [_ a b]
     456
-    789))" {:config {:output {:analysis {:protocol-impls true}}}})]
+    789))" {:config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        []
        protocol-impls)))
@@ -196,7 +196,7 @@
     123)
   (^Bla d-method [_ a b]
     456
-    789))" {:config {:output {:analysis {:protocol-impls true}}}})]
+    789))" {:config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        '[{:protocol-name AProtocol
           :protocol-ns user
@@ -247,7 +247,7 @@
                          "    456"
                          "    789))"]
                         (string/join "\n"))
-                   {:config {:output {:analysis {:protocol-impls true}}}})]
+                   {:config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        '[{:protocol-name AProtocol
           :protocol-ns some-ns
@@ -289,7 +289,7 @@
     123)
   (^Bla d-method [_ a b]
     456
-    789))" {:config {:output {:analysis {:protocol-impls true}}}})]
+    789))" {:config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        '[{:protocol-name AProtocol
           :protocol-ns user
@@ -346,7 +346,7 @@
     123)
   (^Bla b-method [_ a b]
     456
-    789))" {:config {:output {:analysis {:protocol-impls true}}}})]
+    789))" {:config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        '[{:protocol-name AProtocol
           :protocol-ns user
@@ -406,7 +406,7 @@
     123)
   (^Bla d-method [_ a b]
     456
-    789))" {:config {:output {:analysis {:protocol-impls true}}}})]
+    789))" {:config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        '[{:protocol-name AProtocol
           :protocol-ns user
@@ -464,7 +464,7 @@
     123)
   (^Bla d-method [_ a b]
     456
-    789))" {:config {:output {:analysis {:protocol-impls true}}}})]
+    789))" {:config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        '[{:protocol-name AProtocol
           :protocol-ns user
@@ -524,7 +524,7 @@
     123)
   (^Bla d-method [_ a b]
     456
-    789))" {:lang :cljs, :config {:output {:analysis {:protocol-impls true}}}})]
+    789))" {:lang :cljs, :config {:analysis {:protocol-impls true}}})]
       (assert-submaps
        '[{:protocol-name AProtocol
           :protocol-ns user
@@ -567,35 +567,35 @@
 ​
 (defmethod my-multi :some-value
   [_]
-  :bar)" {:config {:output {:analysis true}}})]
+  :bar)" {:config {:analysis true}})]
       (assert-submaps
-        '[{:name my-multi
-           :defined-by clojure.core/defmulti
-           :ns user
-           :name-row 2 :name-col 11 :name-end-row 2 :name-end-col 19
-           :row 2 :col 1 :end-row 2 :end-col 30}]
-        var-definitions)
+       '[{:name my-multi
+          :defined-by clojure.core/defmulti
+          :ns user
+          :name-row 2 :name-col 11 :name-end-row 2 :name-end-col 19
+          :row 2 :col 1 :end-row 2 :end-col 30}]
+       var-definitions)
       (assert-submaps
-        '[{:name defmulti}
-          {}
-          {:name defmethod}
-          {:name my-multi
-           :from user
-           :to user
-           :defmethod true
-           :name-row 4 :name-col 12 :name-end-row 4 :name-end-col 20
-           :row 4 :col 12 :end-row 4 :end-col 20}]
-        var-usages))))
+       '[{:name defmulti}
+         {}
+         {:name defmethod}
+         {:name my-multi
+          :from user
+          :to user
+          :defmethod true
+          :name-row 4 :name-col 12 :name-end-row 4 :name-end-col 20
+          :row 4 :col 12 :end-row 4 :end-col 20}]
+       var-usages))))
 
 (deftest name-position-test
-  (let [{:keys [:var-definitions :var-usages]} (analyze "(defn foo [] foo)" {:config {:output {:analysis {:locals true}}}})]
+  (let [{:keys [:var-definitions :var-usages]} (analyze "(defn foo [] foo)" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name foo :name-row 1 :name-col 7 :name-end-row 1 :name-end-col 10 :end-row 1 :end-col 18}]
      var-definitions)
     (assert-submaps
      '[{:name foo :name-row 1 :name-col 14 :name-end-row 1 :name-end-col 17} {}]
      var-usages))
-  (let [{:keys [:var-definitions :var-usages]} (analyze "(defprotocol Foo (bar [])) Foo bar" {:config {:output {:analysis {:locals true}}}})]
+  (let [{:keys [:var-definitions :var-usages]} (analyze "(defprotocol Foo (bar [])) Foo bar" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name Foo :name-row 1 :name-col 14 :name-end-row 1 :name-end-col 17 :end-row 1 :end-col 27}
        {:name bar :name-row 1 :name-col 19 :name-end-row 1 :name-end-col 22 :end-row 1 :end-col 27}]
@@ -613,7 +613,7 @@
         :name-row 1,
         :name-col 32}]
      var-usages))
-  (let [{:keys [:namespace-definitions :namespace-usages]} (analyze "(ns foo (:require [bar :as b :refer [x]] [clojure [string :as str]]))" {:config {:output {:analysis {:locals true}}}})]
+  (let [{:keys [:namespace-definitions :namespace-usages]} (analyze "(ns foo (:require [bar :as b :refer [x]] [clojure [string :as str]]))" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name foo
         :row 1,
@@ -645,7 +645,7 @@
         :name-end-row 1
         :name-end-col 58}]
      namespace-usages))
-  (let [{:keys [:var-definitions :var-usages]} (analyze "(def a (atom nil)) (:foo @a)" {:config {:output {:analysis {:locals true}}}})]
+  (let [{:keys [:var-definitions :var-usages]} (analyze "(def a (atom nil)) (:foo @a)" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name-row 1 :name-col 6 :name-end-row 1 :name-end-col 7 :end-row 1 :end-col 19}]
      var-definitions)
@@ -655,7 +655,7 @@
 
 (deftest scope-usage-test
   (testing "when the var-usage is called as function"
-    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (foo 2)" {:config {:output {:analysis true}}})]
+    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (foo 2)" {:config {:analysis true}})]
       (is (some #(= % '{:fixed-arities #{1}
                         :name-end-col 22
                         :name-end-row 1
@@ -672,7 +672,7 @@
                         :to user})
                 var-usages))))
   (testing "when the var-usage is not called as function"
-    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) foo" {:config {:output {:analysis true}}})]
+    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) foo" {:config {:analysis true}})]
       (is (some #(= % '{:fixed-arities #{1}
                         :name-end-col 21
                         :name-end-row 1
@@ -688,7 +688,7 @@
                         :to user})
                 var-usages))))
   (testing "when the var-usage call is unknown"
-    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (bar 2)" {:config {:output {:analysis true}}})]
+    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (bar 2)" {:config {:analysis true}})]
       (is (some #(= % '{:name-end-row 1
                         :name-end-col 22
                         :name-row 1
@@ -909,7 +909,7 @@
         (analyze "(ns foo)
                   (defn foo [x] x)
                   (def bar foo)"
-                 {:config {:output {:analysis {:var-usages false}}}})]
+                 {:config {:analysis {:var-usages false}}})]
     (assert-submaps
      '[]
      var-usages))
@@ -918,7 +918,7 @@
         (analyze "(ns foo)
                   (defn foo [x] (inc x))
                   (def bar foo)"
-                 {:config {:output {:analysis {:var-definitions {:shallow true}}}}})]
+                 {:config {:analysis {:var-definitions {:shallow true}}}})]
     (assert-submaps ;; var definitions are analyzed
      '[{:fixed-arities #{1},
         :ns foo,
@@ -942,7 +942,7 @@
       :defined-by user/defflow}]
    (:var-definitions
     (analyze "(user/defflow foobar)"
-             {:config {:output {:analysis {:keywords true}}
+             {:config {:analysis {:keywords true}
                        :hooks {:__dangerously-allow-string-hooks__ true
                                :analyze-call
                                {'user/defflow
@@ -977,7 +977,7 @@
                     (defprotocol A (f3 [g] \"doc\") (f4 [h] [i i']))
                     (defrecord A [j k])
                     (defmacro f5 [l m])"
-                   {:config {:output {:analysis {:arglists true}}}})]
+                   {:config {:analysis {:arglists true}}})]
       (assert-submaps
        '[{:name f1,
           :defined-by clojure.core/defn
@@ -1118,10 +1118,9 @@
 (defn- ana-var-meta [s cfg]
   (-> (with-in-str s
         (clj-kondo/run! {:lint ["-"] :config
-                         {:output
-                          {:analysis
-                           {:var-definitions
-                            cfg}}}}))
+                         {:analysis
+                          {:var-definitions
+                           cfg}}}))
       :analysis :var-definitions first))
 
 (defn- ana-def-expected [m]
@@ -1155,8 +1154,7 @@
                                 :name-end-col 24})
              (-> (with-in-str "(def ^:no-doc ^:other x true)"
                    (clj-kondo/run! {:lint ["-"] :config
-                                    {:output
-                                     {:analysis true}}}))
+                                    {:analysis true}}))
                  :analysis :var-definitions first))))
     (testing "we don't clobber :user-meta"
       (is (= (ana-def-expected {:meta {:user-meta :foo-bar}
@@ -1332,10 +1330,9 @@
 (defn- ana-ns-meta [s cfg]
   (-> (with-in-str s
         (clj-kondo/run! {:lint ["-"] :config
-                         {:output
-                          {:analysis
-                           {:namespace-definitions
-                            cfg}}}}))
+                         {:analysis
+                          {:namespace-definitions
+                           cfg}}}))
       :analysis :namespace-definitions first))
 
 (defn- ana-ns-expected [m]
@@ -1432,8 +1429,7 @@
                              :end-col 49})
            (-> (with-in-str "(ns ^:my-meta1 ^:my-meta2 ^:my-meta3 my.ns.here)"
                  (clj-kondo/run! {:lint ["-"] :config
-                                  {:output
-                                   {:analysis true}}}))
+                                  {:analysis true}}))
                :analysis :namespace-definitions first)))))
 
 (deftest derived-doc
@@ -1544,8 +1540,8 @@
 (re-frame/reg-event-db ::bar (fn [x] (dec x)))
 "
                              (clj-kondo/run! {:lang :cljs :lint ["-"] :config
-                                              {:output {:analysis {:context [:re-frame.core]
-                                                                   :keywords true}}}}))
+                                              {:analysis {:context [:re-frame.core]
+                                                          :keywords true}}}))
                            :analysis)
               usages (:var-usages analysis)
               keywords (:keywords analysis)
@@ -1558,9 +1554,9 @@
               foo-def-usage (some #(when (= 'foo-def (:name %)) %) usages)
               foo-def-re-frame-id (-> foo-def-usage :context :re-frame.core :in-id)
               foo-def-k (some (fn [k]
-                            (when (some-> k :context :re-frame.core :id (= foo-def-re-frame-id))
-                              k))
-                          keywords)
+                                (when (some-> k :context :re-frame.core :id (= foo-def-re-frame-id))
+                                  k))
+                              keywords)
               dec-usage (some #(when (= 'dec (:name %)) %) usages)
               dec-re-frame-id (-> dec-usage :context :re-frame.core :in-id)
               dec-k (some (fn [k]
@@ -1599,8 +1595,8 @@
 (defn barfn [] @(rf/subscribe [:a]))
 "
                          (clj-kondo/run! {:lang :cljs :lint ["-"] :config
-                                          {:output {:analysis {:context [:re-frame.core]
-                                                               :keywords true}}}}))
+                                          {:analysis {:context [:re-frame.core]
+                                                      :keywords true}}}))
                        :analysis)
           usages (:var-usages analysis)
           keywords (:keywords analysis)
@@ -1664,7 +1660,7 @@
   foo/my-other)
 "
                            (clj-kondo/run! {:lang :clj :lint ["-"] :config
-                                            {:output {:analysis true}}}))
+                                            {:analysis true}}))
                          :analysis)
             usages (:var-usages analysis)
             my-func-usage (some #(when (= 'my-func (:name %)) %) usages)
@@ -1729,7 +1725,7 @@
        my-other])
 "
                            (clj-kondo/run! {:lang :clj :lint ["-"] :config
-                                            {:output {:analysis true}}}))
+                                            {:analysis true}}))
                          :analysis)
             usages (:var-usages analysis)
             my-func-usage (some #(when (= 'my-func (:name %)) %) usages)
@@ -1786,7 +1782,7 @@
 
 (deftest re-frame-dispatch-reg-event-fx-test
   (let [analysis (:analysis (with-in-str
-"(ns foo (:require [re-frame.core :as rf]))
+                              "(ns foo (:require [re-frame.core :as rf]))
 (rf/reg-event-db :foo (fn [db [_ arg1]] (dissoc db arg1)))
 (rf/reg-event-db :other-foo (fn [db [_ arg1 arg2]] (assoc db arg1 arg2)))
 
@@ -1797,8 +1793,8 @@
 (rf/reg-event-fx :later-dispatch (fn [{:keys [db]} [_ arg1]] {:fx [[:dispatch-later {:ms 10 :dispatch [:foo (:bar arg1)]}]]}))
 (rf/reg-event-fx :multiple-dispatch (fn [{:keys [db]} [_ arg1 arg2]] {:fx [[:dispatch-n [[:foo (:bar arg1)] [:other-foo arg1 arg2]]]]}))"
                               (clj-kondo/run! {:lang :cljs :lint ["-"] :config
-                                               {:output {:analysis {:context [:re-frame.core]
-                                                                    :keywords true}}}})))
+                                               {:analysis {:context [:re-frame.core]
+                                                           :keywords true}}})))
         keywords (:keywords analysis)
         simple-dispatch-id (some (partial re-frame-id "simple-dispatch") keywords)
         fx-dispatch-id (some (partial re-frame-id "fx-dispatch") keywords)
@@ -1832,21 +1828,21 @@
                             (= multiple-dispatch-id (-> % :context :re-frame.core :in-id))
                             (some-> % :context :re-frame.core :event-ref)) %) keywords)))
     (testing "keyword used as param in a dispatch not resulting in subscription-ref"
-        (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= simple-dispatch-id))) %) keywords))
-        (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= fx-dispatch-id))) %) keywords))
-        (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= later-dispatch-id))) %) keywords))
-        (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= multiple-dispatch-id))) %) keywords))
-        (is (not-any? #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :event-ref)) %) keywords)))))
+      (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= simple-dispatch-id))) %) keywords))
+      (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= fx-dispatch-id))) %) keywords))
+      (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= later-dispatch-id))) %) keywords))
+      (is (some #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :in-id (= multiple-dispatch-id))) %) keywords))
+      (is (not-any? #(when (and (= "bar" (:name %)) (some-> % :context :re-frame.core :event-ref)) %) keywords)))))
 
 (deftest re-frame-inject-cofx-test
   (let [analysis (:analysis (with-in-str
-"(ns foo (:require [re-frame.core :as rf]))
+                              "(ns foo (:require [re-frame.core :as rf]))
 (rf/reg-cofx :foo (fn [cofx _] (assoc :cofx :bar :goo)))
 (rf/reg-event-fx :use-foo [(rf/inject-cofx :foo)] (fn [{:keys [db bar]}] {:db (assoc db :lolfoo bar)}))
 "
                               (clj-kondo/run! {:lang :cljs :lint ["-"] :config
-                                               {:output {:analysis {:context [:re-frame.core]
-                                                                    :keywords true}}}})))
+                                               {:analysis {:context [:re-frame.core]
+                                                           :keywords true}}})))
         keywords (:keywords analysis)
         foo-cofx-id (some (partial re-frame-id "foo") keywords)
         use-foo-id (some (partial re-frame-id "use-foo") keywords)]

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -904,6 +904,14 @@
         :name bound-fn,
         :from foo,
         :to clojure.core}]
+     var-usages))
+  (let [{:keys [:var-usages]}
+        (analyze "(ns foo)
+                  (defn foo [x] x)
+                  (def bar foo)"
+                 {:config {:output {:analysis {:var-usages false}}}})]
+    (assert-submaps
+     '[]
      var-usages)))
 
 (deftest hooks-custom-defined-by-test

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -912,6 +912,27 @@
                  {:config {:output {:analysis {:var-usages false}}}})]
     (assert-submaps
      '[]
+     var-usages))
+  (let [{:keys [:var-definitions
+                :var-usages]}
+        (analyze "(ns foo)
+                  (defn foo [x] (inc x))
+                  (def bar foo)"
+                 {:config {:output {:analysis {:var-definitions {:shallow true}}}}})]
+    (assert-submaps ;; var definitions are analyzed
+     '[{:fixed-arities #{1},
+        :ns foo,
+        :name foo,
+        :defined-by clojure.core/defn}
+       {:ns foo,
+        :name bar,
+        :defined-by clojure.core/def}]
+     var-definitions)
+    (assert-submaps ;; but their bodies aren't
+     '[{:name defn,
+        :to clojure.core}
+       {:name def,
+        :to clojure.core}]
      var-usages)))
 
 (deftest hooks-custom-defined-by-test

--- a/test/clj_kondo/hooks_test.clj
+++ b/test/clj_kondo/hooks_test.clj
@@ -248,7 +248,7 @@ children))]
                                                  (let [child (second (:children node))
                                                        new-node (assoc child :context {:my-hook {:can-set-context true}})]
                                                    {:node new-node}))"}}
-                         :output {:analysis {:keywords true :context true}}}}))
+                         :analysis {:keywords true :context true}}}))
             {:keys [keywords]} analysis
             a-keyword (some #(when (= "a" (:name %))
                                %) keywords)
@@ -272,7 +272,7 @@ children))]
                                                          new-node (assoc child :context {:my-hook {:can-set-context true}})]
                                                      {:node new-node
                                                       :context {:yolo true}}))"}}
-                         :output {:analysis {:keywords true :context true}}}}))
+                         :analysis {:keywords true :context true}}}))
             {:keys [keywords]} analysis
             a-keyword (some #(when (= "a" (:name %))
                                %) keywords)

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -108,7 +108,7 @@
 
 (deftest analyze-input-test
   (let [analyze (fn [^String source]
-                  (let [ctx {:config {:linters {:syntax {:level :error}} :output {:analysis true :format :edn}}
+                  (let [ctx {:config {:linters {:syntax {:level :error}} :output {:format :edn} :analysis true}
                              :filename "-"
                              :base-lang :clj
                              :lang :clj

--- a/test/clj_kondo/re_frame_test.clj
+++ b/test/clj_kondo/re_frame_test.clj
@@ -20,8 +20,8 @@
               instaparse.core/defparser         clojure.core/def
               athens.common.sentry/defntrace    clojure.core/defn}
     ;; trigger full re-frame analysis to test it for lint regressions
-    :output {:analysis {:context [:re-frame.core]
-                        :keywords true}}})
+    :analysis {:context [:re-frame.core]
+               :keywords true}})
 
 (deftest re-frame-athens-lint-test
   (fs/with-temp-dir [tmp {}]
@@ -56,8 +56,8 @@
                  (clj-kondo/run!
                   {:lang :cljs
                    :lint "-"
-                   :config {:output {:analysis {:context [:re-frame.core]
-                                                :keywords true}}}}))))))
+                   :config {:analysis {:context [:re-frame.core]
+                                       :keywords true}}}))))))
 
 (deftest re-frame-analysis-dispatch-n-w-conditionals-test
   (is (empty? (:findings
@@ -73,8 +73,8 @@
                  (clj-kondo/run!
                   {:lang :cljs
                    :lint "-"
-                   :config {:output {:analysis {:context [:re-frame.core]
-                                                :keywords true}}}}))))))
+                   :config {:analysis {:context [:re-frame.core]
+                                       :keywords true}}}))))))
 
 (deftest subscribe-arguments-are-used-test
   (is (empty? (lint! "

--- a/test/clj_kondo/test_test.clj
+++ b/test/clj_kondo/test_test.clj
@@ -71,18 +71,17 @@
 
 (deftest testing-str-analysis
   (let [usages (filter (comp :clojure.test :context)
-                      (-> (with-in-str
-                            (pr-str
-                             '(do (require '[clojure.test :refer [deftest is testing]])
-                                  (deftest foo
-                                    (testing "everything works correctly"
-                                      (is (= 1 1))))))
-                            (clj-kondo/run! {:lint ["-"]
-                                             :config {:output
-                                                      {:analysis
+                       (-> (with-in-str
+                             (pr-str
+                              '(do (require '[clojure.test :refer [deftest is testing]])
+                                   (deftest foo
+                                     (testing "everything works correctly"
+                                       (is (= 1 1))))))
+                             (clj-kondo/run! {:lint ["-"]
+                                              :config {:analysis
                                                        {:context
-                                                        [:clojure.test]}}}}))
-                          :analysis :var-usages))
+                                                        [:clojure.test]}}}))
+                           :analysis :var-usages))
         usage (first usages)]
     (is (= 1 (count usages)))
     (is (= 'testing (:name usage)))


### PR DESCRIPTION
This PR adds config options to limit the amount of analysis that is done.
- `:var-usages false` excludes var-usages from the analysis output
- `:var-definitions {:shallow true}` includes var-definitions, but skips analysis of their bodies

If both options are set analysis is a little over 80% faster. This will be helpful for clojure-lsp, which can use them when scanning deps.

This PR also moves the `:analysis` config option to the top-level of `:config`, out of `:output`. Docs and tests have been updated to reflect this new location. To maintain backward compatibility, the code still accepts `:analysis` in the `:output` config.

Finally, this PR clarifies the meanings of `:analysis` and `:skip-lint`. The output will include `:analysis` only when the config includes `:analysis`. The `:findings` will be non-empty only if the config doesn't include `:skip-lint`. The code tries to minimize the work performed based on these settings.

I experimented with a `:var-definitions false` setting. It was easy to implement, and I have the code if you'd like it, but it doesn't affect performance much. The true performance gain comes from skipping the definition bodies, not from skipping their signatures.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). See Slack discussion starting [here](https://clojurians.slack.com/archives/CHY97NXE2/p1651009819196579) and continuing [here](https://clojurians.slack.com/archives/C02RPGUCQNB/p1651060338202199).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
