### PR TITLE
Update linters.md: `:redundant-call` is `:off` by default

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1058,6 +1058,8 @@ because of an explicit or implicit do as the direct parent s-expression.
 *Description:* warn on redundant calls. The warning arises when a single argument
 is passed to a function or macro that that returns its arguments.
 
+*Default level:* `:off`.
+
 `clojure.core` and `cljs.core` functions and macros that trigger this lint:
 * `->`, `->>`
 * `cond->`, `cond->>`


### PR DESCRIPTION
The "Default level" was left out of linters.md when `:redundant-call` was introduced by #1692.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
    - I think this PR is likely a sufficient statement of the problem and proposed solution.

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
    - not applicable

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
    - not applicable
