### PR TITLE
Fix reflect config for javaparser

### DIFF
--- a/resources/META-INF/native-image/clj-kondo/clj-kondo/reflect-config.json
+++ b/resources/META-INF/native-image/clj-kondo/clj-kondo/reflect-config.json
@@ -33,5 +33,33 @@
   { "name": "clojure.lang.LineNumberingPushbackReader",
     "allPublicConstructors": true,
     "allPublicMethods": true
+  },
+  {
+    "name":"com.github.javaparser.ast.expr.VariableDeclarationExpr",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"com.github.javaparser.ast.Node",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"com.github.javaparser.ast.body.BodyDeclaration",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"com.github.javaparser.ast.body.FieldDeclaration",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"com.github.javaparser.ast.body.ConstructorDeclaration",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"com.github.javaparser.ast.body.CallableDeclaration",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"com.github.javaparser.ast.body.MethodDeclaration",
+    "allDeclaredFields":true
   }
 ]


### PR DESCRIPTION

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

I didn't refactor the tests to use the binary, although I agree should be done, but I manually compiled kondo and tested with the AwesomeClass.java that the tests use.
I guess we can leave the refactor for another PR.

Also, those reflect configs were added based on the output of running `java  -agentlib:native-image-agent=config-merge-dir=... -jar ...` to know what classes were being used.