### PR TITLE
Include dispatch-val in analysis of defmethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#1735](https://github.com/clj-kondo/clj-kondo/issues/1735) Add support for nilable map type specs
 - [#1744](https://github.com/clj-kondo/clj-kondo/issues/1744) Expose `:imported-ns` in analysis of vars imported by potemkin
 - [#1746](https://github.com/clj-kondo/clj-kondo/issues/1746) Printing deps.edn error to stdout
+- [#1716](https://github.com/clj-kondo/clj-kondo/issues/1716) Include dispatch-val in analysis of defmethod
 
 ## 2022.06.22
 

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -125,6 +125,8 @@ The analysis output consists of a map with:
   - `:arity`: if the usage was a function call, the amount of arguments passed
   - `:lang`: if usage occurred in a `.cljc` file, the language in which the call
     was resolved: `:clj` or `:cljs`
+  - `:defmethod`: true when the usage is a defmethod
+  - `:dispatch-val`: the dispatch val of a defmethod
   - several attributes of the used var: `:private`, `:macro`, `:fixed-arities`,
     `:varargs-min-arity`, `:deprecated`.
 

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -126,7 +126,7 @@ The analysis output consists of a map with:
   - `:lang`: if usage occurred in a `.cljc` file, the language in which the call
     was resolved: `:clj` or `:cljs`
   - `:defmethod`: true when the usage is a defmethod
-  - `:dispatch-val`: the dispatch val of a defmethod
+  - `:dispatch-val-str`: the dispatch val of a defmethod, represented as a string
   - several attributes of the used var: `:private`, `:macro`, `:fixed-arities`,
     `:varargs-min-arity`, `:deprecated`.
 

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -32,6 +32,7 @@
                                :refer
                                :alias
                                :defmethod
+                               :dispatch-val
                                :name-row
                                :name-col
                                :name-end-row

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -32,7 +32,7 @@
                                :refer
                                :alias
                                :defmethod
-                               :dispatch-val
+                               :dispatch-val-str
                                :name-row
                                :name-col
                                :name-end-row

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1389,7 +1389,10 @@
 (defn analyze-defmethod [ctx expr]
   (let [children (next (:children expr))
         [method-name-node dispatch-val-node & fn-tail] children
-        _ (analyze-usages2 (assoc ctx :defmethod true, :dispatch-val (sexpr dispatch-val-node)) method-name-node)
+        _ (analyze-usages2 (assoc ctx
+                                  :defmethod true,
+                                  :dispatch-val-str (pr-str (sexpr dispatch-val-node)))
+                           method-name-node)
         _ (analyze-expression** ctx dispatch-val-node)]
     (analyze-fn ctx {:children (cons nil fn-tail)})))
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1389,7 +1389,7 @@
 (defn analyze-defmethod [ctx expr]
   (let [children (next (:children expr))
         [method-name-node dispatch-val-node & fn-tail] children
-        _ (analyze-usages2 (assoc ctx :defmethod true) method-name-node)
+        _ (analyze-usages2 (assoc ctx :defmethod true, :dispatch-val (sexpr dispatch-val-node)) method-name-node)
         _ (analyze-expression** ctx dispatch-val-node)]
     (analyze-fn ctx {:children (cons nil fn-tail)})))
 

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -210,7 +210,7 @@
                                                     :ns ns-name
                                                     :alias resolved-alias
                                                     :defmethod (:defmethod ctx)
-                                                    :dispatch-val (:dispatch-val ctx)
+                                                    :dispatch-val-str (:dispatch-val-str ctx)
                                                     :unresolved? unresolved?
                                                     :clojure-excluded? clojure-excluded?
                                                     :row row

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -210,6 +210,7 @@
                                                     :ns ns-name
                                                     :alias resolved-alias
                                                     :defmethod (:defmethod ctx)
+                                                    :dispatch-val (:dispatch-val ctx)
                                                     :unresolved? unresolved?
                                                     :clojure-excluded? clojure-excluded?
                                                     :row row

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -312,7 +312,7 @@
                                                     :alias (:alias call)
                                                     :refer (:refer call)
                                                     :defmethod (:defmethod call)
-                                                    :dispatch-val (:dispatch-val call)
+                                                    :dispatch-val-str (:dispatch-val-str call)
                                                     :name-row name-row
                                                     :name-col name-col
                                                     :name-end-row name-end-row

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -312,6 +312,7 @@
                                                     :alias (:alias call)
                                                     :refer (:refer call)
                                                     :defmethod (:defmethod call)
+                                                    :dispatch-val (:dispatch-val call)
                                                     :name-row name-row
                                                     :name-col name-col
                                                     :name-end-row name-end-row

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -582,7 +582,7 @@
           :from user
           :to user
           :defmethod true
-          :dispatch-val :some-value
+          :dispatch-val-str ":some-value"
           :name-row 4 :name-col 12 :name-end-row 4 :name-end-col 20
           :row 4 :col 12 :end-row 4 :end-col 20}]
        var-usages))))

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -564,7 +564,7 @@
   (testing "defmulti and defmethod"
     (let [{:keys [:var-usages :var-definitions]} (analyze "
 (defmulti my-multi :some-key)
-​
+
 (defmethod my-multi :some-value
   [_]
   :bar)" {:config {:analysis true}})]
@@ -577,12 +577,12 @@
        var-definitions)
       (assert-submaps
        '[{:name defmulti}
-         {}
          {:name defmethod}
          {:name my-multi
           :from user
           :to user
           :defmethod true
+          :dispatch-val :some-value
           :name-row 4 :name-col 12 :name-end-row 4 :name-end-col 20
           :row 4 :col 12 :end-row 4 :end-col 20}]
        var-usages))))

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -565,7 +565,7 @@
     (let [{:keys [:var-usages :var-definitions]} (analyze "
 (defmulti my-multi :some-key)
 
-(defmethod my-multi :some-value
+(defmethod my-multi \"some-value\"
   [_]
   :bar)" {:config {:analysis true}})]
       (assert-submaps
@@ -582,7 +582,7 @@
           :from user
           :to user
           :defmethod true
-          :dispatch-val-str ":some-value"
+          :dispatch-val-str "\"some-value\""
           :name-row 4 :name-col 12 :name-end-row 4 :name-end-col 20
           :row 4 :col 12 :end-row 4 :end-col 20}]
        var-usages))))


### PR DESCRIPTION
This adds the dispatch value to the analysis of defmethods.

Fixes #1716.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).
- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
