### PR TITLE
Fix `lint stdin` example command

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -12,6 +12,6 @@ dependencies into the container:
 
 To lint stdin:
 
-    echo '(select-keys)' | docker run -i --rm clj-kondo/clj-kondo clj-kondo --lint -
+    echo '(select-keys)' | docker run -i --rm cljkondo/clj-kondo clj-kondo --lint -
 
 You can use the `latest` tag to get the latest non-SNAPSHOT release. See [tags](https://hub.docker.com/r/cljkondo/clj-kondo/tags).


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [ ] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

---

I noticed this error while reading this example to run it myself. Given it's just a typo in the docs and not a functional change, I've skipped all of the above checks.