### PR TITLE
Check for :redundant-fn-wrapper with keywords and bound symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#1831](https://github.com/clj-kondo/clj-kondo/issues/1831): Fix `:redundant-fn-wrapper` not applying to keywords or let-bound vars.
+
 ...
 
 ## 2022.10.05

--- a/test/clj_kondo/redundant_fn_wrapper_test.clj
+++ b/test/clj_kondo/redundant_fn_wrapper_test.clj
@@ -8,7 +8,13 @@
    (lint! "#(inc %)" {:linters {:redundant-fn-wrapper {:level :warning}}}))
   (assert-submaps
    '({:file "<stdin>", :row 1, :col 1, :level :warning, :message "Redundant fn wrapper"})
-   (lint! "#(inc %1)" {:linters {:redundant-fn-wrapper {:level :warning}}})))
+   (lint! "#(inc %1)" {:linters {:redundant-fn-wrapper {:level :warning}}}))
+  (assert-submaps
+    '({:file "<stdin>", :row 1, :col 6, :level :warning, :message "Redundant fn wrapper"})
+    (lint! "(map #(:a %) uuids)" {:linters {:redundant-fn-wrapper {:level :warning}}}))
+  (assert-submaps
+    '({:file "<stdin>", :row 1, :col 19, :level :warning, :message "Redundant fn wrapper"})
+   (lint! "(let [i inc] (map #(i %) uuids))" {:linters {:redundant-fn-wrapper {:level :warning}}})))
 
 (deftest no-redundant-fn-wrapper-test
   (is (empty?


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

---

Closes #1831 

Unsure if the new function is the right move. Felt weird to copy-paste the whole `when` block 3 times but it also felt weird to include `interop?` in the signature.

Seems like there's a lot of redundancy in how these calls are checked. Should all of this be unified somehow? I was surprised to see that this isn't in a `lint-anonymous-fn` function but stored on the var and then linted after the fact.