### PR TITLE
Ignore incorrect class symbols error objects when analyzing imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#1460](https://github.com/clj-kondo/clj-kondo/issues/1460): Add a linter for unknown `:require` options
 - [#1807](https://github.com/clj-kondo/clj-kondo/issues/1807): false positive with map transducer in cljs
 - [#1806](https://github.com/clj-kondo/clj-kondo/issues/1806): false positive recur mismatch with letfn
+- [#1810](https://github.com/clj-kondo/clj-kondo/issues/1810): Fix printing error map as additional error
 
 ## 2022.09.08
 

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -261,9 +261,10 @@
   (if-let [v (:value node)]
     (with-meta v
       (meta node))
-    (findings/reg-finding!
-     ctx
-     (node->line (:filename ctx) node :syntax "Expected: class symbol"))))
+    (do (findings/reg-finding!
+          ctx
+          (node->line (:filename ctx) node :syntax "Expected: class symbol"))
+        nil)))
 
 (defn analyze-import [ctx _ns-name libspec-expr]
   (utils/handle-ignore ctx libspec-expr)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2857,6 +2857,11 @@ foo/baz
    '({:file "<stdin>", :row 1, :col 10, :level :error, :message "import form is invalid: clauses must not be empty"})
    (lint! "(import '())")))
 
+(deftest expected-class-symbol-test
+  (is (empty?
+        (with-out-str
+          (lint! "(ns circle.http.api.v2.context (:import [circle.http.defapi :refer [defapi-with-auth]]))")))))
+
 (deftest empty-require
   (assert-submaps
    '({:file "<stdin>", :row 1, :col 19, :level :error, :message "require form is invalid: clauses must not be empty"})


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

---

Found when working on other stuff.

Closes #1810 