### PR TITLE
#1755: Fix mapcat transducer invalid-arity false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#1755](https://github.com/clj-kondo/clj-kondo/issues/1755): Fix false positive invalid-arity when using mapcat transducer in sequence with multiple collections
 - [#1749](https://github.com/clj-kondo/clj-kondo/issues/1749): expose `clojure.pprint/pprint` to the hooks API
 - [#698](https://github.com/clj-kondo/clj-kondo/issues/698): output rule name with new output option `:show-rule-name-in-message true`. See example in [config guide](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#show-rule-name-in-message).
 - [#1735](https://github.com/clj-kondo/clj-kondo/issues/1735) Add support for nilable map type specs

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1663,7 +1663,8 @@
         arg-count (if (and transducer-eligable?
                            (zero? arg-count)) ;; transducer
                     (if (and (= 'clojure.core hof-ns-name)
-                             (#{'map 'mapcat} hof-resolved-name))
+                             (or (= 'map hof-resolved-name)
+                                 (= 'mapcat hof-resolved-name)))
                       nil 1)
                     arg-count)]
     (cond var?

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1663,7 +1663,7 @@
         arg-count (if (and transducer-eligable?
                            (zero? arg-count)) ;; transducer
                     (if (and (= 'clojure.core hof-ns-name)
-                             (= 'map hof-resolved-name))
+                             (#{'map 'mapcat} hof-resolved-name))
                       nil 1)
                     arg-count)]
     (cond var?

--- a/test/clj_kondo/invalid_arity_test.clj
+++ b/test/clj_kondo/invalid_arity_test.clj
@@ -148,6 +148,7 @@
   (is (empty? (lint! "(keep-indexed (fn [i e]) [1 2 3])")))
   (is (empty? (lint! "(reduce (fn [acc e]) [1 2 3])")))
   (is (empty? (lint! "(sequence (map (fn [_ _])) (range 10) (range 10))")))
+  (is (empty? (lint! "(sequence (mapcat (fn [_ _])) (range 10) (range 10))")))
   (assert-submaps
    '({:file "<stdin>", :row 1, :col 6, :level :error,
       :message "clojure.core/inc is called with 2 args but expects 1"})


### PR DESCRIPTION
Gives mapcat the same special handling as map for situations where it's being used as a transducer inside sequence and thus can have its internal function called with arities above 1.

Fixes #1755.


- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
