### PR TITLE
Update linters.md: `:dynamic-var-not-earmuffed` is `:off` by default

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -593,7 +593,7 @@ Explanation by Bozhidar Batsov:
 
 *Description:* warn when dynamic var doesn't have an earmuffed name.
 
-*Default level:* `:warning`.
+*Default level:* `:off`.
 
 *Example trigger:* `(def ^:dynamic foo)`
 


### PR DESCRIPTION
The default level of `:dynamic-var-not-earmuffed` was changed from `:warning` to `:off` by #1970.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - I think this PR is likely a sufficient statement of the problem and proposed solution.

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
    - not applicable

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
    - not applicable
