### PR TITLE
add datalevin.core/q to datalog syntax checking

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2452,7 +2452,8 @@
                             ([datahike.api q]
                              [datascript.core q]
                              [datomic.api q]
-                             [datomic.client.api q])
+                             [datomic.client.api q]
+                             [datalevin.core q])
                             (do (datalog/analyze-datalog ctx expr)
                                 (analyze-children ctx children false))
                             ([compojure.core GET]


### PR DESCRIPTION
Clj-kondo's datalog linting is really nice. But currently it doesn't work with [datalevin](https://github.com/juji-io/datalevin).

There is currently an easy enough work around which is:

```
{:lint-as {datalevin.core/q datascript.core/q}}  
```

However, seeing as datalevin seems to be popular having support by default would be nice for new users. This change adds datalevin.core/q to the datalog syntax check list.

Appologies for not opening an issue first, I figured this was such a small change that a PR would be easier.

Let me know if I need to make any changes/additions.