### PR TITLE
Avoid side-effects on `clj-kondo.impl.core` ns load

### DIFF
--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -18,9 +18,9 @@
 
 (def dev? (= "true" (System/getenv "CLJ_KONDO_DEV")))
 
-(def version
+(defn version []
   (str/trim
-   (slurp (io/resource "CLJ_KONDO_VERSION"))))
+    (slurp (io/resource "CLJ_KONDO_VERSION"))))
 
 (def cache-version "v1")
 

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -14,7 +14,7 @@
 ;;;; printing
 
 (defn- print-version []
-  (println (str "clj-kondo v" core-impl/version)))
+  (println (str "clj-kondo v" (core-impl/version))))
 
 (defn- print-help []
   (print-version)
@@ -57,7 +57,7 @@ Options:
     warning, error.  The default level if unspecified is warning.
 
   --debug: print debug information.
-" core-impl/version))
+" (core-impl/version)))
   nil)
 
 ;;;; parse command line options


### PR DESCRIPTION
This is more of a refactor to avoid loading a resource on ns load