### PR TITLE
Expose imported-ns in analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - [#698](https://github.com/clj-kondo/clj-kondo/issues/698): output rule name with new output option `:show-rule-name-in-message true`. See example in [config guide](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#show-rule-name-in-message).
 - [#1735](https://github.com/clj-kondo/clj-kondo/issues/1735) Add support for nilable map type specs
+- [#1744](https://github.com/clj-kondo/clj-kondo/issues/1744) Expose `:imported-ns` in analysis of vars imported by potemkin
 
 ## 2022.06.22
 

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -50,6 +50,7 @@
           attrs (select-keys attrs [:private :macro :fixed-arities :varargs-min-arity
                                     :doc :added :deprecated :test :export :defined-by
                                     :protocol-ns :protocol-name
+                                    :imported-ns
                                     :name-row :name-col :name-end-col :name-end-row
                                     :arglist-strs :end-row :end-col])]
       (swap! analysis update :var-definitions conj

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -1688,6 +1688,7 @@
              {:name 'my-func
               :ns 'api
               :defined-by 'potemkin/import-vars
+              :imported-ns 'foo
               :row 10
               :col 1
               :end-row 12
@@ -1701,6 +1702,7 @@
              {:name 'my-other
               :ns 'api
               :defined-by 'potemkin/import-vars
+              :imported-ns 'foo
               :row 10
               :col 1
               :end-row 12
@@ -1757,6 +1759,7 @@
              {:name 'my-func
               :ns 'api
               :defined-by 'potemkin/import-vars
+              :imported-ns 'foo
               :row 10
               :col 1
               :end-row 12
@@ -1770,6 +1773,7 @@
              {:name 'my-other
               :ns 'api
               :defined-by 'potemkin/import-vars
+              :imported-ns 'foo
               :row 10
               :col 1
               :end-row 12


### PR DESCRIPTION
When a var is defined by potemkin/import-vars, we know which namespace it was imported from. This patch exposes that info in the analysis. This will permit a fix for https://github.com/clojure-lsp/clojure-lsp/issues/1020

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).
- [x] Fixes #1744 
- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
