### PR TITLE
Add new `--report-level` CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#1784](https://github.com/clj-kondo/clj-kondo/issues/1784): detect `:redundant-do` in `catch`
+- [#2410](https://github.com/clj-kondo/clj-kondo/issues/2410): add `--report-level` flag
 
 ## 2024.09.27
 

--- a/doc/ci-integration.md
+++ b/doc/ci-integration.md
@@ -14,6 +14,10 @@ clj-kondo --lint src --config .clj-kondo/ci-config.edn
 
 In this way, you can keep your configuration in the standard `config.edn` file and that will continue to work during development, with the overrides only be used during CI.
 
+## Ignoring output below `--fail-level`
+
+If you use the `--fail-level error` flag it might be useful to only see errors in CI, to make the output a bit easier to read for the poor humans that need to address the errors. In that case you can use `--report-level error` to hide any notices below that level.
+
 ## Pre-commit hook
 
 You can use this pre-commit hook to run `clj-kondo` over files you changed before

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -24,12 +24,8 @@
   [{:keys [:config :findings :summary :analysis :report-level]}]
   (let [output-cfg (:output config)
         report-level? (if report-level
-                        (let [report-level (some-> report-level keyword)]
-                          (if-let [levels (->> [:info :warning :error]
-                                               (drop-while #(not= report-level %))
-                                               seq)]
-                            (set levels)
-                            (constantly true)))
+                        (let [report-level (keyword report-level)]
+                          (set (drop-while #(not= report-level %) [:info :warning :error])))
                         (constantly true))
         fmt (or (:format output-cfg) :text)]
     (case fmt

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -23,10 +23,12 @@
   subject to change."
   [{:keys [:config :findings :summary :analysis :report-level]}]
   (let [output-cfg (:output config)
-        report-level (some-> report-level keyword)
-        report-level? (or (set (drop-while #(not= report-level %)
-                                           [:info :warning :error]))
-                          (constantly true))
+        report-level? (let [report-level (some-> report-level keyword)]
+                        (if-some [levels (->> [:info :warning :error]
+                                              (drop-while #(not= report-level %))
+                                              seq)]
+                          (set levels)
+                          (constantly true)))
         fmt (or (:format output-cfg) :text)]
     (case fmt
       :text

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -23,12 +23,14 @@
   subject to change."
   [{:keys [:config :findings :summary :analysis :report-level]}]
   (let [output-cfg (:output config)
-        report-level? (let [report-level (some-> report-level keyword)]
-                        (if-some [levels (->> [:info :warning :error]
-                                              (drop-while #(not= report-level %))
-                                              seq)]
-                          (set levels)
-                          (constantly true)))
+        report-level? (if report-level
+                        (let [report-level (some-> report-level keyword)]
+                          (if-let [levels (->> [:info :warning :error]
+                                               (drop-while #(not= report-level %))
+                                               seq)]
+                            (set levels)
+                            (constantly true)))
+                        (constantly true))
         fmt (or (:format output-cfg) :text)]
     (case fmt
       :text

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -23,9 +23,10 @@
   subject to change."
   [{:keys [:config :findings :summary :analysis :report-level]}]
   (let [output-cfg (:output config)
-        report-level (keyword report-level)
-        report-level? (set (drop-while #(not= report-level %)
-                                       [:info :warning :error]))
+        report-level (some-> report-level keyword)
+        report-level? (or (set (drop-while #(not= report-level %)
+                                           [:info :warning :error]))
+                          (constantly true))
         fmt (or (:format output-cfg) :text)]
     (case fmt
       :text

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -21,7 +21,7 @@
 (defn print!
   "Prints the result from `run!` to `*out*`. Returns `nil`. Alpha,
   subject to change."
-  [{:keys [:config :findings :summary :analysis]} report-level]
+  [{:keys [:config :findings :summary :analysis :report-level]}]
   (let [output-cfg (:output config)
         report-level (keyword report-level)
         report-level? (set (drop-while #(not= report-level %)

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -23,7 +23,8 @@
   subject to change."
   [{:keys [:config :findings :summary :analysis]} report-level]
   (let [output-cfg (:output config)
-        report-level? (set (drop-while #(not= (keyword report-level) %)
+        report-level (keyword report-level)
+        report-level? (set (drop-while #(not= report-level %)
                                        [:info :warning :error]))
         fmt (or (:format output-cfg) :text)]
     (case fmt
@@ -39,7 +40,7 @@
             (let [{:keys [:error :warning :duration]} summary]
               (printf "linting took %sms, " duration)
               (printf "errors: %s" error)
-              (when (report-level? "warning")
+              (when (report-level? :warning)
                 (printf ", warnings: %s" warning))
               (println "")))))
       ;; avoid loading clojure.pprint or bringing in additional libs for printing to EDN for now

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -15,7 +15,7 @@
     ;; note that you will still get an arity error when calling the fn/macro itself incorrectly
     :skip-args [#_clojure.core/comment #_cljs.core/comment]
     :skip-comments false ;; convenient shorthand for :skip-args [clojure.core/comment cljs.core/comment]
-    ;; linter level can be tweaked by setting :level to :error, :warn or :info (or any other keyword)
+    ;; linter level can be tweaked by setting :level to :error, :warning or :info (or any other keyword)
     ;; all linters are enabled by default, but can be turned off by setting :level to :off.
     ;; :config-in-comment {} config override for comment blocks
     :linters {:invalid-arity {:level :error

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -158,7 +158,7 @@ Options:
                            :as results} (clj-kondo/run! parsed)
                           {:keys [:error :warning]} summary]
                       (when-not dependencies
-                        (clj-kondo/print! results report-level))
+                        (clj-kondo/print! (assoc results :report-level report-level)))
                       (cond
                         (= "warning" fail-level)
                         (cond (pos? error) 3

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -55,6 +55,9 @@ Options:
   --fail-level <level>: minimum severity for exit with error code.  Supported values:
     warning, error.  The default level if unspecified is warning.
 
+  --report-level <level>: minimum severity for which to report.  Supported values:
+    info, warning, error.  The default level if unspecified is info.
+
   --debug: print debug information.
 "))
 
@@ -77,6 +80,7 @@ Options:
     "--copy-configs" :scalar
     "--skip-lint"    :scalar
     "--fail-level"   :scalar
+    "--report-level" :scalar
     "--debug"        :scalar
     :scalar))
 
@@ -128,13 +132,16 @@ Options:
      :skip-lint (contains? opts "--skip-lint")
      :fail-level (or (last (get opts "--fail-level"))
                      "warning")
+     :report-level (or (last (get opts "--report-level"))
+                       "info")
      :debug (contains? opts "--debug")}))
 
 (def fail-level? #{"warning" "error"})
+(def report-level? (conj fail-level? "info"))
 
 (defn main
   [& options]
-  (let [{:keys [:help :lint :version :pod :dependencies :fail-level] :as parsed}
+  (let [{:keys [:help :lint :version :pod :dependencies :fail-level :report-level] :as parsed}
         (parse-opts options)]
     (or (cond version
               (print-version)
@@ -145,11 +152,13 @@ Options:
               (print-help)
               (not (fail-level? fail-level))
               (print-help)
+              (not (report-level? report-level))
+              (print-help)
               :else (let [{:keys [:summary]
                            :as results} (clj-kondo/run! parsed)
                           {:keys [:error :warning]} summary]
                       (when-not dependencies
-                        (clj-kondo/print! results))
+                        (clj-kondo/print! results report-level))
                       (cond
                         (= "warning" fail-level)
                         (cond (pos? error) 3

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -86,14 +86,21 @@
         (is (= 2 (count lines)))
         (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
         (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
-    (testing "it reports findings when log-level is unrecognised"
+    (testing "it reports findings above specified log level"
       (let [lines (str/split-lines
                    (with-out-str
-                     (clj-kondo/print! (assoc findings :report-level "orrery"))))]
+                     (clj-kondo/print! (assoc findings :report-level "info"))))]
         (is (= 2 (count lines)))
         (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
         (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
-    (testing "it does not report findings below its level"
+    (testing "it reports findings at specified log level"
+      (let [lines (str/split-lines
+                   (with-out-str
+                     (clj-kondo/print! (assoc findings :report-level "warning"))))]
+        (is (= 2 (count lines)))
+        (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
+        (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
+    (testing "it does not report findings below specified level"
       (let [lines (str/split-lines
                    (with-out-str
                      (clj-kondo/print! (assoc findings :report-level "error"))))]

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -76,6 +76,30 @@
       (is (zero? warning))
       (is (zero? info)))))
 
+(deftest report!-test
+  (let [findings (with-in-str
+                   "(defn foo [x] :foo)" (clj-kondo/run! {:lint ["-"]}))]
+    (testing "it reports findings when report level is nil"
+      (let [lines (str/split-lines
+                   (with-out-str
+                     (clj-kondo/print! findings)))]
+        (is (= 2 (count lines)))
+        (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
+        (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
+    (testing "it reports findings when log-level is unrecognised"
+      (let [lines (str/split-lines
+                   (with-out-str
+                     (clj-kondo/print! (assoc findings :report-level "orrery"))))]
+        (is (= 2 (count lines)))
+        (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
+        (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
+    (testing "it does not report findings below its level"
+      (let [lines (str/split-lines
+                   (with-out-str
+                     (clj-kondo/print! (assoc findings :report-level "error"))))]
+        (is (= 1 (count lines)))
+        (is (re-matches #"linting took \d+ms, errors: 0" (last lines)))))))
+
 (deftest backwards-compatibility-with-analysis-in-output-config-test
   (let [res (fn [config]
               (with-in-str "(fn [a] a)"

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -82,14 +82,14 @@
     (testing "it reports findings at its level"
       (let [lines (string/split-lines
                    (with-out-str
-                     (clj-kondo/print! findings "warning")))]
+                     (clj-kondo/print! (assoc findings :report-level "warning"))))]
         (is (= 2 (count lines)))
         (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
         (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
     (testing "it does not report findings below its level"
       (let [lines (str/split-lines
                    (with-out-str
-                     (clj-kondo/print! findings "error")))]
+                     (clj-kondo/print! (assoc findings :report-level "error"))))]
         (is (= 1 (count lines)))
         (is (re-matches #"linting took \d+ms, errors: 0" (last lines)))))))
 

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -76,6 +76,23 @@
       (is (zero? warning))
       (is (zero? info)))))
 
+(deftest report!-test
+  (let [findings (with-in-str
+                   "(defn foo [x] :foo)" (clj-kondo/run! {:lint ["-"]}))]
+    (testing "it reports findings at its level"
+      (let [lines (string/split-lines
+                   (with-out-str
+                     (clj-kondo/print! findings "warning")))]
+        (is (= 2 (count lines)))
+        (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
+        (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
+    (testing "it does not report findings below its level"
+      (let [lines (str/split-lines
+                   (with-out-str
+                     (clj-kondo/print! findings "error")))]
+        (is (= 1 (count lines)))
+        (is (re-matches #"linting took \d+ms, errors: 0" (last lines)))))))
+
 (deftest backwards-compatibility-with-analysis-in-output-config-test
   (let [res (fn [config]
               (with-in-str "(fn [a] a)"

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -80,7 +80,7 @@
   (let [findings (with-in-str
                    "(defn foo [x] :foo)" (clj-kondo/run! {:lint ["-"]}))]
     (testing "it reports findings at its level"
-      (let [lines (string/split-lines
+      (let [lines (str/split-lines
                    (with-out-str
                      (clj-kondo/print! (assoc findings :report-level "warning"))))]
         (is (= 2 (count lines)))

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -76,23 +76,6 @@
       (is (zero? warning))
       (is (zero? info)))))
 
-(deftest report!-test
-  (let [findings (with-in-str
-                   "(defn foo [x] :foo)" (clj-kondo/run! {:lint ["-"]}))]
-    (testing "it reports findings at its level"
-      (let [lines (str/split-lines
-                   (with-out-str
-                     (clj-kondo/print! (assoc findings :report-level "warning"))))]
-        (is (= 2 (count lines)))
-        (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
-        (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines)))))
-    (testing "it does not report findings below its level"
-      (let [lines (str/split-lines
-                   (with-out-str
-                     (clj-kondo/print! (assoc findings :report-level "error"))))]
-        (is (= 1 (count lines)))
-        (is (re-matches #"linting took \d+ms, errors: 0" (last lines)))))))
-
 (deftest backwards-compatibility-with-analysis-in-output-config-test
   (let [res (fn [config]
               (with-in-str "(fn [a] a)"

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -286,7 +286,13 @@ foo/foo ;; this does use the private var
                      (main "--lint" "-" "--report-level" "error"))))]
       (is (= 1 (count lines)))
       (testing "and summary is omitted"
-        (is (re-matches #"linting took \d+ms, errors: 0" (last lines)))))))
+        (is (re-matches #"linting took \d+ms, errors: 0" (last lines))))))
+  (with-out-str
+    (testing "shows help when report-level is not recognised"
+      (let [output (with-out-str
+                     (with-in-str "(defn foo [x] :foo)"
+                       (main "--lint" "-" "--report-level" "not-a-level")))]
+        (is (re-find #"--report-level <level>: minimum severity for which to report." output))))))
 
 (deftest cond-test
   (doseq [lang [:clj :cljs :cljc]]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -261,6 +261,15 @@ foo/foo ;; this does use the private var
       (is (= 3 (with-in-str "(defn foo []) (foo 1)" (main "--fail-level" "error" "--lint" "-")))))))
 
 (deftest report-level-test
+  (testing "findings are reported when they are above report-level"
+    (let [lines (str/split-lines
+                 (with-out-str
+                   (with-in-str "(defn foo [x] :foo)"
+                     (main "--lint" "-" "--report-level" "info"))))]
+      (is (= 2 (count lines)))
+      (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
+      (testing "and summary is included"
+        (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines))))))
   (testing "findings are reported when they match report-level"
     (let [lines (str/split-lines
                  (with-out-str

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -260,6 +260,25 @@ foo/foo ;; this does use the private var
     (testing "the exit code is 3 when fail-level is error and errors are detected"
       (is (= 3 (with-in-str "(defn foo []) (foo 1)" (main "--fail-level" "error" "--lint" "-")))))))
 
+(deftest report-level-test
+  (testing "findings are reported when they match report-level"
+    (let [lines (str/split-lines
+                 (with-out-str
+                   (with-in-str "(defn foo [x] :foo)"
+                     (main "--lint" "-" "--report-level" "warning"))))]
+      (is (= 2 (count lines)))
+      (is (= "<stdin>:1:12: warning: unused binding x" (first lines)))
+      (testing "and summary is included"
+        (is (re-matches #"linting took \d+ms, errors: 0, warnings: 1" (last lines))))))
+  (testing "findings are omitted if they are below report-level"
+    (let [lines (str/split-lines
+                 (with-out-str
+                   (with-in-str "(defn foo [x] :foo)"
+                     (main "--lint" "-" "--report-level" "error"))))]
+      (is (= 1 (count lines)))
+      (testing "and summary is omitted"
+        (is (re-matches #"linting took \d+ms, errors: 0" (last lines)))))))
+
 (deftest cond-test
   (doseq [lang [:clj :cljs :cljc]]
     (testing (str "lang: " lang)

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -37,7 +37,7 @@
     (is (empty? (lint! "(defn foo [] '(def x 3))" "--lang" (name lang))))))
 
 (deftest def-fn-test
-  (let [config {:linters {:def-fn {:level :warn}}
+  (let [config {:linters {:def-fn {:level :warning}}
                 :lint-as '{some.ns/my-fn clojure.core/fn
                            some.ns/my-reify clojure.core/reify}}
         row-col (fn [results] (map #(select-keys % [:row :col]) results))]


### PR DESCRIPTION
This is useful for CI where you may not want to display info-level notices if you only require folks to fix warnings or above.

The default level is `info`.

With `--report-level error` will also omit the `, warnings: N` part of the output summary.

If the report level is not recognised, prints the help.

Fixes #2410

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
