### PR TITLE
Expand fn literals at threading macroexpand time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] update lein-clj-kondo -->
 <!-- - [ ] update carve -->
 
+## Unreleased
+- [#1923](https://github.com/clj-kondo/clj-kondo/issues/1923): Lint invalid fn name for threaded fn literals
+
 ## 2024.02.12
 
 - [#2274](https://github.com/clj-kondo/clj-kondo/issues/2274): Support clojure 1.12 new type hint notations

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -957,9 +957,11 @@
     "Use defn instead of def + fn")))
 
 (defn analyze-fn [ctx expr]
-  (let [ctx (assoc ctx :seen-recur? (volatile! nil))
-        protocol-fn (:protocol-fn expr)
-        ctx (assoc ctx :protocol-fn protocol-fn)
+  (let [protocol-fn (:protocol-fn expr)
+        has-first-arg? (:clj-kondo.impl/fn-has-first-arg (meta expr))
+        ctx (cond-> (assoc ctx :protocol-fn protocol-fn
+                               :seen-recur? (volatile! nil))
+              has-first-arg? (assoc-in [:bindings '%] {}))
         children (:children expr)
         ?name-expr (second children)
         ?fn-name (when ?name-expr
@@ -2851,12 +2853,8 @@
                                                   :level :error
                                                   :type :syntax
                                                   :message "#()s are not allowed in EDN")))
-              (let [expanded-node (macroexpand/expand-fn expr)
-                    m (meta expanded-node)
-                    has-first-arg? (:clj-kondo.impl/fn-has-first-arg m)]
-                (recur (cond-> (assoc ctx :arg-types nil :in-fn-literal true)
-                         has-first-arg? (update :bindings assoc '% {}))
-                       expanded-node)))
+              (recur (assoc ctx :arg-types nil :in-fn-literal true)
+                     (macroexpand/expand-fn expr)))
         :token
         (let [edn? (= :edn lang)]
           (if (or edn?

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -268,7 +268,7 @@
                              (and (not generated?)
                                   core?
                                   (not (:clj-kondo.impl/generated (meta parent-call)))
-                                  (one-of core-sym [do fn defn defn-
+                                  (one-of core-sym [do fn fn* defn defn-
                                                     let when-let loop binding with-open
                                                     doseq try when when-not when-first
                                                     when-some future]))]
@@ -295,7 +295,7 @@
                                   (or core? test?)
                                   (not (:clj-kondo.impl/generated (meta parent-call)))
                                   (if core?
-                                    (one-of core-sym [do fn defn defn-
+                                    (one-of core-sym [do fn fn* defn defn-
                                                       let when-let loop binding with-open
                                                       doseq try when when-not when-first
                                                       when-some future])

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -512,7 +512,7 @@
                                   ;; doseq always return nil
                                   (utils/one-of core-sym [doseq])
                                   (< idx (dec (:len call))))
-                                 (utils/one-of core-sym [do fn defn defn-
+                                 (utils/one-of core-sym [do fn fn* defn defn-
                                                          let when-let loop binding with-open
                                                          doseq try when when-not when-first
                                                          when-some future]))

--- a/src/clj_kondo/impl/macroexpand.clj
+++ b/src/clj_kondo/impl/macroexpand.clj
@@ -12,7 +12,70 @@
         x (if m* (assoc x :meta m*) x)]
     (with-meta x m)))
 
-(declare expand-fn)
+(defn find-children
+  "Recursively filters children by pred"
+  [pred children]
+  (mapcat #(if (pred %)
+             [(pred %)]
+             (when-let [cchildren (:children %)]
+               (find-children pred cchildren)))
+          children))
+
+(defn fn-args [children]
+  (let [args (find-children
+              #(and (= :token (tag %))
+                    (:string-value %)
+                    (when-let [[_ n] (re-matches #"%((\d?\d?)|&)" (:string-value %))]
+                      (case n
+                        "" 1
+                        "&" 0
+                        (Integer/parseInt n))))
+              children)
+        args (sort args)
+        varargs? (when-let [fst (first args)]
+                   (zero? fst))
+        args (seq (if varargs? (rest args) args))
+        max-n (last args)
+        args (when args (map (fn [i]
+                               (symbol (str "%" i)))
+                             (range 1 (inc max-n))))]
+    {:varargs? varargs?
+     :args args}))
+
+(defn expand-fn [{:keys [:children] :as expr}]
+  (let [{:keys [:row :col] :as m} (meta expr)
+        {:keys [:args :varargs?]} (fn-args children)
+        fn-body (with-meta (list-node children)
+                  (assoc m
+                         :row row
+                         :col (inc col)))
+        arg-list (vector-node
+                  (map #(with-meta (token-node %)
+                          {:clj-kondo/mark-used true
+                           :clj-kondo/skip-reg-binding true})
+                       (if varargs?
+                         (concat args '[& %&])
+                         args)))
+        has-first-arg? (= '%1 (first args))]
+    (with-meta
+      (list-node [(token-node 'fn*) arg-list
+                  fn-body])
+      (assoc m :clj-kondo.impl/fn-has-first-arg has-first-arg?))))
+
+(defn expand-do-template [_ctx node]
+  (let [[_ argv expr & values] (:children node)
+        c (count (:children argv))
+        argv (:children argv)
+        new-node
+        (if (pos? c) ;; prevent infinite partition
+          (list-node (list* (token-node 'do)
+                            (map (fn [a] (walk/postwalk-replace (zipmap argv a) expr))
+                                 (partition c values))))
+          expr)
+        new-node (walk/postwalk #(if (map? %)
+                                   (assoc % :clj-kondo.impl/generated true)
+                                   %) new-node)]
+    new-node))
 
 (defn expand-> [_ctx expr]
   (let [expr expr
@@ -138,71 +201,6 @@
       (if more
         (recur (cons node more) )
         node))))
-
-(defn find-children
-  "Recursively filters children by pred"
-  [pred children]
-  (mapcat #(if (pred %)
-             [(pred %)]
-             (when-let [cchildren (:children %)]
-               (find-children pred cchildren)))
-          children))
-
-(defn fn-args [children]
-  (let [args (find-children
-              #(and (= :token (tag %))
-                    (:string-value %)
-                    (when-let [[_ n] (re-matches #"%((\d?\d?)|&)" (:string-value %))]
-                      (case n
-                        "" 1
-                        "&" 0
-                        (Integer/parseInt n))))
-              children)
-        args (sort args)
-        varargs? (when-let [fst (first args)]
-                   (zero? fst))
-        args (seq (if varargs? (rest args) args))
-        max-n (last args)
-        args (when args (map (fn [i]
-                               (symbol (str "%" i)))
-                             (range 1 (inc max-n))))]
-    {:varargs? varargs?
-     :args args}))
-
-(defn expand-fn [{:keys [:children] :as expr}]
-  (let [{:keys [:row :col] :as m} (meta expr)
-        {:keys [:args :varargs?]} (fn-args children)
-        fn-body (with-meta (list-node children)
-                  (assoc m
-                         :row row
-                         :col (inc col)))
-        arg-list (vector-node
-                  (map #(with-meta (token-node %)
-                          {:clj-kondo/mark-used true
-                           :clj-kondo/skip-reg-binding true})
-                       (if varargs?
-                         (concat args '[& %&])
-                         args)))
-        has-first-arg? (= '%1 (first args))]
-    (with-meta
-      (list-node [(token-node 'fn*) arg-list
-                  fn-body])
-      (assoc m :clj-kondo.impl/fn-has-first-arg has-first-arg?))))
-
-(defn expand-do-template [_ctx node]
-  (let [[_ argv expr & values] (:children node)
-        c (count (:children argv))
-        argv (:children argv)
-        new-node
-        (if (pos? c) ;; prevent infinite partition
-          (list-node (list* (token-node 'do)
-                            (map (fn [a] (walk/postwalk-replace (zipmap argv a) expr))
-                                 (partition c values))))
-          expr)
-        new-node (walk/postwalk #(if (map? %)
-                                   (assoc % :clj-kondo.impl/generated true)
-                                   %) new-node)]
-    new-node))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3480,7 +3480,11 @@ foo/")))
    '({:file "<stdin>", :row 1, :col 7, :level :error, :message "Function name must be simple symbol but got: :foo"}
      {:file "<stdin>", :row 1, :col 20, :level :error, :message "Function name must be simple symbol but got: :foo"}
      {:file "<stdin>", :row 1, :col 33, :level :error, :message "Function name must be simple symbol but got: \"foo\""})
-   (lint! "(defn :foo []) (fn :foo []) (fn \"foo\" [])")))
+   (lint! "(defn :foo []) (fn :foo []) (fn \"foo\" [])"))
+  (assert-submaps
+   '({:file "<stdin>", :row 1, :col 5, :level :error, :message "Function name must be simple symbol but got: :foo"}
+     {:file "<stdin>", :row 1, :col 24, :level :error, :message "Function name must be simple symbol but got: \"foo\""})
+   (lint! "(-> :foo #(inc %)) (-> \"foo\" #(inc %))")))
 
 (deftest lint-stdin-exclude-files-test
   (is (empty?

--- a/test/clj_kondo/unused_value_test.clj
+++ b/test/clj_kondo/unused_value_test.clj
@@ -146,3 +146,12 @@
               '{:linters {:unused-value {:level :warning}}
                 :config-in-call {hyperfiddle.rcf/tests {:linters {:unresolved-symbol {:level :off}
                                                                   :unused-value {:level :off}}}}})))
+
+(deftest thread-last-test
+  (assert-submaps
+   '({:file "<stdin>", :row 1, :col 12, :level :warning, :message "Unused value"})
+   (lint! "(->> :foo #(name %))"
+          {:linters {:unused-value {:level :warning}
+                     :redundant-fn-wrapper {:level :off}}}))
+  (is (empty? (lint! "(->> :foo (#(name %)))" {:linters {:unused-value {:level :warning}
+                                                         :redundant-fn-wrapper {:level :off}}}))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). ([1923](https://github.com/clj-kondo/clj-kondo/issues/1923))

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

---

This PR takes the functionality from #2211 which wasn't implemented in #2243.
Namely the work to thread into fn literals (`#()` forms) so invalid names and unused values can be detected.

Before this PR, the following code would not raise a linting error:
```clojure
(-> :foo #(name %))
```
But after it, it raises a "Function name must be simple symbol but got: :foo" error.
This makes sense because the macroexpansion of the above form looks like so:
```clojure
(macroexpand '(-> :foo #(name %)))
;; => (fn* :foo [p1__23143#] (name p1__23143#))
```

Also, before this PR, the following code would not raise a linting error:
```clojure
(->> :foo #(name %))
```
But after it, it raises an "Unused value" error.
This makes sense because the macroexpansion of the above form looks like so:
```clojure
(macroexpand '(->> :foo #(name %)))
;; => (fn* [p1__23147#] (name p1__23147#) :foo)
```

The PR is split into two commits, which should be squashed:

1. Expand fn literals at threading macroexpand time
This is the functional changes:
a. Add separate treatment for `:fn` forms vs other non-lists in `expand->` and `expand->>`
b. Move `%` anaphoric argument handling earlier in `analyze-fn`
c. Add `fn*` to the list of core-syms checked by `analyze-usages2` and `lint-var-usage` (as this is what fn literals expand to)
2. Move expand-fn code & add tests
I think it's clearer to move the `expand-fn` code and its dependencies as a separate step, to show that nothing in it is changed. Added tests & updated the changelog.