### PR TITLE
Add :files-done to file-analyzed-fn

### DIFF
--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -164,7 +164,6 @@
              :cache-dir cache-dir
              :used-namespaces used-nss
              :file-analyzed-fn file-analyzed-fn
-             :files-analyzed-done (atom 0)
              :ignores (atom {})
              :id-gen (when analyze-locals? (atom 0))
              :analyze-var-usages? analyze-var-usages?

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -164,6 +164,7 @@
              :cache-dir cache-dir
              :used-namespaces used-nss
              :file-analyzed-fn file-analyzed-fn
+             :files-analyzed-done (atom 0)
              :ignores (atom {})
              :id-gen (when analyze-locals? (atom 0))
              :analyze-var-usages? analyze-var-usages?

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2656,7 +2656,7 @@
 (defn analyze-input
   "Analyzes input and returns analyzed defs, calls. Also invokes some
   linters and returns their findings."
-  [{:keys [:config :file-analyzed-fn :total-files] :as ctx} filename uri input lang dev?]
+  [{:keys [:config :file-analyzed-fn :total-files :files-analyzed-done] :as ctx} filename uri input lang dev?]
   (when (:debug ctx)
     (utils/stderr "[clj-kondo] Linting file:" filename))
   (try
@@ -2707,9 +2707,11 @@
           (binding [*out* *err*]
             (print ".") (flush))))
       (when file-analyzed-fn
+        (swap! files-analyzed-done inc)
         (file-analyzed-fn {:filename filename
                            :uri (->uri nil nil filename)
-                           :total-files total-files})))))
+                           :total-files total-files
+                           :files-done @files-analyzed-done})))))
 
 ;;;; Scratch
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2656,7 +2656,7 @@
 (defn analyze-input
   "Analyzes input and returns analyzed defs, calls. Also invokes some
   linters and returns their findings."
-  [{:keys [:config :file-analyzed-fn :total-files :files-analyzed-done] :as ctx} filename uri input lang dev?]
+  [{:keys [:config :file-analyzed-fn :total-files :files] :as ctx} filename uri input lang dev?]
   (when (:debug ctx)
     (utils/stderr "[clj-kondo] Linting file:" filename))
   (try
@@ -2707,11 +2707,11 @@
           (binding [*out* *err*]
             (print ".") (flush))))
       (when file-analyzed-fn
-        (swap! files-analyzed-done inc)
+        (swap! files inc)
         (file-analyzed-fn {:filename filename
                            :uri (->uri nil nil filename)
                            :total-files total-files
-                           :files-done @files-analyzed-done})))))
+                           :files-done @files})))))
 
 ;;;; Scratch
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2701,13 +2701,13 @@
         (throw e)
         (run! #(findings/reg-finding! ctx %) (->findings e filename))))
     (finally
+      (swap! files inc)
       (let [output-cfg (:output config)]
         (when (and (= :text (:format output-cfg))
                    (:progress output-cfg))
           (binding [*out* *err*]
             (print ".") (flush))))
       (when file-analyzed-fn
-        (swap! files inc)
         (file-analyzed-fn {:filename filename
                            :uri (->uri nil nil filename)
                            :total-files total-files

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -411,7 +411,6 @@
        (reduce + 0)))
 
 (defn schedule [ctx {:keys [:filename :source :lang :uri] :as m} dev?]
-  (swap! (:files ctx) inc)
   (if (:parallel ctx)
     (swap! (:sources ctx) conj m)
     (when (or (:analysis ctx) (not (:skip-lint ctx)))

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -204,13 +204,13 @@
                 {})]
       (is res)
       (assert-submaps
-        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6}
-          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6}
-          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6}
-          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6}
-          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6}
-          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6}}
-        (set @calls))))
+        [{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6 :files-done 1}
+          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6 :files-done 2}
+          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6 :files-done 3}
+          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6 :files-done 4}
+          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6 :files-done 5}
+          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6 :files-done 6}]
+        @calls)))
   (testing "when lint is classpath"
     (let [calls (atom [])
           res (file-analyzed-fn
@@ -223,12 +223,12 @@
                 {})]
       (is res)
       (assert-submaps
-        #{{:filename "corpus/invalid_arity/calls.clj" :uri #"file:/.*/corpus/invalid_arity/calls.clj" :total-files 5}
-          {:filename "corpus/invalid_arity/order.clj" :uri #"file:/.*/corpus/invalid_arity/order.clj" :total-files 5}
-          {:filename "corpus/invalid_arity/defs.clj" :uri #"file:/.*/corpus/invalid_arity/defs.clj" :total-files 5}
-          {:filename "corpus/private/private_calls.clj" :uri #"file:/.*/corpus/private/private_calls.clj" :total-files 5}
-          {:filename "corpus/private/private_defs.clj" :uri  #"file:/.*/corpus/private/private_defs.clj" :total-files 5}}
-        (set @calls))))
+        [{:filename "corpus/invalid_arity/defs.clj" :uri #"file:/.*/corpus/invalid_arity/defs.clj" :total-files 5 :files-done 1}
+         {:filename "corpus/invalid_arity/order.clj" :uri #"file:/.*/corpus/invalid_arity/order.clj" :total-files 5 :files-done 2}
+         {:filename "corpus/invalid_arity/calls.clj" :uri #"file:/.*/corpus/invalid_arity/calls.clj" :total-files 5 :files-done 3}
+         {:filename "corpus/private/private_calls.clj" :uri #"file:/.*/corpus/private/private_calls.clj" :total-files 5 :files-done 4}
+         {:filename "corpus/private/private_defs.clj" :uri  #"file:/.*/corpus/private/private_defs.clj" :total-files 5 :files-done 5}]
+        @calls)))
   (testing "when parallel"
     (let [calls (atom [])
           res (file-analyzed-fn
@@ -243,11 +243,11 @@
       (is res)
       (assert-submaps
         #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6}
+          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6}
           {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6}
-          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6}
           {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6}
-          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6}
-          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6}}
+          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6}
+          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6}}
         (set @calls)))))
 
 ;;;; Scratch

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -204,13 +204,15 @@
                 {})]
       (is (= 6 (:files (:summary res))))
       (assert-submaps
-        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6 :files-done 1}
-          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6 :files-done 2}
-          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6 :files-done 3}
-          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6 :files-done 4}
-          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6 :files-done 5}
-          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6 :files-done 6}}
-        (set @calls))))
+        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6}
+          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6}
+          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6}
+          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6}
+          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6}
+          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6}}
+        (set @calls))
+      (is (every? #(and (int? (:total-files %))
+                        (<= (:total-files %) 6)) @calls))))
   (testing "when lint is classpath"
     (let [calls (atom [])
           res (file-analyzed-fn
@@ -223,12 +225,14 @@
                 {})]
       (is (= 5 (:files (:summary res))))
       (assert-submaps
-        #{{:filename "corpus/invalid_arity/defs.clj" :uri #"file:/.*/corpus/invalid_arity/defs.clj" :total-files 5 :files-done 1}
-          {:filename "corpus/invalid_arity/order.clj" :uri #"file:/.*/corpus/invalid_arity/order.clj" :total-files 5 :files-done 2}
-          {:filename "corpus/invalid_arity/calls.clj" :uri #"file:/.*/corpus/invalid_arity/calls.clj" :total-files 5 :files-done 3}
-          {:filename "corpus/private/private_calls.clj" :uri #"file:/.*/corpus/private/private_calls.clj" :total-files 5 :files-done 4}
-          {:filename "corpus/private/private_defs.clj" :uri  #"file:/.*/corpus/private/private_defs.clj" :total-files 5 :files-done 5}}
-        (set @calls))))
+        #{{:filename "corpus/invalid_arity/defs.clj" :uri #"file:/.*/corpus/invalid_arity/defs.clj" :total-files 5}
+          {:filename "corpus/invalid_arity/order.clj" :uri #"file:/.*/corpus/invalid_arity/order.clj" :total-files 5}
+          {:filename "corpus/invalid_arity/calls.clj" :uri #"file:/.*/corpus/invalid_arity/calls.clj" :total-files 5}
+          {:filename "corpus/private/private_calls.clj" :uri #"file:/.*/corpus/private/private_calls.clj" :total-files 5}
+          {:filename "corpus/private/private_defs.clj" :uri  #"file:/.*/corpus/private/private_defs.clj" :total-files 5}}
+        (set @calls))
+      (is (every? #(and (int? (:total-files %))
+                        (<= (:total-files %) 5)) @calls))))
   (testing "when parallel"
     (let [calls (atom [])
           res (file-analyzed-fn
@@ -248,7 +252,9 @@
           {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6}
           {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6}
           {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6}}
-        (set @calls)))))
+        (set @calls))
+      (is (every? #(and (int? (:total-files %))
+                        (<= (:total-files %) 6)) @calls)))))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -202,15 +202,15 @@
                 (fn [entry-map]
                   (swap! calls conj entry-map))
                 {})]
