### PR TITLE
Add end-row and end-col template variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2179](https://github.com/clj-kondo/clj-kondo/issues/2179): consider alias-as-object usage in CLJS for :unused-alias linter
 - [#2184](https://github.com/clj-kondo/clj-kondo/issues/2184): Add missing documentation for :single-logical-operand linter
 - [#2187](https://github.com/clj-kondo/clj-kondo/issues/2187): Fix type annotation of argument of `clojure.core/parse-uuid` from nilable/string to string
+- [#2192](https://github.com/clj-kondo/clj-kondo/issues/2192): Support end-row and end-col in :pattern output format
 
 ## 2023.09.07
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -425,10 +425,13 @@ The custom pattern supports these template values:
 |-------------------|-----------------------------------------------------------|
 | `{{filename}}`    | File name                                                 |
 | `{{row}}`         | Row where linter violation starts                         |
+| `{{end-row}}`     | Row where linter violation ends                           |
 | `{{col}}`         | Column where linter violation starts                      |
+| `{{end-col}}`     | Column where linter violation ends                        |
 | `{{level}}`       | Lowercase level of linter warning, one of info,warn,error |
 | `{{LEVEL}}`       | Uppercase variant of `{{level}}`                          |
 | `{{message}}`     | Linter message                                            |
+| `{{type}}`        | Linter violation type                                     |
 
 ### Include and exclude files from the output
 

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -27,11 +27,13 @@
 (defn format-output [config]
   (let [output-cfg (:output config)]
     (if-let [^String pattern (-> output-cfg :pattern)]
-      (fn [{:keys [:filename :row :col :level :message :type] :as _finding}]
+      (fn [{:keys [:filename :row :end-row :col :end-col :level :message :type] :as _finding}]
         (-> pattern
             (str/replace "{{filename}}" filename)
             (str/replace "{{row}}" (str row))
+            (str/replace "{{end-row}}" (str end-row))
             (str/replace "{{col}}" (str col))
+            (str/replace "{{end-col}}" (str end-col))
             (str/replace "{{level}}" (name level))
             (str/replace "{{LEVEL}}" (str/upper-case (name level)))
             (str/replace "{{message}}" message)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -942,9 +942,9 @@ foo/foo ;; this does use the private var
   (is (str/starts-with?
        (with-out-str
          (with-in-str "(do 1)"
-           (main "--lint" "-" "--config" (str '{:output {:pattern "{{LEVEL}}_{{filename}}"}
+           (main "--lint" "-" "--config" (str '{:output {:pattern "{{LEVEL}}_{{filename}}_{{end-row}}"}
                                                 :linters {:unresolved-symbol {:level :off}}}))))
-       "WARNING_<stdin>"))
+       "WARNING_<stdin>_1"))
   (is (empty? (lint! "(comment (select-keys))" '{:skip-comments true
                                                  :linters {:unresolved-symbol {:level :off}}})))
   (assert-submap


### PR DESCRIPTION
Document 'type' template variable, too, while we're at it.

fixes #2192

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.