### PR TITLE
Add threaded-fn-form linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2159](https://github.com/clj-kondo/clj-kondo/issues/2159): new linter, `:threaded-fn-form`
 - [#2143](https://github.com/clj-kondo/clj-kondo/issues/2143): false positive type warning for `clojure.set/project`
 - [#2145](https://github.com/clj-kondo/clj-kondo/issues/2145): support ignore hint on multi-arity branch of function definition
 - [#2147](https://github.com/clj-kondo/clj-kondo/issues/2147): use altenative solution as workaround for https://github.com/cognitect/transit-clj/issues/43

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1369,9 +1369,9 @@ Mismatched bracket: found an opening [ on line 1 and a closing )
 
 ### Threaded function form
 
-*Keyword:* `threaded-fn-form`.
+*Keyword:* `:threaded-fn-form`.
 
-*Description:* warn when directly supplying a function literal as one of the `forms` (n.b. not the first "expression" argument) to the `->` "thread-first" macro. Although this can compile (when a symbol literal is threaded), threading into the `name` slot of an anonymous function is almost always not intended. "Double wrapping" is usually what is intended (e.g. `(-> foo ((fn [x] ...)))`).
+*Description:* warn when directly supplying a function literal as one of the `forms` (n.b. not the first "expression" argument) to the `->` "thread-first" or `some->` macro. Although this can compile (when a symbol literal is threaded), threading into the `name` slot of an anonymous function is almost always not intended. "Double wrapping" is usually what is intended (e.g. `(-> foo ((fn [x] ...)))`).
 
 *Default level:* `warning`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1373,7 +1373,7 @@ Mismatched bracket: found an opening [ on line 1 and a closing )
 
 *Description:* warn when directly supplying a function literal as one of the `forms` (n.b. not the first "expression" argument) to the `->` "thread-first" or `some->` macro. Although this can compile (when a symbol literal is threaded), threading into the `name` slot of an anonymous function is almost always not intended. "Double wrapping" is usually what is intended (e.g. `(-> foo ((fn [x] ...)))`).
 
-*Default level:* `warning`.
+*Default level:* `:off`.
 
 *Example trigger:* `(-> foo (fn [x] (inc x)))`
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -78,6 +78,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Single operand comparison](#single-operand-comparison)
     - [Shadowed var](#shadowed-var)
     - [Syntax](#syntax)
+    - [Threaded function form](#threaded-fn-form)
     - [Type mismatch](#type-mismatch)
     - [Unbound destructuring default](#unbound-destructuring-default)
     - [Uninitialized var](#uninitialized-var)
@@ -1365,6 +1366,18 @@ Example messages:
 Mismatched bracket: found an opening [ and a closing ) on line 1
 Mismatched bracket: found an opening [ on line 1 and a closing )
 ```
+
+### Threaded function form
+
+*Keyword:* `threaded-fn-form`.
+
+*Description:* warn when directly supplying a function literal as one of the `forms` (n.b. not the first "expression" argument) to the `->` "thread-first" macro. Although this can compile (when a symbol literal is threaded), threading into the `name` slot of an anonymous function is almost always not intended. "Double wrapping" is usually what is intended (e.g. `(-> foo ((fn [x] ...)))`).
+
+*Default level:* `warning`.
+
+*Example trigger:* `(-> foo (fn [x] (inc x)))`
+
+*Example message:* `threading a value into the name slot of an anonymous fn`
 
 ### Type mismatch
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1639,7 +1639,7 @@
              (node->line (:filename ctx)
                          node
                          :threaded-fn-form
-                         "threading a value into the name slot of an anonymous fn")))
+                         "Threading a value into the name slot of an anonymous fn")))
           fn-nodes)))
 
 (defn analyze-memfn [ctx expr]

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -128,6 +128,7 @@
               :unexpected-recur {:level :error}
               :main-without-gen-class {:level :off}
               :redundant-fn-wrapper {:level :off}
+              :threaded-fn-form {:level :warning}
               :namespace-name-mismatch {:level :error}
               :non-arg-vec-return-type-hint {:level :warning}
               :keyword-binding {:level :off}

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -128,7 +128,7 @@
               :unexpected-recur {:level :error}
               :main-without-gen-class {:level :off}
               :redundant-fn-wrapper {:level :off}
-              :threaded-fn-form {:level :warning}
+              :threaded-fn-form {:level :off}
               :namespace-name-mismatch {:level :error}
               :non-arg-vec-return-type-hint {:level :warning}
               :keyword-binding {:level :off}

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -38,6 +38,10 @@
   (and (instance? clj_kondo.impl.rewrite_clj.node.seq.SeqNode n)
        (identical? :set (tag n))))
 
+(defn fn-node? [n]
+  (and (instance? clj_kondo.impl.rewrite_clj.node.fn.FnNode n)
+       (identical? :fn (tag n))))
+
 ;;; end export
 
 (defn print-err! [& strs]

--- a/test/clj_kondo/threaded_fn_form_test.clj
+++ b/test/clj_kondo/threaded_fn_form_test.clj
@@ -1,0 +1,24 @@
+(ns clj-kondo.threaded-fn-form-test
+  (:require
+   [clj-kondo.test-utils :refer [lint! assert-submaps]]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+(deftest threaded-function-form-test
+  (testing "fn literal in thread-first form is a warning"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 9, :level :warning,
+        :message "threading a value into the name slot of an anonymous fn"})
+     (lint! "(-> foo (fn [x] (inc x)))")))
+  (testing "fn* literal in thread-first form is a warning"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 9, :level :warning,
+        :message "threading a value into the name slot of an anonymous fn"})
+     (lint! "(-> bar (fn* [y] (dec y)))")))
+  (testing "reader fn in thread-first form is a warning"
+    (assert-submaps
+     '({:file "<stdin>", :row 1, :col 9, :level :warning,
+        :message "threading a value into the name slot of an anonymous fn"})
+     (lint! "(-> baz #(inc %))")))
+  (testing "double wrapped fn literal is not a warning"
+    (is (empty? (lint! "(-> qux ((fn [x] (inc x))))")))
+    (is (empty? (lint! "(-> qux (#(inc %)))")))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [✓] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [✓] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
https://github.com/clj-kondo/clj-kondo/issues/2159

- [✓] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [✓] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

As mentioned in the issue, I think a thread-last linter could be useful as well, but I could see that it's slightly less likely to be a mistake, so maybe if added it would be off by default?

In terms of implementation, I'm checking the unqualified symbols are `fn` or `fn*` rather than checking their qualified forms, as this didn't seem available to me in the `ctx` or `expr`. Otherwise, I think it works as expected.
