### PR TITLE
analyze and act on defprotocol metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
-- [#](https://github.com/clj-kondo/clj-kondo/issues/2097): analyze and act on `defprotocol` metadata ([@lread](https://github.com/lread))
+- [#2097](https://github.com/clj-kondo/clj-kondo/issues/2097): analyze and act on `defprotocol` metadata ([@lread](https://github.com/lread))
 
 ## 2023.05.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] update clj-kondo-bb -->
 <!-- - [ ] update carve -->
 
+## Unreleased
+
+- [#](https://github.com/clj-kondo/clj-kondo/issues/2097): analyze and act on `defprotocol` metadata ([@lread](https://github.com/lread))
+
 ## 2023.05.26
 
 - [#2083](https://github.com/clj-kondo/clj-kondo/issues/2083): fix regression with `:missing-test-assertion` introduced in 2023.05.18

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1369,6 +1369,8 @@
   ;; for syntax, see https://clojure.org/reference/protocols#_basics
   (let [children (next (:children expr))
         name-node (first children)
+        name-node (meta/lift-meta-content2 ctx name-node)
+        name-meta (meta name-node)
         protocol-name (:value name-node)
         ns-name (:name ns)
         docstring (string-from-token (second children))
@@ -1379,7 +1381,9 @@
                               #(when (= :vector (tag %)) %))]
     (when protocol-name
       (namespace/reg-var! ctx ns-name protocol-name expr
-                          (assoc-some (meta name-node)
+                          (assoc-some name-meta
+                                      :user-meta (when (:analysis-var-meta ctx)
+                                                   (:user-meta name-meta))
                                       :doc docstring
                                       :defined-by defined-by
                                       :defined-by->lint-as defined-by->lint-as)))
@@ -1412,7 +1416,9 @@
            (cond-> ctx
              (= 'clojure.core/definterface defined-by->lint-as)
              (assoc :skip-reg-var true)) ns-name fn-name c
-           (assoc-some (meta c)
+           (assoc-some (merge name-meta (meta c))
+                       :user-meta (when (:analysis-var-meta ctx)
+                                    (:user-meta name-meta))
                        :doc docstring
                        :arglist-strs arglist-strs
                        :name-row (:row name-meta)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2737,13 +2737,16 @@ foo/baz
    '({:file "<stdin>", :row 1, :col 8, :level :warning, :message "Unused private var user/foo"}
      {:file "<stdin>", :row 1, :col 29, :level :warning, :message "Unused private var user/bar"})
    (lint! "(defn- foo [] (foo)) (defn- bar ([] (bar 1)) ([_]))"))
+  (assert-submaps2
+   '({:file "<stdin>", :row 1, :col 24, :level :warning, :message "Unused private var user/Foo"}
+     {:file "<stdin>", :row 1, :col 55, :level :warning, :message "Unused private var user/baz"})
+   (lint! "(defprotocol ^:private Foo [] (bar [this]) (^:private baz [this]))"))
   (is (empty? (lint! "(ns foo) (defn- f []) (f)")))
   (is (empty? (lint! "(ns foo) (defn- f [])"
                      '{:linters {:unused-private-var {:exclude [foo/f]}}})))
   (is (empty? (lint! "
 (defrecord ^:private SessionStore [session-service])
 (deftype ^:private SessionStore2 [session-service])
-(defprotocol ^:private Foo (foo [this]))
 (definterface ^:private SessionStore3)"))))
 
 (deftest definterface-test


### PR DESCRIPTION
Metadata applied to protocol name and protocol methods are now included
in analysis data.

Unused private defprotocols and unused private defprotocol methods now
lint to :unused-local-var

Closes #2097

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
