### PR TITLE
analysis: :arglists meta applies to :arglist-strs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2105](https://github.com/clj-kondo/clj-kondo/issues/2105): Consider .cljd files when linting.
 - [#2101](https://github.com/clj-kondo/clj-kondo/issues/2101): false positive with `if-some` + `recur`
 - [#2109](https://github.com/clj-kondo/clj-kondo/issues/2109): `java.util.List` type hint corresponds to `:list` or nil
+- [#2096](https://github.com/clj-kondo/clj-kondo/issues/2096): apply `:arglists` metadata to `:arglist-strs` for analysis data ([@lread](https://github.com/lread))
 
 ## 2023.05.26
 

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -21,7 +21,7 @@ Further analysis can be returned by providing `:analysis` with a map of options:
 
 - `:locals`: when truthy return `:locals` and `:local-usages` described below
 - `:keywords`: when truthy return `:keywords` described below
-- `:arglists`: when truthy return `:arglists` on `:var-definitions`
+- `:arglists`: when truthy return `:arglist-strs` on `:var-definitions`
 - `:protocol-impls`: when truthy return `:protocol-impls` described below
 - `:symbols`: when truthy, return `:symbols` described below
 - `:java-class-definitions`: when truthy, return `:java-class-definitions` as described below.
@@ -106,13 +106,13 @@ The analysis output consists of a map with:
   - `:defined-by`: the namespaced symbol which defined this var
 
   Optional:
-  - `:fixed-arities`: a set of fixed arities
-  - `:varargs-min-arity`: the minimal number of arguments of a varargs signature
+  - `:fixed-arities`: a set of fixed arities, unaffected by any `:arglists` metadata overrides
+  - `:varargs-min-arity`: the minimal number of arguments of a varargs signature, unaffected by any `:arglists` metadata overrides
   - common metadata values: `:private`, `:macro`, `:deprecated`, `:doc`, `:added`
   - `:meta` map of requested metadata for var
   - `:lang`: if definition occurred in a `.cljc` file, the language in which the
     definition was done: `:clj` or `:cljs`
-  - `:arglists-str`: a list of each set of args as written
+  - `:arglist-strs`: arg lists as written, or valid looking `:arglists` metadata override, ex. `["[x]" "[x y]"]`
   - `:protocol-ns`, `:protocol-name`: the protocol namespace and name for a protocol method
 
 - `:var-usages`, a list of maps with:

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -201,6 +201,16 @@
 (defn map-node-vals [{:keys [:children]}]
   (take-nth 2 (rest children)))
 
+(defn map-node-get-value-node
+  "Return value node from map node matching given keyword `kw`"
+  [{:keys [:children]} kw]
+  (loop [kvs (partition 2 children)]
+    (let [kv (first kvs)]
+      (cond
+        (nil? kv) nil
+        (= kw (node->keyword (first kv))) (second kv)
+        :else (recur (rest kvs))))))
+
 (defmacro one-of [x elements]
   `(let [x# ~x]
      (case x# (~@elements) x# nil)))
@@ -426,4 +436,6 @@
 
 y\""))
   (tag (parse-string "\"xy\""))
-  )
+  (map-node-get-value-node (p/parse-string "{:binky 2 :arglists #_ :ha '([a b c]) :boingo 4}")
+                           :arglists)
+)


### PR DESCRIPTION
Highlights:
- `:arglists` metadata only overrides `:arglist-strs` if it looks valid
- `:fixed-arities` and `:varargs-min-arity` are never affected by `:arglists` metadata, they always describe original arg lists params, if present

Also includes:
- minor analysis doc update & corrections

Closes #2096

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
