### PR TITLE
Pass existing filename URI to file-analyzed-fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+  [#1782](https://github.com/clj-kondo/clj-kondo/issues/1782): Fix issue with jar URI missreporting to `file-analyzed-fn`, bump babashka/fs to 0.1.11
 - [#1780](https://github.com/clj-kondo/clj-kondo/issues/1780): Can not use NPM dependency namespaces beginning with "@" in consistent-linter alias
 - [#1771](https://github.com/clj-kondo/clj-kondo/issues/1771): don't crash on empty ns clauses: `(require '[])` and `(import '())` 
 - [#1774](https://github.com/clj-kondo/clj-kondo/issues/1774): Add support for sourcehut inferred git dep urls for the Clojure CLI

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         cheshire/cheshire {:mvn/version "5.11.0"}
         nrepl/bencode {:mvn/version "1.1.0"}
         org.babashka/sci {:mvn/version "0.3.2"}
-        babashka/fs {:mvn/version "0.1.2"}
+        babashka/fs {:mvn/version "0.1.11"}
         org.ow2.asm/asm {:mvn/version "9.2"}}
  :aliases {:clj-kondo/dev
            {:main-opts ["-m" "clj-kondo.main"]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -36,8 +36,7 @@
    [clj-kondo.impl.types :as types]
    [clj-kondo.impl.utils :as utils :refer
     [symbol-call node->line parse-string tag select-lang deep-merge one-of
-     linter-disabled? tag sexpr string-from-token assoc-some ctx-with-bindings
-     ->uri]]
+     linter-disabled? tag sexpr string-from-token assoc-some ctx-with-bindings]]
    [clojure.set :as set]
    [clojure.string :as str]
    [sci.core :as sci]))
@@ -2797,7 +2796,7 @@
             (print ".") (flush))))
       (when file-analyzed-fn
         (file-analyzed-fn {:filename filename
-                           :uri (->uri nil nil filename)
+                           :uri uri
                            :total-files total-files
                            :files-done @files})))))
 

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -8,6 +8,7 @@
    [clj-kondo.impl.rewrite-clj.node.string :as node-string]
    [clj-kondo.impl.rewrite-clj.node.token :as token]
    [clj-kondo.impl.rewrite-clj.parser :as p]
+   [clojure.java.io :as io]
    [clojure.string :as str]))
 
 (set! *warn-on-reflection* true)
@@ -377,7 +378,7 @@
   (cond file (when (fs/exists? file)
                (str (.toURI (fs/file file))))
         (and jar entry)
-        (str "jar:file:" (fs/canonicalize jar) "!/" entry)))
+        (str "jar:" (.toURI (io/file jar)) "!/" entry)))
 
 (defn file-ext [fn]
   (when-let [last-dot (str/last-index-of fn ".")]

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -8,7 +8,6 @@
    [clj-kondo.impl.rewrite-clj.node.string :as node-string]
    [clj-kondo.impl.rewrite-clj.node.token :as token]
    [clj-kondo.impl.rewrite-clj.parser :as p]
-   [clojure.java.io :as io]
    [clojure.string :as str]))
 
 (set! *warn-on-reflection* true)
@@ -378,7 +377,7 @@
   (cond file (when (fs/exists? file)
                (str (.toURI (fs/file file))))
         (and jar entry)
-        (str "jar:file:" (.toURI (io/file jar)) "!/" entry)))
+        (str "jar:file:" (fs/canonicalize jar) "!/" entry)))
 
 (defn file-ext [fn]
   (when-let [last-dot (str/last-index-of fn ".")]

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -197,22 +197,25 @@
                 ["corpus/use.clj"
                  "corpus/case.clj"
                  "corpus/schema"
-                 "corpus/exports/dir"]
+                 "corpus/exports/dir"
+                 "corpus/withcljdir.jar"]
                 :clj
                 (fn [entry-map]
                   (swap! calls conj entry-map))
                 {})]
-      (is (= 6 (:files (:summary res))))
+      (is (= 7 (:files (:summary res))))
       (assert-submaps
-        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6}
-          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6}
-          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6}
-          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6}
-          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6}
-          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6}}
+        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 7}
+          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 7}
+          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 7}
+          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 7}
+          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 7}
+          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 7}
+          {:filename "dirinjar.clj/arity.clj" :uri #"jar:file:file:/.*/corpus/withcljdir.jar!/dirinjar.clj/arity.clj" :total-files 7}}
         (set @calls))
       (is (every? #(and (int? (:total-files %))
-                        (<= (:total-files %) 6)) @calls))))
+                        (<= (:total-files %) 7)) @calls))))
+
   (testing "when lint is classpath"
     (let [calls (atom [])
           res (file-analyzed-fn
@@ -236,25 +239,27 @@
   (testing "when parallel"
     (let [calls (atom [])
           res (file-analyzed-fn
-                ["corpus/use.clj"
-                 "corpus/case.clj"
-                 "corpus/schema"
-                 "corpus/exports/dir"]
-                :clj
-                (fn [entry-map]
-                  (swap! calls conj entry-map))
-                {:parallel true})]
-      (is (= 6 (:files (:summary res))))
+               ["corpus/use.clj"
+                "corpus/case.clj"
+                "corpus/schema"
+                "corpus/exports/dir"
+                "corpus/withcljdir.jar"]
+               :clj
+               (fn [entry-map]
+                 (swap! calls conj entry-map))
+               {:parallel true})]
+      (is (= 7 (:files (:summary res))))
       (assert-submaps
-        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 6}
-          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 6}
-          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 6}
-          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 6}
-          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 6}
-          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 6}}
+        #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 7}
+          {:filename "corpus/schema/defs.clj" :uri #"file:/.*/corpus/schema/defs.clj" :total-files 7}
+          {:filename "corpus/case.clj" :uri #"file:/.*/corpus/case.clj" :total-files 7}
+          {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 7}
+          {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 7}
+          {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 7}
+          {:filename "dirinjar.clj/arity.clj" :uri #"jar:file:file:/.*/corpus/withcljdir.jar!/dirinjar.clj/arity.clj" :total-files 7}}
         (set @calls))
       (is (every? #(and (int? (:total-files %))
-                        (<= (:total-files %) 6)) @calls)))))
+                        (<= (:total-files %) 7)) @calls)))))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -211,7 +211,7 @@
           {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 7}
           {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 7}
           {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 7}
