### PR TITLE
Add missing documentation for :single-logical-operand linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#2179](https://github.com/clj-kondo/clj-kondo/issues/2179): consider alias-as-object usage in CLJS for :unused-alias linter
+- [#2184](https://github.com/clj-kondo/clj-kondo/issues/2184): Add missing documentation for :single-logical-operand linter
 
 ## 2023.09.07
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -75,6 +75,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Refer](#refer)
     - [Refer all](#refer-all)
     - [Single key in](#single-key-in)
+    - [Single logical operand](#single-logical-operand)
     - [Single operand comparison](#single-operand-comparison)
     - [Shadowed var](#shadowed-var)
     - [Syntax](#syntax)
@@ -1314,6 +1315,18 @@ Example warning: `require with :refer`.
 *Example trigger:* `(get-in {:a 1} [:a])`.
 
 *Example message:* `get-in with single key.`
+
+### Single logical operand
+
+*Keyword:* `:single-logical-operand`.
+
+*Description:* warn on single operand logical operators with always the same value.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(and 1)`.
+
+*Example message:* `Single arg use of and always returns the arg itself.`
 
 ### Single operand comparison
 


### PR DESCRIPTION
Adds documentation for `:single-logical-operand` linter to linter docs https://github.com/clj-kondo/clj-kondo/blob/6bca0676674ae784ba487dea150b63567e2b6b2a/src/clj_kondo/impl/linters.clj#L194
Fixes https://github.com/clj-kondo/clj-kondo/issues/2184

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
Documentation change, no tests

- [X] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
