### PR TITLE
fix: discouraged-var :level :off w/ merged configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#1842](https://github.com/clj-kondo/clj-kondo/issues/1842): Add `:exclude` option to `:used-underscored-binding` ([@staifa](https://github.com/staifa))
 - [#1840](https://github.com/clj-kondo/clj-kondo/issues/1840): Fix warning in `.cljs` and `.cljc` for `:aliased-namespace-symbol` in interop calls. ([@NoahTheDuke](https://github.com/NoahTheDuke))
 - [#1845](https://github.com/clj-kondo/clj-kondo/issues/1845): add `:derived-location` to analysis when location is derived from parent node
+- [#1853](https://github.com/clj-kondo/clj-kondo/issues/1853): fix `:level :off` not being respected in `:discouraged-var` configs that are merged in.
 
 ## 2022.10.14
 

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -328,7 +328,8 @@
                   _
                   (let [discouraged-var-config
                         (get-in (:config call) [:linters :discouraged-var])]
-                    (when-not (empty? (dissoc discouraged-var-config :level))
+                    (when-not (or (identical? :off (:level discouraged-var-config))
+                                  (empty? (dissoc discouraged-var-config :level)))
                       (let [fn-lookup-sym (symbol (str (config/ns-group call-config resolved-ns filename))
                                                   (str fn-name))]
                         (when-let [cfg (get discouraged-var-config fn-lookup-sym)]

--- a/test/clj_kondo/discouraged_var_test.clj
+++ b/test/clj_kondo/discouraged_var_test.clj
@@ -3,7 +3,7 @@
    [clj-kondo.test-utils :refer [lint! assert-submaps]]
    [clojure.test :as t :refer [deftest is testing]]))
 
-(deftest config-in-ns-test
+(deftest discouraged-var-test
   (assert-submaps
    '({:file "<stdin>", :row 1, :col 15, :level :warning, :message "Too slow"})
    (lint! "(defn foo [x] (satisfies? Datafy x))"
@@ -16,4 +16,16 @@
   (assert-submaps
    '({:file "<stdin>", :row 1, :col 34, :level :warning, :message "Closed source"})
    (lint! "(require '[closed.source :as s]) (s/fn)"
-          '{:linters  {:discouraged-var {closed.source/fn {:message "Closed source"}}}})))
+          '{:linters  {:discouraged-var {closed.source/fn {:message "Closed source"}}}}))
+  (assert-submaps
+   '()
+   (lint! "(require '[closed.source :as s]) (comment (s/fn))"
+                 '{:linters  {:discouraged-var {closed.source/fn {:message "Closed source"}}}
+                   :config-in-comment
+                   {:linters {:discouraged-var {:level :off}}}}))
+  (assert-submaps
+    '()
+    (lint!
+      (str "(ns foo {:clj-kondo/config {:linters {:discouraged-var {:level :off}}}})\n"
+           "(satisfies? Datafy 5)")
+      '{:linters  {:discouraged-var {clojure.core/satisfies? {:message "Too slow"}}}})))


### PR DESCRIPTION
Fixes an issue where merged configs (config-in-comment, config-in-ns, ns-metadata, etc.) that updated the :level in `discouraged-var` to :off were ignored.

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). Fixes #1853 

- [X] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
