### PR TITLE
Remove Rosetta2 from installation docs

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -61,15 +61,6 @@ To install with brew:
 To upgrade:
 
     brew upgrade clj-kondo
-    
-Apple's new M1 Silicon computers use the ARM architecture, instead of Intel. To use clj-kondo, you'll need to install Rosetta2:
-
-    softwareupdate --install-rosetta
-    <accept the prompt>
-    
-Once Rosetta2 is installed, try the ordinary `brew install`; if that doesn't work, it's possible that you'll instead need to:
-
-    arch -x86_64 brew install borkdude/brew/clj-kondo
 
 <!-- ## NPM (Linux, MacOS, Windows) -->
 


### PR DESCRIPTION
As of 2022.06.22 we now have a MacOS aarch64 (M1-compatible) binary via #1728.

Please answer the following questions and leave the below in as part of your PR.

- [ ] ~I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).~ **N/A**

- [ ] ~This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).~ **N/A**

- [ ] ~This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions~ **N/A**

- [ ] ~I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.~ **N/A**
