### PR TITLE
Fix optional linters documentation

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -144,7 +144,6 @@ Some linters are not enabled by default. Right now these linters are:
 - `:docstring-no-summary`: warn when first line of docstring is not a complete sentence.
 - `:docstring-leading-trailing-whitespace`: warn when docstring has leading or trailing whitespace.
 - `:used-underscored-binding`: warn when a underscored (ie marked as unused) binding is used.
-- `:namespace-name-mismatch`: warn when namespace name doesn't match filename.
 
 You can enable these linters by setting the `:level`:
 


### PR DESCRIPTION
The `:namespace-name-mismatch` linter has been re-enabled by default but the documentation was not reflecting it. Follow up of [74ab2f5019b9743a2343a5771e033a669524c5ce].

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR correponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
