### PR TITLE
Use backwards-compatible option for xargs

### DIFF
--- a/doc/ci-integration.md
+++ b/doc/ci-integration.md
@@ -32,7 +32,7 @@ else
     against=$(git hash-object -t tree /dev/null)
 fi
 
-if !(git diff --cached --name-only --diff-filter=AM $against | grep -E '.clj[cs]?$' | xargs --no-run-if-empty clj-kondo --lint)
+if !(git diff --cached --name-only --diff-filter=AM $against | grep -E '.clj[cs]?$' | xargs -r clj-kondo --lint)
 then
     echo
     echo "Error: new clj-kondo errors found. Please fix them and retry the commit."


### PR DESCRIPTION
From the manual
```
     -r      Compatibility with GNU xargs.  The GNU version of xargs runs the utility argument at least once, even if xargs input is empty, and it supports a -r
             option to inhibit this behavior.  The FreeBSD version of xargs does not run the utility argument on empty input, but it supports the -r option for
             command-line compatibility with GNU xargs, but the -r option does nothing in the FreeBSD version of xargs.
```