### PR TITLE
[fixes 1704] skip re-frame analysis if event-id is not a keyword...

### DIFF
--- a/src/clj_kondo/impl/analyzer/re_frame.clj
+++ b/src/clj_kondo/impl/analyzer/re_frame.clj
@@ -71,7 +71,8 @@
         [farg & _args :as _children] (next (:children expr))]
     (when (and farg (identical? :vector (utils/tag farg)))
       (let [[event-id & _event-params] (:children farg)]
-        (common/analyze-children (assoc-in ctx [:context kns :event-ref] true) [event-id])))))
+        (when (utils/keyword-node? event-id)
+          (common/analyze-children (assoc-in ctx [:context kns :event-ref] true) [event-id]))))))
 
 (defn analyze-dispatch
   "Analyzes re-frame dispatch call.

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -40,7 +40,7 @@
         (:classpath *ctx*)))
 
 (defn keyword-node? [n]
-  (instance? clj_kondo.impl.rewrite_clj.node.keyword.KeywordNode n))
+  (utils/keyword-node? n))
 
 (defn string-node? [n]
   (instance? clj_kondo.impl.rewrite_clj.node.string.StringNode n))

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -46,6 +46,9 @@
       (when (symbol? ?sym)
         ?sym))))
 
+(defn keyword-node? [n]
+  (instance? clj_kondo.impl.rewrite_clj.node.keyword.KeywordNode n))
+
 (defn node->keyword
   "Returns keyword from node, if it contains any."
   [node]


### PR DESCRIPTION
... in a reg-event-fx

should be addressed when we add support for anything being an event-id

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
