### PR TITLE
Analyze and lint clara-rules defrule and defquery macros

### DIFF
--- a/corpus/clara/rules.clj
+++ b/corpus/clara/rules.clj
@@ -1,0 +1,11 @@
+(ns clara.rules)
+
+(defmacro defrule
+  [name & body]
+  `(def ^:query ~name '~body))
+
+(defmacro defquery
+  [name & body]
+  `(def ^:rule ~name '~body))
+
+(declare insert!)

--- a/corpus/clara/rules/accumulators.clj
+++ b/corpus/clara/rules/accumulators.clj
@@ -1,0 +1,4 @@
+(ns clara.rules.accumulators)
+
+;;; just define some accumulators to write tests
+(declare all exists grouping-by)

--- a/corpus/clara/rules_test.clj
+++ b/corpus/clara/rules_test.clj
@@ -1,5 +1,6 @@
 (ns clara.rules-test
   (:require [clara.rules :refer [defquery defrule insert!]]
+            [clara.rules.accumulators :as acc]
             [clojure.test :as t :refer [deftest is testing]]))
 
 (defquery foo-query
@@ -8,11 +9,36 @@
   [:test (some? ?query-output)])
 
 (defrule foo-rule
-  [?fact <- :foo/bar [{:keys [foo-value]}] (= foo-value ?foo-value)]
+  [?fact <- :foo/bar [{:keys [foo-value]}]
+   (= foo-value ?foo-value)
+   (some? ?fact)] ;;; should return unresolved symbol
+  [:foo/fact]
+  [?foo-data <- :foo/data]
+  [:not [:foo/not [{:keys [foo-not]}] (= foo-not ?foo-value)]]
+  [:and
+   [:foo/thing1]
+   [:not [:foo/begone [{:keys [foo-not]}]
+          (= foo-not ?foo-not)
+          (true? ?foo-not)
+          (true? foo-yes)]] ;;; should return unresolved-symbol
+   [:foo/thing2 [{:keys [foo-thing1]}] (= foo-thing1 ?foo-value)]
+   [:or
+    [:foo/maybe1]
+    [:foo/maybe2 [{:keys [foo-maybe]}] (= foo-maybe ?foo-value)]]]
+  [:exists
+   [:foo/required1 [{:keys [foo-required]}] (true? foo-required)]]
+  [:exists
+   [:foo/required]]
+  [?acc-result1 <- (acc/grouping-by :foo-hash) :from [:foo/item1 [{:keys [foo-item]}] (= foo-item ?foo-value)]]
+  [?acc-result2 <- (acc/all) :from [:foo/item2]]
+  [?acc-result3 <- (acc/all) :from [:foo/item3 (= foo-item ?foo-item)]] ;;; should return unresolved-symbol
   [:test (and (some? ?foo-value)
-              (some? ?fact))]
+              (some? ?fact)
+              (seq ?acc-result1)
+              (seq ?acc-result2))]
   =>
   (insert! {:fact/type :foo/result
+            :other foo-value ;;; should return unresolved-symbol
             :fact ?fact
             :result ?foo-value}))
 

--- a/corpus/clara/rules_test.clj
+++ b/corpus/clara/rules_test.clj
@@ -1,0 +1,22 @@
+(ns clara.rules-test
+  (:require [clara.rules :refer [defquery defrule insert!]]
+            [clojure.test :as t :refer [deftest is testing]]))
+
+(defquery foo-query
+  [?foo-query-value]
+  [?query-output <- :foo/bar [{:keys [foo-query-value]}] (= foo-query-value ?foo-query-value)]
+  [:test (some? ?query-output)])
+
+(defrule foo-rule
+  [?fact <- :foo/bar [{:keys [foo-value]}] (= foo-value ?foo-value)]
+  [:test (and (some? ?foo-value)
+              (some? ?fact))]
+  =>
+  (insert! {:fact/type :foo/result
+            :fact ?fact
+            :result ?foo-value}))
+
+(deftest a-test
+  (testing "a-test"
+    (is (some? foo-query))
+    (is (some? foo-rule))))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -6,6 +6,7 @@
    [clj-kondo.hooks-api :as hooks-api]
    [clj-kondo.impl.analysis :as analysis]
    [clj-kondo.impl.analyzer.babashka :as babashka]
