### PR TITLE
New config flag `:show-rule-name-in-message` to display rule name in outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ performance.txt
 clj-kondo*.snap
 .planck_cache
 
+# IntelliJ
+.idea
+*.iml
+
 .DS_Store
 !corpus/**/*.jar
 !corpus/java/classes/foo/bar/AwesomeClass.class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+- [#698](https://github.com/clj-kondo/clj-kondo/issues/698): output rule name with new output option `:show-rule-name-in-message true`. See example in [config guide](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#show-rule-name-in-message).
+
 ## 2022.06.22
 
 - [#1721](https://github.com/clj-kondo/clj-kondo/issues/1721): new `:discouraged-namespace` linter. See [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/linters.md#discouraged-namespace).

--- a/doc/config.md
+++ b/doc/config.md
@@ -30,6 +30,7 @@ Table of contents:
         - [Include and exclude files from the output](#include-and-exclude-files-from-the-output)
         - [Show progress bar while linting](#show-progress-bar-while-linting)
         - [Output canonical file paths](#output-canonical-file-paths)
+        - [Display rule name in text output](#show-rule-name-in-message)
     - [Namespace groups](#namespace-groups)
     - [Example configurations](#example-configurations)
     - [Exporting and importing configuration](#exporting-and-importing-configuration)
@@ -318,6 +319,30 @@ file when you lint a classpath.
 $ clj-kondo --lint corpus --config '{:output {:canonical-paths true}}'
 /Users/borkdude/dev/clj-kondo/corpus/cljc/datascript.cljc:8:1: error: datascript.db/seqable? is called with 2 args but expects 1
 (rest of the output omitted)
+```
+
+### Show rule name in message
+
+Adding `'{:output {:show-rule-name-in-message true}}` will append rule name to the output line for each reported finding.
+
+By default, this configuration is set to `false`.
+
+Output example with default `false`:
+
+```shell
+$ echo '(def x (def x 1))' | clj-kondo --lint -
+<stdin>:1:1: warning: redefined var #'user/x
+<stdin>:1:8: warning: inline def
+linting took 22ms, errors: 0, warnings: 2
+```
+
+Output example with `{:output {:show-rule-name-in-message true}}`:
+
+```shell
+$ echo '(def x (def x 1))' | clj-kondo --config '{:output {:show-rule-name-in-message true}}' --lint -
+<stdin>:1:1: warning: redefined var #'user/x [:redefined-var]
+<stdin>:1:8: warning: inline def [:inline-def]
+linting took 9ms, errors: 0, warnings: 2
 ```
 
 ## Namespace groups

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -27,10 +27,8 @@
         (when (:progress output-cfg) (binding [*out* *err*]
                                        (println)))
         (let [format-fn (core-impl/format-output config)]
-          (doseq [{:keys [:filename :message
-                          :level :row :col] :as _finding}
-                  findings]
-            (println (format-fn filename row col level message)))
+          (doseq [finding findings]
+            (println (format-fn finding)))
           (when (:summary output-cfg)
             (let [{:keys [:error :warning :duration]} summary]
               (printf "linting took %sms, " duration)

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -154,6 +154,9 @@
              ;; the output pattern can be altered using a template. use {{LEVEL}} to print the level in capitals.
              ;; the default template looks like this:
              ;; :pattern "{{filename}}:{{row}}:{{col}}: {{level}}: {{message}}"
+             ;; if below :show-rule-name-in-message is set to true, type (linter name) of reported the finding
+             ;; is appended to the end of the default pattern as " [{{type}}]"
+             :show-rule-name-in-message false
              :canonical-paths false}}) ;; set to true to see absolute file paths and jar files
 
 (defn merge-config!

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -26,16 +26,23 @@
 
 (defn format-output [config]
   (if-let [^String pattern (-> config :output :pattern)]
-    (fn [filename row col level message]
+    (fn [{:keys [:filename :row :col :level :message :type] :as _finding}]
       (-> pattern
           (str/replace "{{filename}}" filename)
           (str/replace "{{row}}" (str row))
           (str/replace "{{col}}" (str col))
           (str/replace "{{level}}" (name level))
           (str/replace "{{LEVEL}}" (str/upper-case (name level)))
-          (str/replace "{{message}}" message)))
-    (fn [filename row col level message]
-      (str filename ":" row ":" col ": " (name level) ": " message))))
+          (str/replace "{{message}}" message)
+          (str/replace "{{type}}" (str type))))
+    (fn [{:keys [:filename :row :col :level :message :type] :as _finding}]
+      (str filename ":"
+           row ":"
+           col ": "
+           (name level) ": "
+           message
+           (when (-> config :output :show-rule-name-in-message)
+             (str " [" type "]"))))))
 
 ;;;; process config
 


### PR DESCRIPTION
resolves #698

As suggested by Michiel in https://github.com/clj-kondo/clj-kondo/issues/698#issuecomment-573089135
this will add new :output config option to display rule name in text
based finding outputs

Please answer the following questions and leave the below in as part of your PR.

- [ ] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
