### PR TITLE
Lint constructor calls providing unresolved-symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#1971](https://github.com/clj-kondo/clj-kondo/issues/1971): false positive `:redundant-fn-wrapper` with syntax-quoted body
+- [#1984](https://github.com/clj-kondo/clj-kondo/issues/1984): lint java constructor calls as unresolved-symbol when using dot notation.
 
 ## 2023.01.20
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1568,7 +1568,7 @@
   "Analyzes (new Foo ...) constructor call."
   [ctx expr]
   (let [[_ ctor-node & children] (:children expr)]
-    (analyze-usages2 (assoc (utils/ctx-with-linter-disabled ctx :unresolved-symbol)
+    (analyze-usages2 (assoc ctx
                             :constructor-expr expr) ctor-node)
     (analyze-children ctx children)))
 

--- a/test/clj_kondo/unresolved_symbol_test.clj
+++ b/test/clj_kondo/unresolved_symbol_test.clj
@@ -250,10 +250,8 @@
  (:foo x))
 
 " '{:linters {:unresolved-symbol {:exclude [(slingshot.slingshot/try+)]}}})))
-  (assert-submaps
-   '({:file "<stdin>", :row 1, :col 56, :level :error, :message "Unresolved symbol: diff_match_patch"})
-   (lint! "(def ^name.fraser.neil.plaintext.diff_match_patch dmp (diff_match_patch.))"
-          '{:linters {:unresolved-symbol {:level :error}}}))
+  (is (empty? (lint! "(def ^name.fraser.neil.plaintext.diff_match_patch dmp 1)"
+                     '{:linters {:unresolved-symbol {:level :error}}})))
   (testing "known java classes"
     (is (empty? (lint! "(String. \"a\")"
                        '{:linters {:unresolved-symbol {:level :error}}})))))


### PR DESCRIPTION
Fixes #1984

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

During development I noticed clj-kondo already not mark as unresolved java.lang classes, so AFAICS we don't need to change anything, I added a test to test java.lang is linted correctly.