-          {:filename "dirinjar.clj/arity.clj" :uri #"jar:file:file:/.*/corpus/withcljdir.jar!/dirinjar.clj/arity.clj" :total-files 7}}
+          {:filename "dirinjar.clj/arity.clj" :uri #"jar:file:/.*/corpus/withcljdir.jar!/dirinjar.clj/arity.clj" :total-files 7}}
         (set @calls))
       (is (every? #(and (int? (:total-files %))
                         (<= (:total-files %) 7)) @calls))))
@@ -239,15 +239,15 @@
   (testing "when parallel"
     (let [calls (atom [])
           res (file-analyzed-fn
-               ["corpus/use.clj"
-                "corpus/case.clj"
-                "corpus/schema"
-                "corpus/exports/dir"
-                "corpus/withcljdir.jar"]
-               :clj
-               (fn [entry-map]
-                 (swap! calls conj entry-map))
-               {:parallel true})]
+                ["corpus/use.clj"
+                 "corpus/case.clj"
+                 "corpus/schema"
+                 "corpus/exports/dir"
+                 "corpus/withcljdir.jar"]
+                :clj
+                (fn [entry-map]
+                  (swap! calls conj entry-map))
+                {:parallel true})]
       (is (= 7 (:files (:summary res))))
       (assert-submaps
         #{{:filename "corpus/use.clj" :uri #"file:/.*/corpus/use.clj" :total-files 7}
@@ -256,7 +256,7 @@
           {:filename "corpus/schema/defmethod.clj" :uri #"file:/.*/corpus/schema/defmethod.clj" :total-files 7}
           {:filename "corpus/schema/calls.clj" :uri #"file:/.*/corpus/schema/calls.clj" :total-files 7}
           {:filename "corpus/schema/defrecord.clj" :uri #"file:/.*/corpus/schema/defrecord.clj" :total-files 7}
-          {:filename "dirinjar.clj/arity.clj" :uri #"jar:file:file:/.*/corpus/withcljdir.jar!/dirinjar.clj/arity.clj" :total-files 7}}
+          {:filename "dirinjar.clj/arity.clj" :uri #"jar:file:/.*/corpus/withcljdir.jar!/dirinjar.clj/arity.clj" :total-files 7}}
         (set @calls))
       (is (every? #(and (int? (:total-files %))
                         (<= (:total-files %) 7)) @calls)))))


### PR DESCRIPTION
(cc'ing @ericdallo)

Hi,

could you please consider a patch to simplify the logic around what to pass as the filename URI to the `file-analyzed-fn` as discussed in #1782 starting with https://github.com/clj-kondo/clj-kondo/issues/1782#issuecomment-1228920239

The analyzer, without this patch, will pass a nil URI to the `file-analyzed-fn` when there is a request for a nested jar file. As discussed, It is better instead to pass in the already calculated input `uri` argument rather than construct on the fly from the `filename` which might leave the URI as nil.

As also discussed in the above thread, and  is now obvious from the additional test vector, the analyzer will return "unconventional" URIs for the nested jar files, such as `"jar:file:file:/.*/corpus/withcljdir.jar!/dirinjar.clj/arity.clj"` (double "file" in the URI scheme).

This can also be seen using the public API, e.g.:

``` clojure
(clj-kondo.core/run! {:parallel true :lint ["corpus/withcljdir.jar"] :config {:output {:canonical-paths true} } :file-analyzed-fn #(prn :analysis-results %)})
;; => :analysis-results {:filename "/home/ikappaki/src/clj-kondo/corpus/withcljdir.jar:dirinjar.clj/arity.clj", :uri "jar:file:file:/home/ikappaki/src/clj-kondo/corpus/withcljdir.jar!/dirinjar.clj/arity.clj", :total-files 1, :files-done 1}
;; => ...
```

I have also have a patch at hand to "fix" the above, i.e. remove the repeated "file" uri scheme. Let me know if you think this can be accommodated in this patch.

Will update the changelog in due time.

Thanks 


Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
