### PR TITLE
expose clojure.pprint/pprint to hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#1749](https://github.com/clj-kondo/clj-kondo/issues/1749): expose `clojure.pprint/pprint` to the hooks API
 - [#698](https://github.com/clj-kondo/clj-kondo/issues/698): output rule name with new output option `:show-rule-name-in-message true`. See example in [config guide](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#show-rule-name-in-message).
 - [#1735](https://github.com/clj-kondo/clj-kondo/issues/1735) Add support for nilable map type specs
 - [#1744](https://github.com/clj-kondo/clj-kondo/issues/1744) Expose `:imported-ns` in analysis of vars imported by potemkin

--- a/src/clj_kondo/hooks_api.clj
+++ b/src/clj_kondo/hooks_api.clj
@@ -1,11 +1,12 @@
 (ns clj-kondo.hooks-api
-  (:require
-   [clj-kondo.impl.cache :as cache]
-   [clj-kondo.impl.findings :as findings]
-   [clj-kondo.impl.metadata :as meta]
-   [clj-kondo.impl.rewrite-clj.node :as node]
-   [clj-kondo.impl.rewrite-clj.parser :as parser]
-   [clj-kondo.impl.utils :as utils])
+  (:require [clj-kondo.impl.cache :as cache]
+            [clj-kondo.impl.findings :as findings]
+            [clj-kondo.impl.metadata :as meta]
+            [clj-kondo.impl.rewrite-clj.node :as node]
+            [clj-kondo.impl.rewrite-clj.parser :as parser]
+            [clj-kondo.impl.utils :as utils]
+            clojure.pprint
+            [sci.core :as sci])
   (:refer-clojure :exclude [macroexpand]))
 
 (defn- mark-generate [node]
@@ -146,3 +147,7 @@
         lifted (meta/lift-meta-content2 utils/*ctx* annotated)]
     ;;
     lifted))
+
+(defn pprint [& args]
+  (binding [*out* @sci/out]
+    (apply clojure.pprint/pprint args)))

--- a/src/clj_kondo/hooks_api.clj
+++ b/src/clj_kondo/hooks_api.clj
@@ -1,12 +1,13 @@
 (ns clj-kondo.hooks-api
-  (:require [clj-kondo.impl.cache :as cache]
-            [clj-kondo.impl.findings :as findings]
-            [clj-kondo.impl.metadata :as meta]
-            [clj-kondo.impl.rewrite-clj.node :as node]
-            [clj-kondo.impl.rewrite-clj.parser :as parser]
-            [clj-kondo.impl.utils :as utils]
-            clojure.pprint
-            [sci.core :as sci])
+  (:require
+   [clj-kondo.impl.cache :as cache]
+   [clj-kondo.impl.findings :as findings]
+   [clj-kondo.impl.metadata :as meta]
+   [clj-kondo.impl.rewrite-clj.node :as node]
+   [clj-kondo.impl.rewrite-clj.parser :as parser]
+   [clj-kondo.impl.utils :as utils]
+   clojure.pprint
+   [sci.core :as sci])
   (:refer-clojure :exclude [macroexpand]))
 
 (defn- mark-generate [node]

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -1,10 +1,10 @@
 (ns clj-kondo.impl.hooks
   {:no-doc true}
-  (:require
-   [clj-kondo.hooks-api :as api]
-   [clj-kondo.impl.utils :as utils :refer [*ctx*]]
-   [clojure.java.io :as io]
-   [sci.core :as sci])
+  (:require [clj-kondo.hooks-api :as api]
+            [clj-kondo.impl.utils :as utils :refer [*ctx*]]
+            [clojure.java.io :as io]
+            clojure.pprint
+            [sci.core :as sci])
   (:refer-clojure :exclude [macroexpand]))
 
 (set! *warn-on-reflection* true)
@@ -53,6 +53,7 @@
 
 (def sci-ctx
   (sci/init {:namespaces {'clojure.core {'time (with-meta time* {:sci/macro true})}
+                          'clojure.pprint {'pprint api/pprint}
                           'clj-kondo.hooks-api api-ns}
              :classes {'java.io.Exception Exception
                        'java.lang.System System}

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -1,10 +1,11 @@
 (ns clj-kondo.impl.hooks
   {:no-doc true}
-  (:require [clj-kondo.hooks-api :as api]
-            [clj-kondo.impl.utils :as utils :refer [*ctx*]]
-            [clojure.java.io :as io]
-            clojure.pprint
-            [sci.core :as sci])
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clj-kondo.impl.utils :as utils :refer [*ctx*]]
+   [clojure.java.io :as io]
+   clojure.pprint
+   [sci.core :as sci])
   (:refer-clojure :exclude [macroexpand]))
 
 (set! *warn-on-reflection* true)

--- a/test/clj_kondo/hooks_test.clj
+++ b/test/clj_kondo/hooks_test.clj
@@ -285,6 +285,9 @@ children))]
         (is (= {:my-hook {:can-set-context true}, :yolo true} context))))))
 
 (deftest pprint-test
+  ;; this doesn't test the output
+  ;; however, the "no empty docstring" linter would catch the error
+  ;; if there was no output
   (testing "hook code supports pprint"
     (let [res (lint! "
       
@@ -313,5 +316,5 @@ foo/defdoced \"
 
 (defdoced mysuperthing {:a 1 :b 2 :c {:d 3 :e 4}})
 "
-                       {:hooks {:__dangerously-allow-string-hooks__ true}})]
+                     {:hooks {:__dangerously-allow-string-hooks__ true}})]
       (is (empty? res)))))

--- a/test/clj_kondo/hooks_test.clj
+++ b/test/clj_kondo/hooks_test.clj
@@ -304,9 +304,7 @@ foo/defdoced \"
           name
           (api/string-node
             (with-out-str (pprint/pprint value)))
-          value))
-        _ (println (api/string-node
-            (with-out-str (pprint/pprint value))))]
+          value))]
     {:node new-node}))
 \"
 


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

---

See [#1749](https://github.com/clj-kondo/clj-kondo/issues/1749).

This only exposes `clojure.pprint/pprint`. Babashka has a whole `pprint` [module](https://github.com/babashka/babashka/blob/master/src/babashka/impl/pprint.clj) that could be exposed completely, but `clj-kondo` doesn't depend on it right now, and copying it seemed to be an overkill.
