### PR TITLE
Add invalid-fn-name linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
-- ...
+- [#2159](https://github.com/clj-kondo/clj-kondo/issues/2159): New linter, `:invalid-fn-name`
 
 ## 2023.12.15
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -47,6 +47,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Format](#format)
     - [Def + fn instead of defn](#def--fn-instead-of-defn)
     - [Inline def](#inline-def)
+    - [Invalid fn name](#invalid-fn-name)
     - [Invalid arity](#invalid-arity)
     - [Conflicting arity](#conflicting-arity)
     - [Reduce without initial value](#reduce-without-initial-value)
@@ -844,6 +845,21 @@ See [issue](https://github.com/clj-kondo/clj-kondo/issues/1920).
 *Example trigger:* `(defn foo [] (def x 1))`.
 
 *Example message:* `inline def`.
+
+### Invalid fn name
+
+**Keyword:** `:invalid-fn-name`.
+
+*Description:* warn when a function's name is not valid. If present, it should
+be an unquoted symbol.
+
+*Default level:* `:error`.
+
+*Example trigger:* `(fn :fn-name [x] (inc x))`.
+
+*Example message:* `First arg of fn should be a symbol, params vector or arity clause`.
+
+*Config:*
 
 ### Invalid arity
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -26,6 +26,7 @@
               :private-call {:level :error}
               :inline-def {:level :warning}
               :def-fn {:level :off}
+              :invalid-fn-name {:level :error}
               :redundant-do {:level :warning}
               :redundant-let {:level :warning}
               :cond-else {:level :warning}

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -38,6 +38,10 @@
   (and (instance? clj_kondo.impl.rewrite_clj.node.seq.SeqNode n)
        (identical? :set (tag n))))
 
+(defn vector-node? [n]
+  (and (instance? clj_kondo.impl.rewrite_clj.node.seq.SeqNode n)
+       (identical? :vector (tag n))))
+
 ;;; end export
 
 (defn print-err! [& strs]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -60,6 +60,22 @@
       (is (empty? (lint! "(def x (reify Object (toString [_] \"x\")))" "--lang" (name lang) "--config" (pr-str config))))
       (is (empty? (lint! "(require '[some.ns :refer [my-reify]]) (def x (my-reify Object (toString [_] \"x\")))" "--lang" (name lang) "--config" (pr-str config)))))))
 
+(deftest invalid-fn-name-test
+  (assert-submaps
+   '({:row 1, :col 1, :level :error, :message "First arg of fn should be a symbol, params vector or arity clause"})
+   (lint! "(fn \"fn-name\" [x] (inc x))"))
+  (assert-submaps
+   '({:row 1, :col 1, :level :error, :message "First arg of fn should be a symbol, params vector or arity clause"})
+   (lint! "(defn :fn-name [x] (inc x))"))
+  (assert-submaps
+   '({:row 1, :col 6, :level :error, :message "First arg of fn should be a symbol, params vector or arity clause"})
+   (lint! "(map (fn 'symbol ([x] (inc x))) coll)"))
+  (assert-submaps
+   '({:row 1, :col 7, :level :error, :message "First arg of fn should be a symbol, params vector or arity clause"})
+   (lint! "(-> 7 (fn [x] (inc x)))"))
+  (is (empty? (lint! "(fn fn-name [x] (inc x))")))
+  (is (empty? (lint! "(defn fn-name [x] (inc x))"))))
+
 (deftest redundant-let-test
   (let [linted (lint! (io/file "corpus" "redundant_let.clj"))
         row-col-files (map #(select-keys % [:row :col :file])


### PR DESCRIPTION
Alternative to #2243

Covers cases such as this:

```clojure
(fn {:foo :bar} [x] (+ x 42))

({:file "<stdin>",
  :row 1,
  :col 1,
  :level :error,
  :message "First arg of fn should be a symbol, params vector or arity clause"})
```

Spun out of #2211