+   [clj-kondo.impl.analyzer.clara-rules :as clara-rules]
    [clj-kondo.impl.analyzer.clojure-data-xml :as xml]
    [clj-kondo.impl.analyzer.common :refer [common]]
    [clj-kondo.impl.analyzer.compojure :as compojure]
@@ -2331,6 +2332,10 @@
                              [compojure.core context]
                              [compojure.core rfn])
                             (compojure/analyze-compojure-macro ctx expr resolved-as-name)
+                            ([clara.rules defrule])
+                            (clara-rules/analyze-defrule-macro ctx expr)
+                            ([clara.rules defquery])
+                            (clara-rules/analyze-defquery-macro ctx expr)
                             ([clojure.java.jdbc with-db-transaction]
                              [clojure.java.jdbc with-db-connection]
                              [clojure.java.jdbc with-db-metadata]

--- a/src/clj_kondo/impl/analyzer/clara_rules.clj
+++ b/src/clj_kondo/impl/analyzer/clara_rules.clj
@@ -1,0 +1,92 @@
+(ns clj-kondo.impl.analyzer.clara-rules
+  {:no-doc true}
+  (:require
+    [clj-kondo.impl.analyzer.common :refer [extract-bindings
+                                            ctx-with-bindings
+                                            analyze-children]]
+    [clj-kondo.impl.namespace :as namespace]
+    [clj-kondo.impl.utils :as utils :refer [tag]]
+    [clojure.string :as str]))
+
+(defn- binding-node?
+  "determine if a symbol is a clara-rules binding symbol in the form `?<name>`"
+  [node]
+  (let [node-name (:value node)]
+    (when (and (symbol? node-name)
+               (str/starts-with? (name node-name) "?"))
+      node)))
+
+(defn analyze-constraints
+  "sequentially analyzes constraint expressions of clara rules and queries
+  defined via defrule or defquery by sequentially analyzing its children lhs
+  expressions and bindings."
+  [context constraint-seq]
+  (loop [[constraint-expr & more] constraint-seq
+         context context
+         results []]
+    (if (nil? constraint-expr)
+      [results context]
+      (let [constraint (:children constraint-expr)
+            binding-form (when (= '= (:value (first constraint)))
+                           (some binding-node? (rest constraint)))
+            constraint-bindings (when binding-form
+                                  (extract-bindings context binding-form))
+            next-context (ctx-with-bindings context constraint-bindings)
+            next-results (analyze-children next-context constraint)]
+        (recur more next-context (concat results next-results))))))
+
+(defn analyze-conditions
+  "sequentially analyzes condition expressions of clara rules and queries
+  defined via defrule and defquery by taking into account the optional
+  result binding, optional args bindings and sequentially analyzing
+  its children constraint expressions."
+  [context condition-seq]
+  (loop [[condition-expr & more] condition-seq
+         context context
+         results []]
+    (if (nil? condition-expr)
+      [results context]
+      (let [condition (:children condition-expr)
+            result-form (when (= '<- (-> condition second :value))
+                          (first condition))
+            [fact-node & condition] (if result-form (drop 2 condition) condition)
+            condition-args (if (= :vector (tag (first condition))) (first condition) nil)
+            condition-bindings (when condition-args
+                                 (extract-bindings context condition-args))
+            context (ctx-with-bindings context condition-bindings)
+            constraint-seq (if condition-args (rest condition) condition)
+            fact-results (analyze-children context [fact-node])
+            [next-results context] (analyze-constraints context constraint-seq)
+            result-bindings (when result-form
+                              (extract-bindings context result-form))
+            next-context (ctx-with-bindings context result-bindings)]
+        (recur more next-context (concat results fact-results next-results))))))
+
+(defn analyze-defquery-macro
+  "analyze clara-rules defquery macro"
+  [context expr]
+  (let [[name-node destructuring-form & condition-seq] (next (:children expr))
+        query-bindings (when destructuring-form
+                         (extract-bindings context destructuring-form))
+        context (ctx-with-bindings context query-bindings)
+        ns-name (-> context :ns :name)
+        var-name (:value name-node)]
+    (when var-name
+      (namespace/reg-var!
+        context ns-name var-name expr {:temp true}))
+    (let [[results] (analyze-conditions context condition-seq)]
+      results)))
+
+(defn analyze-defrule-macro
+  "analyze clara-rules defrule macro"
+  [context expr]
+  (let [[name-node & production-seq] (next (:children expr))
+        ns-name (-> context :ns :name)
+        var-name (:value name-node)
+        [condition-seq _ body-seq] (partition-by (comp #{'=>} :value) production-seq)]
+    (when var-name
+      (namespace/reg-var!
+        context ns-name var-name expr {:temp true}))
+    (let [[lhs-results context] (analyze-conditions context condition-seq)
+          rhs-results (analyze-children context body-seq)]
+      (concat lhs-results rhs-results))))

--- a/src/clj_kondo/impl/analyzer/clara_rules.clj
+++ b/src/clj_kondo/impl/analyzer/clara_rules.clj
@@ -68,21 +68,17 @@
             fact-results (analyze-children context [fact-node])
             [next-results next-context] (cond
                                           (nil? condition)
-                                          (do
-                                            [[] context])
+                                          [[] context]
 
                                           (contains? #{:not :or :and :exists} (node-value fact-node))
-                                          (do
-                                            (analyze-conditions context condition))
+                                          (analyze-conditions context condition)
 
                                           (and (= (node-type fact-node) :list)
                                                (= :from (-> condition first node-value)))
-                                          (do
-                                            (analyze-conditions context (rest condition)))
+                                          (analyze-conditions context (rest condition))
 
                                           :else
-                                          (do
-                                            (analyze-constraints context condition)))
+                                          (analyze-constraints context condition))
             result-bindings (when result-form
                               (extract-bindings context result-form))
             next-context (ctx-with-bindings next-context result-bindings)]

--- a/src/clj_kondo/impl/analyzer/clara_rules.clj
+++ b/src/clj_kondo/impl/analyzer/clara_rules.clj
@@ -5,13 +5,21 @@
                                             ctx-with-bindings
                                             analyze-children]]
     [clj-kondo.impl.namespace :as namespace]
-    [clj-kondo.impl.utils :as utils :refer [tag]]
+    [clj-kondo.impl.rewrite-clj.node.protocols :as node]
     [clojure.string :as str]))
+
+(defn- node-value
+  [a-node]
+  (some-> a-node node/sexpr))
+
+(defn- node-type
+  [a-node]
+  (some-> a-node node/tag))
 
 (defn- binding-node?
   "determine if a symbol is a clara-rules binding symbol in the form `?<name>`"
   [node]
-  (let [node-name (:value node)]
+  (let [node-name (node-value node)]
     (when (and (symbol? node-name)
                (str/starts-with? (name node-name) "?"))
       node)))
@@ -20,20 +28,27 @@
   "sequentially analyzes constraint expressions of clara rules and queries
   defined via defrule or defquery by sequentially analyzing its children lhs
   expressions and bindings."
-  [context constraint-seq]
-  (loop [[constraint-expr & more] constraint-seq
-         context context
-         results []]
-    (if (nil? constraint-expr)
-      [results context]
-      (let [constraint (:children constraint-expr)
-            binding-form (when (= '= (:value (first constraint)))
-                           (some binding-node? (rest constraint)))
-            constraint-bindings (when binding-form
-                                  (extract-bindings context binding-form))
-            next-context (ctx-with-bindings context constraint-bindings)
-            next-results (analyze-children next-context constraint)]
-        (recur more next-context (concat results next-results))))))
+  [context condition]
+  (let [condition-args (if (= :vector (node-type (first condition))) (first condition) nil)
+        condition-bindings (when condition-args
+                             (extract-bindings context condition-args))
+        local-context (ctx-with-bindings context condition-bindings)
+        constraint-seq (if condition-args (rest condition) condition)]
+    (loop [[constraint-expr & more] constraint-seq
+           local-context local-context
+           context context
+           results []]
+      (if (nil? constraint-expr)
+        [results context]
+        (let [constraint (:children constraint-expr)
+              binding-form (when (= '= (node-value (first constraint)))
+                             (some binding-node? (rest constraint)))
+              constraint-bindings (when binding-form
+                                    (extract-bindings local-context binding-form))
+              local-context (ctx-with-bindings local-context constraint-bindings)
+              context (ctx-with-bindings context constraint-bindings)
+              next-results (analyze-children local-context constraint)]
+          (recur more local-context context (concat results next-results)))))))
 
 (defn analyze-conditions
   "sequentially analyzes condition expressions of clara rules and queries
@@ -47,19 +62,30 @@
     (if (nil? condition-expr)
       [results context]
       (let [condition (:children condition-expr)
-            result-form (when (= '<- (-> condition second :value))
+            result-form (when (= '<- (-> condition second node-value))
                           (first condition))
             [fact-node & condition] (if result-form (drop 2 condition) condition)
-            condition-args (if (= :vector (tag (first condition))) (first condition) nil)
-            condition-bindings (when condition-args
-                                 (extract-bindings context condition-args))
-            context (ctx-with-bindings context condition-bindings)
-            constraint-seq (if condition-args (rest condition) condition)
             fact-results (analyze-children context [fact-node])
-            [next-results context] (analyze-constraints context constraint-seq)
+            [next-results next-context] (cond
+                                          (nil? condition)
+                                          (do
+                                            [[] context])
+
+                                          (contains? #{:not :or :and :exists} (node-value fact-node))
+                                          (do
+                                            (analyze-conditions context condition))
+
+                                          (and (= (node-type fact-node) :list)
+                                               (= :from (-> condition first node-value)))
+                                          (do
+                                            (analyze-conditions context (rest condition)))
+
+                                          :else
+                                          (do
+                                            (analyze-constraints context condition)))
             result-bindings (when result-form
                               (extract-bindings context result-form))
-            next-context (ctx-with-bindings context result-bindings)]
+            next-context (ctx-with-bindings next-context result-bindings)]
         (recur more next-context (concat results fact-results next-results))))))
 
 (defn analyze-defquery-macro
@@ -70,7 +96,7 @@
                          (extract-bindings context destructuring-form))
         context (ctx-with-bindings context query-bindings)
         ns-name (-> context :ns :name)
-        var-name (:value name-node)]
+        var-name (node-value name-node)]
     (when var-name
       (namespace/reg-var!
         context ns-name var-name expr {:temp true}))
@@ -82,11 +108,15 @@
   [context expr]
   (let [[name-node & production-seq] (next (:children expr))
         ns-name (-> context :ns :name)
-        var-name (:value name-node)
-        [condition-seq _ body-seq] (partition-by (comp #{'=>} :value) production-seq)]
+        var-name (node-value name-node)
+        [condition-seq _ body-seq] (partition-by (comp #{'=>} node-value) production-seq)]
     (when var-name
       (namespace/reg-var!
         context ns-name var-name expr {:temp true}))
     (let [[lhs-results context] (analyze-conditions context condition-seq)
           rhs-results (analyze-children context body-seq)]
       (concat lhs-results rhs-results))))
+
+;;; scratch
+(comment
+  )

--- a/test/clj_kondo/clara_test.clj
+++ b/test/clj_kondo/clara_test.clj
@@ -6,26 +6,23 @@
     [missing.test.assertions]))
 
 (deftest clara-rules-test
-  (is (= [{:file "corpus/clara/rules_test.clj"
-           :row 14
+  (is (= [{:row 14
            :col 11
            :level :on
            :message "Unresolved symbol: ?fact"}
-          {:file "corpus/clara/rules_test.clj"
-           :row 23
+          {:row 23
            :col 18
            :level :on
            :message "Unresolved symbol: foo-yes"}
-          {:file "corpus/clara/rules_test.clj"
-           :row 34
+          {:row 34
            :col 51
            :level :on
            :message "Unresolved symbol: foo-item"}
-          {:file "corpus/clara/rules_test.clj"
-           :row 41
+          {:row 41
            :col 20
            :level :on
            :message "Unresolved symbol: foo-value"}]
-         (lint! (io/file "corpus" "clara" "rules_test.clj")
-                {:linters
-                 {:unresolved-symbol {:level :on}}}))))
+         (for [finding (lint! (io/file "corpus" "clara" "rules_test.clj")
+                              {:linters
+                               {:unresolved-symbol {:level :on}}})]
+           (dissoc finding :file)))))

--- a/test/clj_kondo/clara_test.clj
+++ b/test/clj_kondo/clara_test.clj
@@ -1,0 +1,11 @@
+(ns clj-kondo.clara-test
+  (:require
+   [clj-kondo.test-utils :refer [lint!]]
+   [clojure.java.io :as io]
+   [clojure.test :as t :refer [deftest is testing]]
+   [missing.test.assertions]))
+
+(deftest clara-rules-no-errors-test
+  (is (empty? (lint! (io/file "corpus" "clara" "rules_test.clj")
+                     {:linters
+                      {:unresolved-symbol {:level :on}}}))))

--- a/test/clj_kondo/clara_test.clj
+++ b/test/clj_kondo/clara_test.clj
@@ -1,11 +1,31 @@
 (ns clj-kondo.clara-test
   (:require
-   [clj-kondo.test-utils :refer [lint!]]
-   [clojure.java.io :as io]
-   [clojure.test :as t :refer [deftest is testing]]
-   [missing.test.assertions]))
+    [clj-kondo.test-utils :refer [lint!]]
+    [clojure.java.io :as io]
+    [clojure.test :as t :refer [deftest is testing]]
+    [missing.test.assertions]))
 
-(deftest clara-rules-no-errors-test
-  (is (empty? (lint! (io/file "corpus" "clara" "rules_test.clj")
-                     {:linters
-                      {:unresolved-symbol {:level :on}}}))))
+(deftest clara-rules-test
+  (is (= [{:file "corpus/clara/rules_test.clj"
+           :row 14
+           :col 11
+           :level :on
+           :message "Unresolved symbol: ?fact"}
+          {:file "corpus/clara/rules_test.clj"
+           :row 23
+           :col 18
+           :level :on
+           :message "Unresolved symbol: foo-yes"}
+          {:file "corpus/clara/rules_test.clj"
+           :row 34
+           :col 51
+           :level :on
+           :message "Unresolved symbol: foo-item"}
+          {:file "corpus/clara/rules_test.clj"
+           :row 41
+           :col 20
+           :level :on
+           :message "Unresolved symbol: foo-value"}]
+         (lint! (io/file "corpus" "clara" "rules_test.clj")
+                {:linters
+                 {:unresolved-symbol {:level :on}}}))))


### PR DESCRIPTION
This is my proposed implementation for #2059 to add clara-rules support for clj-kondo, it includes a custom analyzer and a test to ensure that we also detect some common failures.