### PR TITLE
Add `nilable` as an option to map type specs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#698](https://github.com/clj-kondo/clj-kondo/issues/698): output rule name with new output option `:show-rule-name-in-message true`. See example in [config guide](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#show-rule-name-in-message).
+- [#1735](https://github.com/clj-kondo/clj-kondo/issues/1735) Add support for nilable map type specs
 
 ## 2022.06.22
 

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -380,7 +380,9 @@
         (emit-missing-required-key! ctx arg k)))))
 
 (defn lint-map! [ctx s a t]
-  (cond (keyword? t)
+  (cond (and (:nilable s) (= :nil t))
+        nil
+        (keyword? t)
         (when-not (match? t :map)
           (emit-non-match! ctx :map a t))
         :else

--- a/test/clj_kondo/types_test.clj
+++ b/test/clj_kondo/types_test.clj
@@ -790,7 +790,12 @@
         {:arities
          {1
           {:args [{:op :keys, :req {:a :int}}],
-           :ret {:op :keys, :req {:user/a :string}}}}}}}}}})
+           :ret {:op :keys, :req {:user/a :string}}}}}
+        fun4
+        {:arities
+         {1
+          {:args [{:op :keys, :req {:a :int} :nilable true}],
+           :ret {:op :keys, :req {:a :string}}}}}}}}}})
 
 (deftest keyword-resolution-test
   (testing "keyword call"
@@ -905,6 +910,25 @@
   (defn fun2 [m] (:a m))
   (fun2 (fun2 {:a 23})))"
             config-2))))
+
+(deftest nilable-map-test
+  (testing "pass nil to a nilable map"
+    (assert-submaps
+      []
+      (lint! "
+(do
+  (defn fun4 [m] (:a m))
+  (fun4 nil))"
+             config-2)))
+
+  (testing "pass invalid map to a nilable map"
+    (assert-submaps
+      [{:file "<stdin>", :row 4, :col 9, :level :error, :message "Missing required key: :a"}]
+      (lint! "
+(do
+  (defn fun4 [m] (:a m))
+  (fun4 {}))"
+             config-2))))
 
 (deftest misc-false-positives-test
   (is (empty? (lint! "(even? ('a {'a 10}))" config)))


### PR DESCRIPTION
Fixes #1735

The simplest solution that I could figure out right away. The only obvious weakness would be performance, there may be a way to run the nil checking code less often?

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
