### PR TITLE
Use no-flush-outputstream rather than byte array outputstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - [#2143](https://github.com/clj-kondo/clj-kondo/issues/2143): false positive type warning for `clojure.set/project`
 - [#2145](https://github.com/clj-kondo/clj-kondo/issues/2145): support ignore hint on multi-arity branch of function definition
+- [#2147](https://github.com/clj-kondo/clj-kondo/issues/2147): use altenative solution as workaround for https://github.com/cognitect/transit-clj/issues/43
 
 ## 2023.07.13
 

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -67,9 +67,7 @@
       (let [file (cache-file cache-dir lang ns-sym)
             _ (io/make-parents file)
             os (io/output-stream file)]
-        (with-open [;; first we write to a baos as a workaround for transit-clj #43
-                    ;; bos (java.io.ByteArrayOutputStream. 1024)
-                    os (no-flush-output-stream os)]
+        (with-open [os (no-flush-output-stream os)]
           (let [writer (transit/writer os :json)]
             (transit/write writer ns-data)))))))
 

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -47,7 +47,7 @@
                                 (.toAbsolutePath))
                             (-> (.toPath config-dir)
                                 (.toAbsolutePath)))
-               #_(catch Exception _ false))) )))
+               #_(catch Exception _ false))))))
 
 (defn no-flush-output-stream
   "See https://github.com/cognitect/transit-clj/issues/43#issuecomment-1650341353"
@@ -64,14 +64,16 @@
   [config-dir cache-dir lang ns-sym ns-data]
   (let [filename (:filename ns-data)]
     (when-not (skip-write? config-dir filename)
-      (let [file (cache-file cache-dir lang ns-sym)
-            _ (io/make-parents file)
-            os (io/output-stream file)]
-        (with-open [;; first we write to a baos as a workaround for transit-clj #43
-                    ;; bos (java.io.ByteArrayOutputStream. 1024)
-                    os (no-flush-output-stream os)]
-          (let [writer (transit/writer os :json)]
-            (transit/write writer ns-data)))))))
+      (time
+       (dotimes [i 1000]
+         (let [file (cache-file cache-dir lang ns-sym)
+               _ (io/make-parents file)
+               os (io/output-stream file)]
+           (with-open [;; first we write to a baos as a workaround for transit-clj #43
+                       ;; bos (java.io.ByteArrayOutputStream. 1024)
+                       os (no-flush-output-stream os)]
+             (let [writer (transit/writer os :json)]
+               (transit/write writer ns-data)))))))))
 
 (def ^:dynamic *lock-file-name* "lock")
 
@@ -189,5 +191,4 @@
   (time (get (from-cache-1 nil :clj 'java.lang.Thread) 'sleep))
 
   (get (from-cache-1 nil :clj 'clojure.core) 'agent-errors)
-  (from-cache-1 nil :clj 'clojure.core.specs.alpha)
-  )
+  (from-cache-1 nil :clj 'clojure.core.specs.alpha))

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -64,16 +64,14 @@
   [config-dir cache-dir lang ns-sym ns-data]
   (let [filename (:filename ns-data)]
     (when-not (skip-write? config-dir filename)
-      (time
-       (dotimes [i 1000]
-         (let [file (cache-file cache-dir lang ns-sym)
-               _ (io/make-parents file)
-               os (io/output-stream file)]
-           (with-open [;; first we write to a baos as a workaround for transit-clj #43
-                       ;; bos (java.io.ByteArrayOutputStream. 1024)
-                       os (no-flush-output-stream os)]
-             (let [writer (transit/writer os :json)]
-               (transit/write writer ns-data)))))))))
+      (let [file (cache-file cache-dir lang ns-sym)
+            _ (io/make-parents file)
+            os (io/output-stream file)]
+        (with-open [;; first we write to a baos as a workaround for transit-clj #43
+                    ;; bos (java.io.ByteArrayOutputStream. 1024)
+                    os (no-flush-output-stream os)]
+          (let [writer (transit/writer os :json)]
+            (transit/write writer ns-data)))))))
 
 (def ^:dynamic *lock-file-name* "lock")
 


### PR DESCRIPTION
See https://github.com/cognitect/transit-clj/issues/43