### PR TITLE
unit tests: explore using matcher-combinators lib

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,9 @@
              }}
            :reduce-without-init {:level :warning}
            :missing-docstring {:level :off}
-           :unsorted-required-namespaces {:level :warning}}
+           :unsorted-required-namespaces {:level :warning}
+           ;; for  nubank/matcher-combinators
+           :unresolved-symbol {:exclude [(clojure.test/is [match?])]}}
  :lint-as {me.raynes.conch/programs clojure.core/declare
            me.raynes.conch/let-programs clojure.core/let
            datalog.parser.type/deftrecord clojure.core/defrecord
@@ -36,4 +38,5 @@
  :ns-groups [{:pattern ".*-test"
               :name test-namespaces}]
  :config-in-ns {test-namespaces {:linters {:warn-on-reflection {:level :off}}}}
+
  }

--- a/deps.edn
+++ b/deps.edn
@@ -30,7 +30,8 @@
              jonase/eastwood {:mvn/version "1.3.0"}
              borkdude/missing.test.assertions {:mvn/version "0.0.2"}
              babashka/process {:mvn/version "0.1.0"}
-             org.clojure/tools.deps.alpha {:mvn/version "0.12.1048"}}
+             org.clojure/tools.deps.alpha {:mvn/version "0.12.1048"}
+             nubank/matcher-combinators {:mvn/version "3.5.1" :exclusions [midje/midje]}}
             :extra-paths ["test" "extract"]
             :main-opts ["-m" "cognitect.test-runner"]}
            :clojure-1.9.0 {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,8 @@
                                    [jonase/eastwood "1.3.0"]
                                    [borkdude/missing.test.assertions "0.0.2"]
                                    [babashka/process "0.1.0"]
-                                   [org.clojure/tools.deps.alpha "0.12.1048"]]
+                                   [org.clojure/tools.deps.alpha "0.12.1048"]
+                                   [nubank/matcher-combinators "3.5.1" :exclusions [midje/midje]]]
                     :source-paths ["src" "parser" "inlined" "extract"]}
              :uberjar {:dependencies [[com.github.clj-easy/graal-build-time "0.1.0"]]
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"

--- a/test/clj_kondo/analysis/java_test.clj
+++ b/test/clj_kondo/analysis/java_test.clj
@@ -38,7 +38,7 @@
     (assert-submap2
      {:class "clojure.lang.RT",
       :uri #"jar:file:.*\.clj",
-      :filename #".*\.clj2"}
+      :filename #".*\.clj"}
      rt-usage)
     (is (every? number? ((juxt :row
                                :col

--- a/test/clj_kondo/analysis/java_test.clj
+++ b/test/clj_kondo/analysis/java_test.clj
@@ -2,11 +2,11 @@
   (:require
    [clj-kondo.core :as clj-kondo]
    [clj-kondo.impl.utils :refer [err]]
+   [clj-kondo.test-utils :refer [assert-submap2 assert-submaps2]]
    #_[clojure.edn :as edn]
    #_[clojure.string :as string]
    [clojure.test :as t :refer [deftest is testing]]
-   [clojure.tools.deps.alpha :as deps]
-   [matcher-combinators.test]))
+   [clojure.tools.deps.alpha :as deps]))
 
 (defn analyze
   ([paths] (analyze paths nil))
@@ -30,16 +30,16 @@
                         %) java-class-definitions)
         rt-usage (some #(when (= (:class %) "clojure.lang.RT")
                           %) java-class-usages)]
