### PR TITLE
Include vectors in :exclude-destructured-as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - [#1758](https://github.com/clj-kondo/clj-kondo/issues/1758): Overrides don't get applied to var-definitions during analysis
 - [#1794](https://github.com/clj-kondo/clj-kondo/issues/1794): Add a linter for line length
-- [#1460](https://github.com/clj-kondo/clj-kondo/issues/1460): Add a linter for unknown `:require` options
+- [#1460](https://github.com/clj-kondo/clj-kondo/issues/1460): Add a linter for unknown `:require` options ([@noahtheduke](https://github.com/noahtheduke))
 - [#1807](https://github.com/clj-kondo/clj-kondo/issues/1807): false positive with map transducer in cljs
 - [#1806](https://github.com/clj-kondo/clj-kondo/issues/1806): false positive recur mismatch with letfn
 - [#1810](https://github.com/clj-kondo/clj-kondo/issues/1810): Fix printing error map as additional error
 - [#1812](https://github.com/clj-kondo/clj-kondo/issues/1812): Inconsistent handling of location metadata sometimes produces nil values
-- [#1800](https://github.com/clj-kondo/clj-kondo/issues/1800): Add `:aliased-namespace-symbol`, a linter that checks qualified symbols to see if they're using an existing alias.
+- [#1800](https://github.com/clj-kondo/clj-kondo/issues/1800): Add `:aliased-namespace-symbol`, a linter that checks qualified symbols to see if they're using an existing alias. ([@noahtheduke](https://github.com/noahtheduke))
 - [#1805](https://github.com/clj-kondo/clj-kondo/issues/1805): Ignore hints not being considered on protocol vars
 - [#1819](https://github.com/clj-kondo/clj-kondo/issues/1819): Fix "Too many open files" in java class definition analysis caused by files not being closed
-- [#1821](https://github.com/clj-kondo/clj-kondo/issues/1821): Include vectors in `:unused-binding` config `:exclude-destructured-as` flag.
+- [#1821](https://github.com/clj-kondo/clj-kondo/issues/1821): Include vectors in `:unused-binding` config `:exclude-destructured-as` flag. ([@noahtheduke](https://github.com/noahtheduke))
 
 ## 2022.09.08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#1800](https://github.com/clj-kondo/clj-kondo/issues/1800): Add `:aliased-namespace-symbol`, a linter that checks qualified symbols to see if they're using an existing alias.
 - [#1805](https://github.com/clj-kondo/clj-kondo/issues/1805): Ignore hints not being considered on protocol vars
 - [#1819](https://github.com/clj-kondo/clj-kondo/issues/1819): Fix "Too many open files" in java class definition analysis caused by files not being closed
+- [#1821](https://github.com/clj-kondo/clj-kondo/issues/1821): Include vectors in `:unused-binding` config `:exclude-destructured-as` flag.
 
 ## 2022.09.08
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1129,6 +1129,8 @@ This will disable the warning in:
 
 ``` clojure
 (defn f [{:keys [a b c] :as g}] a b c)
+
+(defn g [[a :as b]] a)
 ```
 
 To exclude warnings about defmulti dispatch function arguments, use:

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -248,13 +248,12 @@
                        exclude-as? (and as-binding?
                                         (-> ctx :config :linters :unused-binding
                                             :exclude-destructured-as))
-                       [_as as-var] (when exclude-as?
-                                      (drop (- (count children) 2) children))
+                       as-sym (when exclude-as? (last children))
                        v (let [ctx (update ctx :callstack conj [nil :vector])]
                            (if all-tokens?
                              (map #(extract-bindings ctx % scoped-expr opts) children)
                              (-> (reduce (fn [[ctx acc] expr]
-                                           (let [ctx (if (and exclude-as? (= expr as-var))
+                                           (let [ctx (if (and exclude-as? (= expr as-sym))
                                                        (assoc ctx :mark-bindings-used? true)
                                                        ctx)
                                                  bnds (extract-bindings ctx expr scoped-expr opts)]

--- a/test/clj_kondo/bindings_test.clj
+++ b/test/clj_kondo/bindings_test.clj
@@ -283,6 +283,10 @@
                        '{:linters {:unused-binding
                                    {:level :warning
                                     :exclude-destructured-as true}}})))
+    (is (empty? (lint! "(defn f [[a :as config]] a)"
+                       '{:linters {:unused-binding
+                                   {:level :warning
+                                    :exclude-destructured-as true}}})))
     (testing "still shows unused bindings not in as "
       (assert-submaps '({:file "<stdin>"
                          :row 1


### PR DESCRIPTION
Fixes #1821

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

---

Relatively simple change:
1. Check if the vector has an `:as` binding and if the `:exclude-destructured-as` is set.
2. If so, store the vector's last child as `as-sym`.
3. When looping over the vector's children, if the expr matches the `as-sym`, mark binding as used on context (same as how map destructuring works).

Closes #1821