### PR TITLE
Add :unknown-require-option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#1460](https://github.com/clj-kondo/clj-kondo/issues/1460): Add a linter for incorrect `:require` options
 - [#1794](https://github.com/clj-kondo/clj-kondo/issues/1794): Add a linter for line length
 
 ## 2022.09.08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
-- [#1460](https://github.com/clj-kondo/clj-kondo/issues/1460): Add a linter for incorrect `:require` options
 - [#1794](https://github.com/clj-kondo/clj-kondo/issues/1794): Add a linter for line length
+- [#1460](https://github.com/clj-kondo/clj-kondo/issues/1460): Add a linter for unknown `:require` options
 
 ## 2022.09.08
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -546,6 +546,18 @@ Explanation by Bozhidar Batsov:
 
 *Example message:* `Format string expects 1 arguments instead of 2.`.
 
+### Incorrect :require Option
+
+*Keyword:* `:incorrect-require-option`
+
+*Description:* warn on unknown `:require` option pairs.
+
+*Default level:* `:error`.
+
+*Example trigger:* `(ns foo (:require [bar :s b]))`.
+
+*Example message:* `unknown :require option: ':s b'`.
+
 ### Inline def
 
 *Keyword:* `:inline-def`.

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -63,6 +63,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Syntax](#syntax)
     - [Type mismatch](#type-mismatch)
     - [Unbound destructuring default](#unbound-destructuring-default)
+    - [Unknown :require option](#unknown-require-option)
     - [Unused binding](#unused-binding)
     - [Used underscored bindings](#used-underscored-bindings)
     - [Unreachable code](#unreachable-code)
@@ -545,18 +546,6 @@ Explanation by Bozhidar Batsov:
 *Example trigger:* `(format "%s" 1 2)`.
 
 *Example message:* `Format string expects 1 arguments instead of 2.`.
-
-### Incorrect :require Option
-
-*Keyword:* `:incorrect-require-option`
-
-*Description:* warn on unknown `:require` option pairs.
-
-*Default level:* `:error`.
-
-*Example trigger:* `(ns foo (:require [bar :s b]))`.
-
-*Example message:* `unknown :require option: ':s b'`.
 
 ### Inline def
 
@@ -1156,6 +1145,18 @@ These warnings can be enabled by setting the level to `:warning` or
 ``` clojure
 {:linters {:used-underscored-binding {:level :warning}}}
 ```
+
+### Unknown :require option
+
+*Keyword:* `:unknown-require-option`
+
+*Description:* warn on unknown `:require` option pairs.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(ns foo (:require [bar :s b]))`.
+
+*Example message:* `Unknown :require option: ':s b'`.
 
 ### Unreachable code
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1156,7 +1156,7 @@ These warnings can be enabled by setting the level to `:warning` or
 
 *Example trigger:* `(ns foo (:require [bar :s b]))`.
 
-*Example message:* `Unknown :require option: ':s b'`.
+*Example message:* `Unknown :require option: :s`.
 
 ### Unreachable code
 

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -227,11 +227,10 @@
                         filename
                         child-expr
                         :unknown-require-option
-                        (format "Unknown %srequire option: '%s %s'"
+                        (format "Unknown %srequire option: %s"
                                 (if require-sym
                                   "" ":")
-                                child-k
-                                opt-expr)))
+                                child-k)))
                     (recur (nnext children)
                            m))))
             (let [{:keys [:as :referred :excluded :referred-all :renamed]} m

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -221,8 +221,19 @@
                        (update :excluded into (set (keys opt)))
                        ;; for :refer it is sufficient to pretend they were never referred
                        (update :referred set/difference (set (keys opt))))))
-                (recur (nnext children)
-                       m)))
+                (do (findings/reg-finding!
+                      ctx
+                      (node->line
+                        filename
+                        child-expr
+                        :incorrect-require-option
+                        (format "unknown %srequire option: '%s %s'"
+                                (if require-sym
+                                  "" ":")
+                                child-k
+                                opt-expr)))
+                    (recur (nnext children)
+                           m))))
             (let [{:keys [:as :referred :excluded :referred-all :renamed]} m
                   referred (if (and referred-all
                                     (identical? :clj base-lang))

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -226,8 +226,8 @@
                       (node->line
                         filename
                         child-expr
-                        :incorrect-require-option
-                        (format "unknown %srequire option: '%s %s'"
+                        :unknown-require-option
+                        (format "Unknown %srequire option: '%s %s'"
                                 (if require-sym
                                   "" ":")
                                 child-k

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -36,6 +36,7 @@
               :datalog-syntax {:level :error}
               :unbound-destructuring-default {:level :warning}
               :used-underscored-binding {:level :off}
+              :unknown-require-option {:level :warning}
               :unused-binding {:level :warning
                                :exclude-destructured-keys-in-fn-args false
                                :exclude-destructured-as false
@@ -132,8 +133,7 @@
               :warn-on-reflection {:level :off
                                    :warn-only-on-interop true}
               :line-length {:level :warning
-                            :max-line-length nil}
-              :incorrect-require-option {:level :error}}
+                            :max-line-length nil}}
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -132,7 +132,8 @@
               :warn-on-reflection {:level :off
                                    :warn-only-on-interop true}
               :line-length {:level :warning
-                            :max-line-length nil}}
+                            :max-line-length nil}
+              :incorrect-require-option {:level :error}}
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1791,9 +1791,6 @@ foo/foo ;; this does use the private var
                      {:linters {:unresolved-symbol {:level :error}}})))
   (is (empty? (lint! (io/file "corpus" "core.rrb-vector.clj")
                      {:linters {:unresolved-symbol {:level :error}}})))
-  ;; don't crash in this example. maybe in the future have better syntax checking for ns
-  ;; see GH-497
-  (is (empty? (lint! "(ns circleci.rollcage.test-core (:require [clojure.test :refer :refer [deftest]]))")))
   (is (empty? (lint! "(defn get-email [{email :email :as user :or {email user}}] email)"
                      {:linters {:unresolved-symbol {:level :error}}})))
   (is (empty? (lint! "(ns repro (:require [clojure.string :refer [starts-with?]]))

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -441,6 +441,15 @@ foo/foo ;; this does use the private var
                               foo.bar]))"
                   {:linters {:unused-namespace {:level :off}}})))))
 
+(deftest incorrect-require-option-test
+  (is (= '({:file "<stdin>",
+            :row 1,
+            :col 24,
+            :level :error,
+            :message "unknown :require option: ':s b'"})
+         (lint! "(ns foo (:require [bar :s b]))"
+                {:linters {:incorrect-require-option {:level :error}}}))))
+
 (deftest rename-test
   (testing "the renamed function isn't available under the referred name"
     (assert-submaps

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -441,15 +441,6 @@ foo/foo ;; this does use the private var
                               foo.bar]))"
                   {:linters {:unused-namespace {:level :off}}})))))
 
-(deftest incorrect-require-option-test
-  (is (= '({:file "<stdin>",
-            :row 1,
-            :col 24,
-            :level :error,
-            :message "unknown :require option: ':s b'"})
-         (lint! "(ns foo (:require [bar :s b]))"
-                {:linters {:incorrect-require-option {:level :error}}}))))
-
 (deftest rename-test
   (testing "the renamed function isn't available under the referred name"
     (assert-submaps

--- a/test/clj_kondo/unknown_require_option_test.clj
+++ b/test/clj_kondo/unknown_require_option_test.clj
@@ -7,7 +7,7 @@
             :row 1,
             :col 24,
             :level :warning,
-            :message "Unknown :require option: ':s b'"})
+            :message "Unknown :require option: :s"})
          (lint! "(ns foo (:require [bar :s b]))"
                 {:linters {:unknown-require-option {:level :warning}}}))))
 

--- a/test/clj_kondo/unknown_require_option_test.clj
+++ b/test/clj_kondo/unknown_require_option_test.clj
@@ -10,3 +10,8 @@
             :message "Unknown :require option: ':s b'"})
          (lint! "(ns foo (:require [bar :s b]))"
                 {:linters {:unknown-require-option {:level :warning}}}))))
+
+(deftest ignorable-test
+  (is (= '()
+         (lint! "(ns foo (:require #_:clj-kondo/ignore [bar :s b]))"
+                {:linters {:unknown-require-option {:level :warning}}}))))

--- a/test/clj_kondo/unknown_require_option_test.clj
+++ b/test/clj_kondo/unknown_require_option_test.clj
@@ -1,0 +1,12 @@
+(ns clj-kondo.unknown-require-option-test
+  (:require [clj-kondo.test-utils :refer [lint!]]
+            [clojure.test :refer [deftest is]]))
+
+(deftest unknown-require-option-test
+  (is (= '({:file "<stdin>",
+            :row 1,
+            :col 24,
+            :level :warning,
+            :message "Unknown :require option: ':s b'"})
+         (lint! "(ns foo (:require [bar :s b]))"
+                {:linters {:unknown-require-option {:level :warning}}}))))


### PR DESCRIPTION
Warns on unknown `:require` option pairs. Includes no options as I can't think of any reason to include that at this time.

Closes #1460

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