-    (is (match?
-          {:class "clojure.lang.RT",
-           :uri #"jar:file:.*/org/clojure/clojure/1.10.3/clojure-1.10.3.jar!/clojure/lang/RT.class",
-           :filename #"\.class"}
-          rt-def))
-    (is (match?
-          {:class "clojure.lang.RT",
-           :uri #"jar:file:.*\.clj",
-           :filename #".*\.clj"}
-          rt-usage))
+    (assert-submap2
+     {:class "clojure.lang.RT",
+      :uri #"jar:file:.*/org/clojure/clojure/1.10.3/clojure-1.10.3.jar!/clojure/lang/RT.class",
+      :filename #"\.class"}
+     rt-def)
+    (assert-submap2
+     {:class "clojure.lang.RT",
+      :uri #"jar:file:.*\.clj",
+      :filename #".*\.clj2"}
+     rt-usage)
     (is (every? number? ((juxt :row
                                :col
                                :end-row
@@ -47,74 +47,74 @@
 
 (deftest local-classes-test
   (let [{:keys [:java-class-definitions]} (analyze ["corpus/java/classes"])]
-    (is (match?
-          '[{:class "foo.bar.AwesomeClass",
-             :uri #"file:.*/corpus/java/classes/foo/bar/AwesomeClass.class",
-             :filename #".*corpus/java/classes/foo/bar/AwesomeClass.class"}]
-          java-class-definitions)))
+    (assert-submaps2
+     '[{:class "foo.bar.AwesomeClass",
+        :uri #"file:.*/corpus/java/classes/foo/bar/AwesomeClass.class",
+        :filename #".*corpus/java/classes/foo/bar/AwesomeClass.class"}]
+     java-class-definitions))
   (let [{:keys [:java-class-definitions]} (analyze ["corpus/java/sources"])]
-    (is (match?
-          '[{:class "foo.bar.AwesomeClass",
-             :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
-             :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
-          java-class-definitions)))
+    (assert-submaps2
+     '[{:class "foo.bar.AwesomeClass",
+        :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
+        :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
+     java-class-definitions))
   (testing "linting just one java source"
     (let [{:keys [:java-class-definitions]} (analyze ["corpus/java/sources/foo/bar/AwesomeClass.java"])]
-      (is (match?
-            '[{:class "foo.bar.AwesomeClass",
-               :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
-               :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
-            java-class-definitions)))))
+      (assert-submaps2
+       '[{:class "foo.bar.AwesomeClass",
+          :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
+          :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
+       java-class-definitions))))
 
 (deftest class-usages-test
   (let [{:keys [:java-class-usages :var-usages]} (analyze ["corpus/java/usages.clj"])]
     (is (= '(try fn new import) (map :name var-usages)))
-    (is (match?
-          [{:class "clojure.lang.PersistentVector", :uri #"file:.*corpus/java/usages.clj",
-            :filename #"corpus/java/usages.clj", :row 1, :col 40, :end-row 1, :end-col 56
-            :import true}
-           {:class "java.lang.Exception"
-            :uri #"file:.*corpus/java/usages.clj"
-            :filename #"corpus/java/usages.clj"
-            :row 3 :col 13 :end-row 3 :end-col 22
-            :name-row 3 :name-col 13 :name-end-row 3 :name-end-col 22}
-           {:class "java.lang.Thread"
-            :uri #"file:.*corpus/java/usages.clj"
-            :filename #"corpus/java/usages.clj"
-            :row 4 :col 1 :end-row 4 :end-col 13
-            :name-row 4 :name-col 1 :name-end-row 4 :name-end-col 13}
-           {:class "java.lang.Thread"
-            :uri #"file:.*corpus/java/usages.clj"
-            :filename #"corpus/java/usages.clj"
-            :row 5 :col 1 :end-row 5 :end-col 19
-            :name-row 5 :name-col 2 :name-end-row 5 :name-end-col 14}
-           {:class "java.lang.Thread"
-            :uri #"file:.*corpus/java/usages.clj"
-            :filename #"corpus/java/usages.clj"
-            :row 6 :col 2 :end-row 6 :end-col 9
-            :name-row 6 :name-col 2 :name-end-row 6 :name-end-col 9}
-           {:end-row 7, :name-end-col 17, :name-end-row 7, :name-row 7,
-            :filename #"corpus/java/usages.clj", :col 1,
-            :class "clojure.lang.PersistentVector", :name-col 1,
-            :uri #"file:.*corpus/java/usages.clj", :end-col 17, :row 7}
-           {:class "clojure.lang.Compiler", :uri #"file:.*corpus/java/usages.clj",
-            :filename #"corpus/java/usages.clj",
-            :row 9, :col 24, :end-row 9, :end-col 32, :import true}
-           {:end-row 10, :name-end-col 18, :name-end-row 10, :name-row 10,
-            :uri #"file:.*corpus/java/usages.clj", :col 1, :class "clojure.lang.Compiler", :name-col 1,
-            :filename #"corpus/java/usages.clj"
-            :end-col 18, :row 10}
-           {:class "foo.bar.Baz",
-            :uri #"file:.*corpus/java/usages.clj",
-            :filename #"corpus/java/usages.clj", :row 11, :col 1, :end-row 11, :end-col 12}
-           {:class "foo.bar.Baz", :uri #"file:.*corpus/java/usages.clj",
-            :filename #"corpus/java/usages.clj", :row 12, :col 1, :end-row 12, :end-col 18}
-           {:class "java.util.Date", :uri #"file:.*corpus/java/usages.clj",
-            :filename #"corpus/java/usages.clj", :row 13, :col 1, :end-row 13, :end-col 15}
-           {:class "java.io.File", :uri #"file:.*corpus/java/usages.clj",
-            :filename #"corpus/java/usages.clj", :row 14, :col 1, :end-row 14, :end-col 42
-            :name-col 2 :name-end-col 29, :name-end-row 14, :name-row 14}]
-          java-class-usages))))
+    (assert-submaps2
+     [{:class "clojure.lang.PersistentVector", :uri #"file:.*corpus/java/usages.clj",
+       :filename #"corpus/java/usages.clj", :row 1, :col 40, :end-row 1, :end-col 56
+       :import true}
+      {:class "java.lang.Exception"
+       :uri #"file:.*corpus/java/usages.clj"
+       :filename #"corpus/java/usages.clj"
+       :row 3 :col 13 :end-row 3 :end-col 22
+       :name-row 3 :name-col 13 :name-end-row 3 :name-end-col 22}
+      {:class "java.lang.Thread"
+       :uri #"file:.*corpus/java/usages.clj"
+       :filename #"corpus/java/usages.clj"
+       :row 4 :col 1 :end-row 4 :end-col 13
+       :name-row 4 :name-col 1 :name-end-row 4 :name-end-col 13}
+      {:class "java.lang.Thread"
+       :uri #"file:.*corpus/java/usages.clj"
+       :filename #"corpus/java/usages.clj"
+       :row 5 :col 1 :end-row 5 :end-col 19
+       :name-row 5 :name-col 2 :name-end-row 5 :name-end-col 14}
+      {:class "java.lang.Thread"
+       :uri #"file:.*corpus/java/usages.clj"
+       :filename #"corpus/java/usages.clj"
+       :row 6 :col 2 :end-row 6 :end-col 9
+       :name-row 6 :name-col 2 :name-end-row 6 :name-end-col 9}
+      {:end-row 7, :name-end-col 17, :name-end-row 7, :name-row 7,
+       :filename #"corpus/java/usages.clj", :col 1,
+       :class "clojure.lang.PersistentVector", :name-col 1,
+       :uri #"file:.*corpus/java/usages.clj", :end-col 17, :row 7}
+      {:class "clojure.lang.Compiler", :uri #"file:.*corpus/java/usages.clj",
+       :filename #"corpus/java/usages.clj",
+       :row 9, :col 24, :end-row 9, :end-col 32, :import true}
+      {:end-row 10, :name-end-col 18, :name-end-row 10, :name-row 10,
+       :uri #"file:.*corpus/java/usages.clj", :col 1, :class "clojure.lang.Compiler", :name-col 1,
+       :filename #"corpus/java/usages.clj"
+       :end-col 18, :row 10}
+      {:class "foo.bar.Baz",
+       :uri #"file:.*corpus/java/usages.clj",
+       :filename #"corpus/java/usages.clj", :row 11, :col 1, :end-row 11, :end-col 12}
+      {:class "foo.bar.Baz", :uri #"file:.*corpus/java/usages.clj",
+       :filename #"corpus/java/usages.clj", :row 12, :col 1, :end-row 12, :end-col 18}
+      {:class "java.util.Date", :uri #"file:.*corpus/java/usages.clj",
+       :filename #"corpus/java/usages.clj", :row 13, :col 1, :end-row 13, :end-col 15}
+      {:class "java.io.File", :uri #"file:.*corpus/java/usages.clj",
+       :filename #"corpus/java/usages.clj", :row 14, :col 1, :end-row 14, :end-col 42
+       :name-col 2 :name-end-col 29, :name-end-row 14, :name-row 14}]
+     java-class-usages)))
 
 (comment
 

--- a/test/clj_kondo/analysis/java_test.clj
+++ b/test/clj_kondo/analysis/java_test.clj
@@ -2,11 +2,11 @@
   (:require
    [clj-kondo.core :as clj-kondo]
    [clj-kondo.impl.utils :refer [err]]
-   [clj-kondo.test-utils :refer [assert-submap assert-submaps]]
    #_[clojure.edn :as edn]
    #_[clojure.string :as string]
    [clojure.test :as t :refer [deftest is testing]]
-   [clojure.tools.deps.alpha :as deps]))
+   [clojure.tools.deps.alpha :as deps]
+   [matcher-combinators.test]))
 
 (defn analyze
   ([paths] (analyze paths nil))
@@ -30,16 +30,16 @@
                         %) java-class-definitions)
         rt-usage (some #(when (= (:class %) "clojure.lang.RT")
                           %) java-class-usages)]
-    (assert-submap
-     {:class "clojure.lang.RT",
-      :uri #"jar:file:.*/org/clojure/clojure/1.10.3/clojure-1.10.3.jar!/clojure/lang/RT.class",
-      :filename #"\.class"}
-     rt-def)
-    (assert-submap
-     {:class "clojure.lang.RT",
-      :uri #"jar:file:.*\.clj",
-      :filename #".*\.clj"}
-     rt-usage)
+    (is (match?
+          {:class "clojure.lang.RT",
+           :uri #"jar:file:.*/org/clojure/clojure/1.10.3/clojure-1.10.3.jar!/clojure/lang/RT.class",
+           :filename #"\.class"}
+          rt-def))
+    (is (match?
+          {:class "clojure.lang.RT",
+           :uri #"jar:file:.*\.clj",
+           :filename #".*\.clj"}
+          rt-usage))
     (is (every? number? ((juxt :row
                                :col
                                :end-row
@@ -47,74 +47,74 @@
 
 (deftest local-classes-test
   (let [{:keys [:java-class-definitions]} (analyze ["corpus/java/classes"])]
-    (assert-submaps
-     '[{:class "foo.bar.AwesomeClass",
-        :uri #"file:.*/corpus/java/classes/foo/bar/AwesomeClass.class",
-        :filename #".*corpus/java/classes/foo/bar/AwesomeClass.class"}]
-     java-class-definitions))
+    (is (match?
+          '[{:class "foo.bar.AwesomeClass",
+             :uri #"file:.*/corpus/java/classes/foo/bar/AwesomeClass.class",
+             :filename #".*corpus/java/classes/foo/bar/AwesomeClass.class"}]
+          java-class-definitions)))
   (let [{:keys [:java-class-definitions]} (analyze ["corpus/java/sources"])]
-    (assert-submaps
-     '[{:class "foo.bar.AwesomeClass",
-        :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
-        :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
-     java-class-definitions))
+    (is (match?
+          '[{:class "foo.bar.AwesomeClass",
+             :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
+             :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
+          java-class-definitions)))
   (testing "linting just one java source"
     (let [{:keys [:java-class-definitions]} (analyze ["corpus/java/sources/foo/bar/AwesomeClass.java"])]
-      (assert-submaps
-       '[{:class "foo.bar.AwesomeClass",
-          :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
-          :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
-       java-class-definitions))))
+      (is (match?
+            '[{:class "foo.bar.AwesomeClass",
+               :uri #"file:.*/corpus/java/sources/foo/bar/AwesomeClass.java",
+               :filename #".*corpus/java/sources/foo/bar/AwesomeClass.java"}]
+            java-class-definitions)))))
 
 (deftest class-usages-test
   (let [{:keys [:java-class-usages :var-usages]} (analyze ["corpus/java/usages.clj"])]
     (is (= '(try fn new import) (map :name var-usages)))
-    (assert-submaps
-     [{:class "clojure.lang.PersistentVector", :uri #"file:.*corpus/java/usages.clj",
-       :filename #"corpus/java/usages.clj", :row 1, :col 40, :end-row 1, :end-col 56
-       :import true}
-      {:class "java.lang.Exception"
-       :uri #"file:.*corpus/java/usages.clj"
-       :filename #"corpus/java/usages.clj"
-       :row 3 :col 13 :end-row 3 :end-col 22
-       :name-row 3 :name-col 13 :name-end-row 3 :name-end-col 22}
-      {:class "java.lang.Thread"
-       :uri #"file:.*corpus/java/usages.clj"
-       :filename #"corpus/java/usages.clj"
-       :row 4 :col 1 :end-row 4 :end-col 13
-       :name-row 4 :name-col 1 :name-end-row 4 :name-end-col 13}
-      {:class "java.lang.Thread"
-       :uri #"file:.*corpus/java/usages.clj"
-       :filename #"corpus/java/usages.clj"
-       :row 5 :col 1 :end-row 5 :end-col 19
-       :name-row 5 :name-col 2 :name-end-row 5 :name-end-col 14}
-      {:class "java.lang.Thread"
-       :uri #"file:.*corpus/java/usages.clj"
-       :filename #"corpus/java/usages.clj"
-       :row 6 :col 2 :end-row 6 :end-col 9
-       :name-row 6 :name-col 2 :name-end-row 6 :name-end-col 9}
-      {:end-row 7, :name-end-col 17, :name-end-row 7, :name-row 7,
-       :filename #"corpus/java/usages.clj", :col 1,
-       :class "clojure.lang.PersistentVector", :name-col 1,
-       :uri #"file:.*corpus/java/usages.clj", :end-col 17, :row 7}
-      {:class "clojure.lang.Compiler", :uri #"file:.*corpus/java/usages.clj",
-       :filename #"corpus/java/usages.clj",
-       :row 9, :col 24, :end-row 9, :end-col 32, :import true}
-      {:end-row 10, :name-end-col 18, :name-end-row 10, :name-row 10,
-       :uri #"file:.*corpus/java/usages.clj", :col 1, :class "clojure.lang.Compiler", :name-col 1,
-       :filename #"corpus/java/usages.clj"
-       :end-col 18, :row 10}
-      {:class "foo.bar.Baz",
-       :uri #"file:.*corpus/java/usages.clj",
-       :filename #"corpus/java/usages.clj", :row 11, :col 1, :end-row 11, :end-col 12}
-      {:class "foo.bar.Baz", :uri #"file:.*corpus/java/usages.clj",
-       :filename #"corpus/java/usages.clj", :row 12, :col 1, :end-row 12, :end-col 18}
-      {:class "java.util.Date", :uri #"file:.*corpus/java/usages.clj",
-       :filename #"corpus/java/usages.clj", :row 13, :col 1, :end-row 13, :end-col 15}
-      {:class "java.io.File", :uri #"file:.*corpus/java/usages.clj",
-       :filename #"corpus/java/usages.clj", :row 14, :col 1, :end-row 14, :end-col 42
-       :name-col 2 :name-end-col 29, :name-end-row 14, :name-row 14}]
-     java-class-usages)))
+    (is (match?
+          [{:class "clojure.lang.PersistentVector", :uri #"file:.*corpus/java/usages.clj",
+            :filename #"corpus/java/usages.clj", :row 1, :col 40, :end-row 1, :end-col 56
+            :import true}
+           {:class "java.lang.Exception"
+            :uri #"file:.*corpus/java/usages.clj"
+            :filename #"corpus/java/usages.clj"
+            :row 3 :col 13 :end-row 3 :end-col 22
+            :name-row 3 :name-col 13 :name-end-row 3 :name-end-col 22}
+           {:class "java.lang.Thread"
+            :uri #"file:.*corpus/java/usages.clj"
+            :filename #"corpus/java/usages.clj"
+            :row 4 :col 1 :end-row 4 :end-col 13
+            :name-row 4 :name-col 1 :name-end-row 4 :name-end-col 13}
+           {:class "java.lang.Thread"
+            :uri #"file:.*corpus/java/usages.clj"
+            :filename #"corpus/java/usages.clj"
+            :row 5 :col 1 :end-row 5 :end-col 19
+            :name-row 5 :name-col 2 :name-end-row 5 :name-end-col 14}
+           {:class "java.lang.Thread"
+            :uri #"file:.*corpus/java/usages.clj"
+            :filename #"corpus/java/usages.clj"
+            :row 6 :col 2 :end-row 6 :end-col 9
+            :name-row 6 :name-col 2 :name-end-row 6 :name-end-col 9}
+           {:end-row 7, :name-end-col 17, :name-end-row 7, :name-row 7,
+            :filename #"corpus/java/usages.clj", :col 1,
+            :class "clojure.lang.PersistentVector", :name-col 1,
+            :uri #"file:.*corpus/java/usages.clj", :end-col 17, :row 7}
+           {:class "clojure.lang.Compiler", :uri #"file:.*corpus/java/usages.clj",
+            :filename #"corpus/java/usages.clj",
+            :row 9, :col 24, :end-row 9, :end-col 32, :import true}
+           {:end-row 10, :name-end-col 18, :name-end-row 10, :name-row 10,
+            :uri #"file:.*corpus/java/usages.clj", :col 1, :class "clojure.lang.Compiler", :name-col 1,
+            :filename #"corpus/java/usages.clj"
+            :end-col 18, :row 10}
+           {:class "foo.bar.Baz",
+            :uri #"file:.*corpus/java/usages.clj",
+            :filename #"corpus/java/usages.clj", :row 11, :col 1, :end-row 11, :end-col 12}
+           {:class "foo.bar.Baz", :uri #"file:.*corpus/java/usages.clj",
+            :filename #"corpus/java/usages.clj", :row 12, :col 1, :end-row 12, :end-col 18}
+           {:class "java.util.Date", :uri #"file:.*corpus/java/usages.clj",
+            :filename #"corpus/java/usages.clj", :row 13, :col 1, :end-row 13, :end-col 15}
+           {:class "java.io.File", :uri #"file:.*corpus/java/usages.clj",
+            :filename #"corpus/java/usages.clj", :row 14, :col 1, :end-row 14, :end-col 42
+            :name-col 2 :name-end-col 29, :name-end-row 14, :name-row 14}]
+          java-class-usages))))
 
 (comment
 


### PR DESCRIPTION
Of note:
- experiment currently limited to clj-kondo.analysis.java-test ns
- updated .clj-kondo/config.edn to ignore matcher-combinators' match? assert expr

Closes #1869

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
