### PR TITLE
Add :gen support on clojure.spec.alpha/keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - [#2026](https://github.com/clj-kondo/clj-kondo/issues/2026): coercing string did not create StringNode, but TokenNode, lead to false positive `Too many arguments to def`
 - [#2030](https://github.com/clj-kondo/clj-kondo/issues/2030): Add a new `:discouraged-tag` linter for discouraged tag literals. See the [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/linters.md#discouraged-tag).
+- Add `:gen` support on `clojure.spec.alpha/keys`
 
 ## 2023.03.17
 

--- a/corpus/spec_syntax.clj
+++ b/corpus/spec_syntax.clj
@@ -26,11 +26,13 @@
               :opt-un [::a]
               :req [::a]
               :req-un [::a]
-              ;; unkown
+              :gen (fn [])
+              ;; unknown
               ::opt [::a]
               ::opt-un [::a]
               ::req [::a]
-              ::req-un [::a]))
+              ::req-un [::a]
+              ::gen (fn [])))
 
 (require '[spec-keys :as sk]) ;; namespace is used because of below s/keys call
 

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -41,7 +41,7 @@
 
 (defn analyze-keys [ctx expr]
   (let [body (next (:children expr))]
-    (keys/lint-map-keys ctx {:children body} {:known-key? #{:req :opt :req-un :opt-un}})
+    (keys/lint-map-keys ctx {:children body} {:known-key? #{:req :opt :req-un :opt-un :gen}})
     (common/analyze-children ctx body)))
 
 ;;;; Scratch

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2035,25 +2035,30 @@ foo/foo ;; this does use the private var
        :level :error,
        :message "Unresolved symbol: xstr/starts-with?"}
     {:file "corpus/spec_syntax.clj",
-     :row 30,
+     :row 31,
      :col 15,
      :level :error,
      :message "unknown option ::opt"}
     {:file "corpus/spec_syntax.clj",
-     :row 31,
+     :row 32,
      :col 15,
      :level :error,
      :message "unknown option ::opt-un"}
     {:file "corpus/spec_syntax.clj",
-     :row 32,
+     :row 33,
      :col 15,
      :level :error,
      :message "unknown option ::req"}
     {:file "corpus/spec_syntax.clj",
-     :row 33,
+     :row 34,
      :col 15,
      :level :error,
-     :message "unknown option ::req-un"}]
+     :message "unknown option ::req-un"}
+    {:file "corpus/spec_syntax.clj",
+     :row 35,
+     :col 15,
+     :level :error,
+     :message "unknown option ::gen"}]
    (lint! (io/file "corpus" "spec_syntax.clj")
           '{:linters {:unresolved-symbol {:level :error}
                       :unused-namespace {:level :error}}})))


### PR DESCRIPTION
While linting a Clojure project I stumbled upon a syntax error on the [`clojure.spec.alpha/keys`](https://github.com/clojure/spec.alpha/blob/70f26984ee171f816eee6b162b563d403a49bfe8/src/main/clojure/clojure/spec/alpha.clj#L414) regarding the map key `:gen`.

You can find more context on [this #clj-kondo thread](https://clojurians.slack.com/archives/CHY97NXE2/p1680180661821299).