### PR TITLE
Updates docs for unused-namespace option

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1276,6 +1276,13 @@ will not trigger a warning:
 (ns foo (:require [foo.specs]))
 ```
 
+If you'd like to have namespaces without `:as` or `:refer` trigger
+warnings, you can enable this by setting the `:simple-libspec` option
+
+``` clojure
+{:linters {:unused-namespace {:simple-libspec true}}}
+```
+
 ### Unused private var
 
 *Keyword:* `:unused-private-var`.


### PR DESCRIPTION
Issue #1680 was resolved by digging through already supported options and figuring out that the unused namespaces linter supports the `:simple-libspec` option. This PR updates the documentation to include it.


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).


~- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions~ Not applicable

~- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.~ Not applicable
