### PR TITLE
Don't warn about single arg use when there's a second arg in a reader conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## 2022.12.10
 
-- [#1912](https://github.com/clj-kondo/clj-kondo/issues/1912): Allow forward references in `comment` forms
+- [#1914](https://github.com/clj-kondo/clj-kondo/issues/1914): Don't warn about single arg use when there's a second arg in a reader conditional ([@mk](https://github.com/mk))
+- [#1912](https://github.com/clj-kondo/clj-kondo/issues/1912): Allow forward references in `comment` forms ([@mk](https://github.com/mk))
 - [#1909](https://github.com/clj-kondo/clj-kondo/issues/1909): lower requirement on `glibc` in dynamic linux binary to 2.31 by using fixed version of CircleCI image
 
 ## 2022.12.08

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -625,7 +625,8 @@
                  ;; always pass when it's not one of these
                  (and (not= :redundant-do type)
                       (not= :redundant-call type)
-                      (not= :redundant-let type))
+                      (not= :redundant-let type)
+                      (not= :single-logical-operand type))
                  ;; but if we get here, then the amount of findings has to be bigger than 1
                  (> (count findings) 1))
           f findings

--- a/test/clj_kondo/single_operand_test.clj
+++ b/test/clj_kondo/single_operand_test.clj
@@ -67,3 +67,10 @@
   (doseq [lang ["clj" "cljs"]]
     (is (empty? (lint! "(and 1 2)" "--lang" lang)) "and with > 1 arg is ok")
     (is (empty? (lint! "(or 1 2 3)" "--lang" lang)) "or with > 1 arg is ok")))
+
+(deftest reader-conditional-test
+  (is (empty? (lint! "(let [scope *ns*]
+                 (or (#{:default} scope)
+                     #?(:clj (keyword? scope))))"
+                     {:linters {:single-logical-operand {:level :warning}}}
+                     "--lang" "cljc"))))


### PR DESCRIPTION
Fixes #1914.