### PR TITLE
Report locations for more reader errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## 2024.05.24
 
 - Imports were copied to `.clj-kondo/imports` but weren't pick up correctly. Thanks [@frenchy64](https://github.com/frenchy64) for reporting the bug.
+- [#2333](https://github.com/clj-kondo/clj-kondo/issues/2333): Add location to invalid literal syntax errors
 
 ## 2024.05.22
 

--- a/corpus/invalid_characters.clj
+++ b/corpus/invalid_characters.clj
@@ -1,0 +1,7 @@
+(ns invalid-characters)
+
+\u12345
+\uxyz
+\o12345
+\o400
+\spcae

--- a/corpus/invalid_literals.clj
+++ b/corpus/invalid_literals.clj
@@ -1,0 +1,10 @@
+(ns corpus.invalid-literals)
+
+:
+::
+:foo:
+foo:
+foo/
+:foo/
+##
+##NAN

--- a/corpus/invalid_unicode.clj
+++ b/corpus/invalid_unicode.clj
@@ -1,3 +1,0 @@
-(ns invalid-unicode)
-
-\u12345

--- a/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
@@ -52,16 +52,11 @@
           (symbol-node reader v s)
           (node/token-node v s)))
       (catch Exception e
-        (if r/*reader-exceptions*
-          (do (let [{:keys [:type :ex-kind]} (ex-data e)]
-                (if (and (= :reader-exception type)
-                         (or (= :reader-error ex-kind)
-                             (= :illegal-argument ex-kind)
-                             (= :eof ex-kind)))
-                  (let [f {:row token-row
-                           :col token-col
-                           :message (.getMessage e)}]
-                    (swap! r/*reader-exceptions* conj (ex-info "Syntax error" {:findings [f]})))
-                  (throw e)))
-              reader)
+        (if (and r/*reader-exceptions*
+                 (= :reader-exception (:type (ex-data e))))
+          (let [f {:row token-row
+                   :col token-col
+                   :message (.getMessage e)}]
+            (swap! r/*reader-exceptions* conj (ex-info "Syntax error" {:findings [f]}))
+            reader)
           (throw e))))))

--- a/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
@@ -56,7 +56,8 @@
           (do (let [{:keys [:type :ex-kind]} (ex-data e)]
                 (if (and (= :reader-exception type)
                          (or (= :reader-error ex-kind)
-                             (= :illegal-argument ex-kind)))
+                             (= :illegal-argument ex-kind)
+                             (= :eof ex-kind)))
                   (let [f {:row token-row
                            :col token-col
                            :message (.getMessage e)}]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3555,8 +3555,12 @@ foo/")))
 
 (deftest issue-2322-test
   (assert-submaps
-   '({:file "corpus/invalid_unicode.clj", :row 3, :col 1, :level :error, :message "Invalid unicode literal: \\u12345."})
-   (lint! (io/file "corpus/invalid_unicode.clj")))
+   '({:row 3, :col 1, :level :error, :message "Invalid unicode literal: \\u12345."}
+     {:row 4, :col 1, :level :error, :message "Invalid unicode literal: \\uxyz."}
+     {:row 5, :col 1, :level :error, :message "Invalid octal escape sequence in a character literal:o12345. Octal escape sequences must be 3 or fewer digits."}
+     {:row 6, :col 1, :level :error, :message "Octal escape sequence must be in range [0, 377]."}
+     {:row 7, :col 1, :level :error, :message "Unsupported character: spcae."})
+   (lint! (io/file "corpus/invalid_characters.clj")))
   (assert-submaps
    '({:row 3, :col 1, :level :error, :message "A single colon is not a valid keyword."}
      {:row 4, :col 1, :level :error, :message "A single colon is not a valid keyword."}

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3556,7 +3556,17 @@ foo/")))
 (deftest issue-2322-test
   (assert-submaps
    '({:file "corpus/invalid_unicode.clj", :row 3, :col 1, :level :error, :message "Invalid unicode literal: \\u12345."})
-   (lint! (io/file "corpus/invalid_unicode.clj"))))
+   (lint! (io/file "corpus/invalid_unicode.clj")))
+  (assert-submaps
+   '({:row 3, :col 1, :level :error, :message "A single colon is not a valid keyword."}
+     {:row 4, :col 1, :level :error, :message "A single colon is not a valid keyword."}
+     {:row 5, :col 1, :level :error, :message "Invalid keyword: foo:."}
+     {:row 6, :col 1, :level :error, :message "Invalid symbol: foo:."}
+     {:row 7, :col 1, :level :error, :message "Invalid symbol: foo/."}
+     {:row 8, :col 1, :level :error, :message "Invalid keyword: foo/."}
+     {:row 9, :col 1, :level :error, :message "EOF while reading."}
+     {:row 10, :col 1, :level :error, :message "Invalid token: ##NAN"})
+   (lint! (io/file "corpus/invalid_literals.clj"))))
 
 ;;;; Scratch
 


### PR DESCRIPTION
Fixes #2322
As mentioned in https://github.com/clj-kondo/clj-kondo/issues/2322#issuecomment-2132237967 I added an additional clause to check for `:eof` reader-exception types, which surfaces the correct line numbers for invalid literals such as `##`.

The last commit removes those checks altogether (which I felt was unnecessary and brittle) and refactors the logic for better readability. (ie. subjective, can be left out)

Invalid-radix number literals, also mentioned in the original issue, seem to have a deeper root cause in the inlined tools.reader code which might be better reported upstream.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
