### PR TITLE
Add arglist-strs to fn definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#1744](https://github.com/clj-kondo/clj-kondo/issues/1744) Expose `:imported-ns` in analysis of vars imported by potemkin
 - [#1746](https://github.com/clj-kondo/clj-kondo/issues/1746) Printing deps.edn error to stdout
 - [#1716](https://github.com/clj-kondo/clj-kondo/issues/1716) Include dispatch-val in analysis of defmethod
+- [#1760](https://github.com/clj-kondo/clj-kondo/issues/1760) Add :arglist-strs support for functions defined with fn
 
 ## 2022.06.22
 

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -976,7 +976,8 @@
                     (defn f2 ([e] e) ([f f'] f))
                     (defprotocol A (f3 [g] \"doc\") (f4 [h] [i i']))
                     (defrecord A [j k])
-                    (defmacro f5 [l m])"
+                    (defmacro f5 [l m])
+                    (def f6 (fn [n] n))"
                    {:config {:analysis {:arglists true}}})]
       (assert-submaps
        '[{:name f1,
@@ -1001,8 +1002,11 @@
           :arglist-strs ["[m]"]}
          {:name f5
           :defined-by clojure.core/defmacro
-          :arglist-strs ["[l m]"]}]
-       var-definitions))))
+          :arglist-strs ["[l m]"]}
+         {:name f6,
+          :defined-by clojure.core/def
+          :arglist-strs ["[n]"]}]
+        var-definitions))))
 
 (deftest analysis-is-valid-edn-test
   (testing "solution for GH-476, CLJS with string require"


### PR DESCRIPTION
First PR here, so please do provide feedback if there's something I can improve.

One part I wasn't totally sure about was making including `:arglist-strs` optional. I ended up using `cond->` to thread through the original output and adding the new attribute if the value isn't empty. It works in my manual tests.

Fixes #1760 

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
