### PR TITLE
Update linters.md: `:namespace-name-mismatch` is `:error` by default

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -937,7 +937,7 @@ misses a value.
 *Description:* warn when the namespace in the `ns` form does not
 correspond with the file name of the file.
 
-*Default level:* `:off`.
+*Default level:* `:error`.
 
 *Example trigger:* a file named `foo.clj` containing a namespace `(ns bar)`.
 


### PR DESCRIPTION
The default level of `:namespace-name-mismatch` was changed from `:off` to `:error` by commit 74ab2f5019b9743a2343.

See also commit 16cd3f88bd5a14ec40c1.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - I think this PR is likely a sufficient statement of the problem and proposed solution.

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
    - not applicable

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
    - not applicable
