### PR TITLE
More hof invalid arity detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
-- [#2003](https://github.com/clj-kondo/clj-kondo/issues/2003): detect invalid arity call for function passed to `update` and `swap!`
+- [#2003](https://github.com/clj-kondo/clj-kondo/issues/2003): detect invalid arity call for function passed to `update`, `update-in`, `swap!`, `swap-vals!`, `send`, `send-off`, and `send-via`.
 - [#1999](https://github.com/clj-kondo/clj-kondo/issues/1999): add
   `hooks-api/set-node` and `hooks-api/set-node?`.
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1744,7 +1744,8 @@
         core-ns? (or (= 'clojure.core hof-ns-name)
                      (= 'cljs.core hof-ns-name))
         [prepending-n f-pos f-args-n] (cond (and core-ns?
-                                                 (= 'update hof-resolved-name))
+                                                 (or (= 'update hof-resolved-name)
+                                                     (= 'update-in hof-resolved-name)))
                                             [2 2 3]
                                             (and core-ns?
                                                  (= 'swap! hof-resolved-name))
@@ -1778,7 +1779,7 @@
         var? (and fsym (not binding))
         arg-count (cond (one-of resolved-as-name [map mapv mapcat])
                         (count f-args)
-                        (one-of resolved-as-name [update swap!])
+                        (one-of resolved-as-name [update update-in swap!])
                         (inc (count f-args))
                         (one-of resolved-as-name [reduce map-indexed keep-indexed]) 2
                         :else 1)
@@ -2223,7 +2224,7 @@
                           (map mapv filter filterv remove reduce
                                every? not-every? some not-any? mapcat iterate
                                max-key min-key group-by partition-by map-indexed
-                               keep keep-indexed update swap!)
+                               keep keep-indexed update update-in swap!)
                           (analyze-hof ctx expr resolved-as-name resolved-namespace resolved-name)
                           (ns-unmap) (analyze-ns-unmap ctx base-lang lang ns-name expr)
                           (gen-class) (analyze-gen-class ctx expr base-lang lang ns-name)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1745,7 +1745,8 @@
                      (= 'cljs.core hof-ns-name))
         [prepending-n f-pos f-args-n] (cond (and core-ns?
                                                  (or (= 'update hof-resolved-name)
-                                                     (= 'update-in hof-resolved-name)))
+                                                     (= 'update-in hof-resolved-name)
+                                                     (= 'send-via hof-resolved-name)))
                                             [2 2 3]
                                             (and core-ns?
                                                  (or (= 'swap! hof-resolved-name)
@@ -1782,7 +1783,7 @@
         var? (and fsym (not binding))
         arg-count (cond (one-of resolved-as-name [map mapv mapcat])
                         (count f-args)
-                        (one-of resolved-as-name [update update-in send send-off swap! swap-vals!])
+                        (one-of resolved-as-name [update update-in send send-off send-via swap! swap-vals!])
                         (inc (count f-args))
                         (one-of resolved-as-name [reduce map-indexed keep-indexed]) 2
                         :else 1)
@@ -2228,7 +2229,7 @@
                                every? not-every? some not-any? mapcat iterate
                                max-key min-key group-by partition-by map-indexed
                                keep keep-indexed update update-in swap! swap-vals!
-                               send send-off)
+                               send send-off send-via)
                           (analyze-hof ctx expr resolved-as-name resolved-namespace resolved-name)
                           (ns-unmap) (analyze-ns-unmap ctx base-lang lang ns-name expr)
                           (gen-class) (analyze-gen-class ctx expr base-lang lang ns-name)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1749,7 +1749,9 @@
                                             [2 2 3]
                                             (and core-ns?
                                                  (or (= 'swap! hof-resolved-name)
-                                                     (= 'swap-vals! hof-resolved-name)))
+                                                     (= 'swap-vals! hof-resolved-name)
+                                                     (= 'send hof-resolved-name)
+                                                     (= 'send-off hof-resolved-name)))
                                             [1 1 2]
                                             :else
                                             [0 0 1])
@@ -1780,7 +1782,7 @@
         var? (and fsym (not binding))
         arg-count (cond (one-of resolved-as-name [map mapv mapcat])
                         (count f-args)
-                        (one-of resolved-as-name [update update-in swap! swap-vals!])
+                        (one-of resolved-as-name [update update-in send send-off swap! swap-vals!])
                         (inc (count f-args))
                         (one-of resolved-as-name [reduce map-indexed keep-indexed]) 2
                         :else 1)
@@ -2225,7 +2227,8 @@
                           (map mapv filter filterv remove reduce
                                every? not-every? some not-any? mapcat iterate
                                max-key min-key group-by partition-by map-indexed
-                               keep keep-indexed update update-in swap! swap-vals!)
+                               keep keep-indexed update update-in swap! swap-vals!
+                               send send-off)
                           (analyze-hof ctx expr resolved-as-name resolved-namespace resolved-name)
                           (ns-unmap) (analyze-ns-unmap ctx base-lang lang ns-name expr)
                           (gen-class) (analyze-gen-class ctx expr base-lang lang ns-name)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1748,7 +1748,8 @@
                                                      (= 'update-in hof-resolved-name)))
                                             [2 2 3]
                                             (and core-ns?
-                                                 (= 'swap! hof-resolved-name))
+                                                 (or (= 'swap! hof-resolved-name)
+                                                     (= 'swap-vals! hof-resolved-name)))
                                             [1 1 2]
                                             :else
                                             [0 0 1])
@@ -1779,7 +1780,7 @@
         var? (and fsym (not binding))
         arg-count (cond (one-of resolved-as-name [map mapv mapcat])
                         (count f-args)
-                        (one-of resolved-as-name [update update-in swap!])
+                        (one-of resolved-as-name [update update-in swap! swap-vals!])
                         (inc (count f-args))
                         (one-of resolved-as-name [reduce map-indexed keep-indexed]) 2
                         :else 1)
@@ -2224,7 +2225,7 @@
                           (map mapv filter filterv remove reduce
                                every? not-every? some not-any? mapcat iterate
                                max-key min-key group-by partition-by map-indexed
-                               keep keep-indexed update update-in swap!)
+                               keep keep-indexed update update-in swap! swap-vals!)
                           (analyze-hof ctx expr resolved-as-name resolved-namespace resolved-name)
                           (ns-unmap) (analyze-ns-unmap ctx base-lang lang ns-name expr)
                           (gen-class) (analyze-gen-class ctx expr base-lang lang ns-name)

--- a/test/clj_kondo/invalid_arity_test.clj
+++ b/test/clj_kondo/invalid_arity_test.clj
@@ -192,7 +192,13 @@
      :col 19,
      :level :error,
      :message "fn is called with 1 arg but expects 2"}]
-   (lint! "(swap! (atom nil) (fn [old extra] n))")))
+   (lint! "(swap! (atom nil) (fn [old extra] n))"))
+  (assert-submaps2
+   [{:row 1,
+     :col 24,
+     :level :error,
+     :message "fn is called with 1 arg but expects 2"}]
+   (lint! "(swap-vals! (atom nil) (fn [old extra] n))")))
 
 (deftest def+fn-test
   (assert-submaps

--- a/test/clj_kondo/invalid_arity_test.clj
+++ b/test/clj_kondo/invalid_arity_test.clj
@@ -210,7 +210,13 @@
      :col 23,
      :level :error,
      :message "fn is called with 1 arg but expects 2"}]
-   (lint! "(send-off (agent nil) (fn [old extra] n))")))
+   (lint! "(send-off (agent nil) (fn [old extra] n))"))
+  (assert-submaps2
+   [{:row 1,
+     :col 55,
+     :level :error,
+     :message "fn is called with 1 arg but expects 2"}]
+   (lint! "(send-via clojure.lang.Agent/soloExecutor (agent nil) (fn [old extra] n))")))
 
 (deftest def+fn-test
   (assert-submaps

--- a/test/clj_kondo/invalid_arity_test.clj
+++ b/test/clj_kondo/invalid_arity_test.clj
@@ -183,6 +183,12 @@
    (lint! "(update {:a [1]} :a (fn [_ x] x))"))
   (assert-submaps2
    [{:row 1,
+     :col 26,
+     :level :error,
+     :message "fn is called with 1 arg but expects 2"}]
+   (lint! "(update-in {:a [1]} [:a] (fn [_ x] x))"))
+  (assert-submaps2
+   [{:row 1,
      :col 19,
      :level :error,
      :message "fn is called with 1 arg but expects 2"}]

--- a/test/clj_kondo/invalid_arity_test.clj
+++ b/test/clj_kondo/invalid_arity_test.clj
@@ -198,7 +198,19 @@
      :col 24,
      :level :error,
      :message "fn is called with 1 arg but expects 2"}]
-   (lint! "(swap-vals! (atom nil) (fn [old extra] n))")))
+   (lint! "(swap-vals! (atom nil) (fn [old extra] n))"))
+  (assert-submaps2
+   [{:row 1,
+     :col 19,
+     :level :error,
+     :message "fn is called with 1 arg but expects 2"}]
+   (lint! "(send (agent nil) (fn [old extra] n))"))
+  (assert-submaps2
+   [{:row 1,
+     :col 23,
+     :level :error,
+     :message "fn is called with 1 arg but expects 2"}]
+   (lint! "(send-off (agent nil) (fn [old extra] n))")))
 
 (deftest def+fn-test
   (assert-submaps


### PR DESCRIPTION
Adds support for arity detection with `send`, `send-off`, `send-via`, `swap-vals!`, and `update-in!`.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an #2003.

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
