### PR TITLE
Add -Sdeps to REPL example in hooks tips

### DIFF
--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -351,7 +351,7 @@ For developing hooks in a JVM REPL, clj-kondo exposes the `clj-kondo.hooks-api`
 namespace:
 
 ``` Clojure
-$ clj
+$ clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "LATEST"}}}'
 Clojure 1.11.0
 user=> (require '[clj-kondo.hooks-api :as api])
 nil


### PR DESCRIPTION
I found myself struggling trying to write a kondo hook and was trying to figure out how to debug.

It would be lovely to have in the docs an easy snippet to start a REPL with clj-kondo loaded in it, rather than starting `clj` assuming it's already on the class path.