### PR TITLE
Implemented no underscore linter - #1753

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
-- [#1753](https://github.com/clj-kondo/clj-kondo/issues/1753): new linter `:underline-in-namespace`
+- [#1753](https://github.com/clj-kondo/clj-kondo/issues/1753): new linter `:underscore-in-namespace`
 - [#2207](https://github.com/clj-kondo/clj-kondo/issues/2207): New `:condition-always-true` linter, see [docs](doc/linters.md)
 - [#2013](https://github.com/clj-kondo/clj-kondo/issues/2013): Fix NPE and similar errors when linting an import with an illegal token
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#1753](https://github.com/clj-kondo/clj-kondo/issues/1753): new linter `:underline-in-namespace`
 - [#2207](https://github.com/clj-kondo/clj-kondo/issues/2207): New `:condition-always-true` linter, see [docs](doc/linters.md)
 - [#2013](https://github.com/clj-kondo/clj-kondo/issues/2013): Fix NPE and similar errors when linting an import with an illegal token
 

--- a/corpus/no_unused_namespace.clj
+++ b/corpus/no_unused_namespace.clj
@@ -1,4 +1,4 @@
-(ns no_unused-namespace
+(ns no-unused-namespace
   (:require [clojure.string :as str]))
 
 (let [{score (if (str/starts-with? "foo" "f")

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1948,3 +1948,15 @@ namespaces. Defaults to only warning when doing interop.
 
 The value of `:warn-only-on-interop` can be set to `false` to always warn in
 Clojure namespaces.
+
+## Underscore in namespace
+
+*Keyword:* `:underscore-in-namespace`
+
+*Description:* warns about the usage of the `_` character in the declaration of namespaces (as opposed to `-`).
+
+*Default level:* `:warning`
+
+*Example trigger:* `(ns special_files)`
+
+*Example message:* `Avoid underscore in namespace name: special_files`

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -550,6 +550,7 @@
                                (str "Namespace name does not match file name: " ns-name)))))))
 
         _ (when (and (not (identical? :off (-> ctx :config :linters :underline-in-namespace :level)))
+                     (symbol? ns-name)
                      (.contains ^String (name ns-name) "_"))
             (findings/reg-finding!
              ctx

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -549,15 +549,15 @@
                                :namespace-name-mismatch
                                (str "Namespace name does not match file name: " ns-name)))))))
 
-        _ (when (and (not (identical? :off (-> ctx :config :linters :underline-in-namespace :level)))
+        _ (when (and (not (identical? :off (-> ctx :config :linters :underscore-in-namespace :level)))
                      (symbol? ns-name)
-                     (.contains ^String (name ns-name) "_"))
+                     (str/includes? (name ns-name) "_"))
             (findings/reg-finding!
              ctx
              (node->line filename
                          ns-name-expr
-                         :underline-in-namespace
-                         (str "Avoid underline in namespace name: " (namespace-munge ns-name)))))
+                         :underscore-in-namespace
+                         (str "Avoid underscore in namespace name: " (namespace-munge ns-name)))))
 
         clauses children
         _ (run! #(utils/handle-ignore ctx %) children)

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -548,6 +548,16 @@
                                ns-name-expr
                                :namespace-name-mismatch
                                (str "Namespace name does not match file name: " ns-name)))))))
+
+        _ (when (and (not (identical? :off (-> ctx :config :linters :underline-in-namespace :level)))
+                     (.contains ^String (name ns-name) "_"))
+            (findings/reg-finding!
+             ctx
+             (node->line filename
+                         ns-name-expr
+                         :underline-in-namespace
+                         (str "Avoid underline in namespace name: " (namespace-munge ns-name)))))
+
         clauses children
         _ (run! #(utils/handle-ignore ctx %) children)
         kw+libspecs (for [?require-clause clauses

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -557,7 +557,7 @@
              (node->line filename
                          ns-name-expr
                          :underscore-in-namespace
-                         (str "Avoid underscore in namespace name: " (namespace-munge ns-name)))))
+                         (str "Avoid underscore in namespace name: " ns-name))))
 
         clauses children
         _ (run! #(utils/handle-ignore ctx %) children)

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -156,7 +156,8 @@
               :protocol-method-varargs {:level :error}
               :unused-alias {:level :off}
               :self-requiring-namespace {:level :off}
-              :condition-always-true {:level :off}}
+              :condition-always-true {:level :off}
+              :underline-in-namespace {:level :warning}}
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -157,7 +157,7 @@
               :unused-alias {:level :off}
               :self-requiring-namespace {:level :off}
               :condition-always-true {:level :off}
-              :underline-in-namespace {:level :warning}}
+              :underscore-in-namespace {:level :warning}}
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3426,12 +3426,12 @@ foo/")))
     (assert-submaps2 expected (lint! "(import 3.14)"))
     (assert-submaps2 expected (lint! "(import -1)"))))
 
-(deftest underline-in-ns
+(deftest underscore-in-ns
 
   (let [expected #(list {:file "<stdin>"
                          :row 1 :col 5
                          :level :warning
-                         :message (str "Avoid underline in namespace name: " %)})]
+                         :message (str "Avoid underscore in namespace name: " %)})]
 
     (assert-submaps2 (expected "beep_boop") (lint! "(ns beep_boop)"))
     (assert-submaps2 (expected "beep_") (lint! "(ns beep_)"))

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3436,7 +3436,8 @@ foo/")))
     (assert-submaps2 (expected "beep_boop") (lint! "(ns beep_boop)"))
     (assert-submaps2 (expected "beep_") (lint! "(ns beep_)"))
     (assert-submaps2 (expected "_boop") (lint! "(ns _boop)"))
-    (assert-submaps2 (expected "never_give.you_up") (lint! "(ns never_give.you_up)"))))
+    (assert-submaps2 (expected "never_give.you-up") (lint! "(ns never_give.you-up)"))
+    (assert-submaps2 (expected "a.large-smelly_dog") (lint! "(ns a.large-smelly_dog)"))))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3426,6 +3426,18 @@ foo/")))
     (assert-submaps2 expected (lint! "(import 3.14)"))
     (assert-submaps2 expected (lint! "(import -1)"))))
 
+(deftest underline-in-ns
+
+  (let [expected #(list {:file "<stdin>"
+                         :row 1 :col 5
+                         :level :warning
+                         :message (str "Avoid underline in namespace name: " %)})]
+
+    (assert-submaps2 (expected "beep_boop") (lint! "(ns beep_boop)"))
+    (assert-submaps2 (expected "beep_") (lint! "(ns beep_)"))
+    (assert-submaps2 (expected "_boop") (lint! "(ns _boop)"))
+    (assert-submaps2 (expected "never_give.you_up") (lint! "(ns never_give.you_up)"))))
+
 ;;;; Scratch
 
 (comment


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

This adds a linter `:underscore-in-namespace` which warns on the presence of the `_` character in `ns` declarations, as requested in issue #1753.

This also modifies the `corpus/no_unused_namespace.clj` test sample file so that the namespace is named `no-unused-namespace`  instead of `no_unused-namespace`.