### PR TITLE
Add :syntax-quote to :unresolved-namespace linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] script/bump_version post-release -->
 <!-- - [ ] update carve -->
 
+## Unreleased
+
+- [#1968](https://github.com/clj-kondo/clj-kondo/issues/1968): Add `:syntax-quote` to `:unresolved-namespace` linter to check syntax-quoted forms that are meant to fully-resolve. ([@NoahTheDuke](https://github.com/NoahTheDuke))
+
 ## 2023.01.20
 
 - [#1956](https://github.com/clj-kondo/clj-kondo/issues/1956): enable printing to `*err*` in hooks

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1367,6 +1367,20 @@ This will exclude all bindings starting with `_x`.
 
 *Config:* use `:exclude [foo.bar]` to suppress the above warning.
 
+You can check syntax-quoted symbols to make sure they use a resolved namespace with:
+
+```clojure
+{:linters {:unresolved-namespace {:syntax-quote true}}}
+```
+
+which will print an error if given
+
+```clojure
+(ns foo)
+
+`bar/x
+```
+
 You can report duplicate warnings using:
 
 ``` clojure

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -246,7 +246,9 @@
                            (utils/reg-call ctx usage (:id expr))
                            nil)))
                      (when (and unresolved?
-                                (get-in ctx [:config :linters :unresolved-namespace :syntax-quote]))
+                                (-> ctx :config :linters :unresolved-namespace :syntax-quote)
+                                symbol-val
+                                (not-empty (namespace symbol-val)))
                        (namespace/reg-unresolved-namespace!
                          ctx ns-name
                          (with-meta (symbol (namespace symbol-val))

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -245,7 +245,12 @@
                                                      usage)
                            (utils/reg-call ctx usage (:id expr))
                            nil)))
-
+                     (when (and unresolved?
+                                (get-in ctx [:config :linters :unresolved-namespace :syntax-quote]))
+                       (namespace/reg-unresolved-namespace!
+                         ctx ns-name
+                         (with-meta (symbol (namespace symbol-val))
+                                    (meta expr))))
                      nil))
                  ;; this is a symbol, either binding or var reference
                  (when-let [idx (:idx ctx)]

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -176,8 +176,14 @@
                           resolved-core? :resolved-core?
                           :as _m}
                          (let [v (namespace/resolve-name ctx false ns-name symbol-val expr)]
-                           (when-not syntax-quote?
-                             (when-let [n (:unresolved-ns v)]
+                           (when-let [n (:unresolved-ns v)]
+                             (if syntax-quote?
+                               (when (and (-> ctx :config :linters :unresolved-namespace :syntax-quote)
+                                          symbol-val)
+                                 (namespace/reg-unresolved-namespace!
+                                  ctx ns-name
+                                  (with-meta n
+                                    (meta expr))))
                                (namespace/reg-unresolved-namespace!
                                 ctx ns-name
                                 (with-meta n
@@ -245,14 +251,7 @@
                                                      usage)
                            (utils/reg-call ctx usage (:id expr))
                            nil)))
-                     (when (and unresolved?
-                                (-> ctx :config :linters :unresolved-namespace :syntax-quote)
-                                symbol-val
-                                (not-empty (namespace symbol-val)))
-                       (namespace/reg-unresolved-namespace!
-                         ctx ns-name
-                         (with-meta (symbol (namespace symbol-val))
-                                    (meta expr))))
+
                      nil))
                  ;; this is a symbol, either binding or var reference
                  (when-let [idx (:idx ctx)]

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -63,7 +63,8 @@
                                             (cljs.test/is [thrown? thrown-with-msg?])]}
               :unresolved-var {:level :warning}
               :unresolved-namespace {:level :warning
-                                     :exclude [#_foo.bar]}
+                                     :exclude [#_foo.bar]
+                                     :syntax-quote false}
               ;; for example: foo.bar is always loaded in a user profile
               :reduce-without-init {:level :off
                                     :exclude [#_foo.bar/baz]}

--- a/test/clj_kondo/unresolved_namespace_test.clj
+++ b/test/clj_kondo/unresolved_namespace_test.clj
@@ -23,6 +23,10 @@
       {:file "<stdin>", :row 1, :col 10, :level :warning,
        :message "Unresolved namespace foo. Are you missing a require?"})
     (lint! "(foo/x) (foo/x)" {:linters {:unresolved-namespace {:report-duplicates true}}}))
+  (assert-submaps
+    '({:file "<stdin>", :row 1, :col 2, :level :warning,
+       :message "Unresolved namespace foo. Are you missing a require?"})
+    (lint! "`foo/x" {:linters {:unresolved-namespace {:syntax-quote true}}}))
   ;; avoiding false positives
   (is (empty? (lint! (io/file "project.clj"))))
   (is (empty? (lint! "js/foo" "--lang" "cljs")))

--- a/test/clj_kondo/unresolved_namespace_test.clj
+++ b/test/clj_kondo/unresolved_namespace_test.clj
@@ -57,4 +57,5 @@ x/bar ;; <- no warning")))
   (is (empty? (lint! "
 (require (quote [clojure.string :as str]))
 (str/join 1 [1 2 3])
-"))))
+")))
+  (is (empty? (lint! "`x" {:linters {:unresolved-namespace {:syntax-quote true}}}))))


### PR DESCRIPTION
Fix #1968

Checks forms like `foo/bar to make sure that the foo namespace is resolvable. Off by default.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