-      (is res)
+      (is (= 6 (:files (:summary res))))
       (assert-submaps
-        [{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6 :files-done 1}
+        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6 :files-done 1}
           {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6 :files-done 2}
           {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6 :files-done 3}
           {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6 :files-done 4}
           {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6 :files-done 5}
-          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6 :files-done 6}]
-        @calls)))
+          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6 :files-done 6}}
+        (set @calls))))
   (testing "when lint is classpath"
     (let [calls (atom [])
           res (file-analyzed-fn
@@ -221,14 +221,14 @@
                 (fn [entry-map]
                   (swap! calls conj entry-map))
                 {})]
-      (is res)
+      (is (= 5 (:files (:summary res))))
       (assert-submaps
-        [{:filename "corpus/invalid_arity/defs.clj" :uri #"file:/.*/corpus/invalid_arity/defs.clj" :total-files 5 :files-done 1}
-         {:filename "corpus/invalid_arity/order.clj" :uri #"file:/.*/corpus/invalid_arity/order.clj" :total-files 5 :files-done 2}
-         {:filename "corpus/invalid_arity/calls.clj" :uri #"file:/.*/corpus/invalid_arity/calls.clj" :total-files 5 :files-done 3}
-         {:filename "corpus/private/private_calls.clj" :uri #"file:/.*/corpus/private/private_calls.clj" :total-files 5 :files-done 4}
-         {:filename "corpus/private/private_defs.clj" :uri  #"file:/.*/corpus/private/private_defs.clj" :total-files 5 :files-done 5}]
-        @calls)))
+        #{{:filename "corpus/invalid_arity/defs.clj" :uri #"file:/.*/corpus/invalid_arity/defs.clj" :total-files 5 :files-done 1}
+          {:filename "corpus/invalid_arity/order.clj" :uri #"file:/.*/corpus/invalid_arity/order.clj" :total-files 5 :files-done 2}
+          {:filename "corpus/invalid_arity/calls.clj" :uri #"file:/.*/corpus/invalid_arity/calls.clj" :total-files 5 :files-done 3}
+          {:filename "corpus/private/private_calls.clj" :uri #"file:/.*/corpus/private/private_calls.clj" :total-files 5 :files-done 4}
+          {:filename "corpus/private/private_defs.clj" :uri  #"file:/.*/corpus/private/private_defs.clj" :total-files 5 :files-done 5}}
+        (set @calls))))
   (testing "when parallel"
     (let [calls (atom [])
           res (file-analyzed-fn
@@ -240,7 +240,7 @@
                 (fn [entry-map]
                   (swap! calls conj entry-map))
                 {:parallel true})]
-      (is res)
+      (is (= 6 (:files (:summary res))))
       (assert-submaps
         #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6}
           {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6}

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -109,6 +109,7 @@
 (deftest analyze-input-test
   (let [analyze (fn [^String source]
                   (let [ctx {:config {:linters {:syntax {:level :error}} :output {:format :edn} :analysis true}
+                             :files (atom 0)
                              :filename "-"
                              :base-lang :clj
                              :lang :clj


### PR DESCRIPTION
This adds `:files-done` to the `file-analyzed-fn`, this is useful because usually clients want to know how many files we already analyzed, not only the total.

@bokdude I know we already have the `files` atom, but on parallel it's not reliable for this feature as it will swap all files before starts analyzing it, it'd result in a wrong number when we trigger the file-analyzed-fn call.