### PR TITLE
reset docker hook to stable image tag

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,7 +11,7 @@
 - id: clj-kondo-docker
   name: clj-kondo (via docker)
   description: '`clj-kondo` is a command-line utility for enforcing style consistency across Clojure projects.'
-  entry: cljkondo/clj-kondo:2022.11.03-SNAPSHOT
+  entry: cljkondo/clj-kondo:2022.11.02
   args: [clj-kondo, --lint]
   language: docker_image
   types: [clojure]


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - see discussion in #1864 

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

just sets the docker pre-commit hook to the last stable tagged release. This will get bumped next time a release is cut