### PR TITLE
Include fn* in the core-syms that analyze-usages2 checks

### DIFF
--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -277,7 +277,7 @@
                              (and (not generated?)
                                   core?
                                   (not (:clj-kondo.impl/generated (meta parent-call)))
-                                  (one-of core-sym [do fn defn defn-
+                                  (one-of core-sym [do fn fn* defn defn-
                                                     let when-let loop binding with-open
                                                     doseq try when when-not when-first
                                                     when-some future]))]
@@ -304,7 +304,7 @@
                                   (or core? test?)
                                   (not (:clj-kondo.impl/generated (meta parent-call)))
                                   (if core?
-                                    (one-of core-sym [do fn defn defn-
+                                    (one-of core-sym [do fn fn* defn defn-
                                                       let when-let loop binding with-open
                                                       doseq try when when-not when-first
                                                       when-some future])


### PR DESCRIPTION
I'd like to start chipping away at #2282, as it seems to be stuck in PR limbo 😄. Instead of trying to get the functionality - plus the numerous bits of supporting functionality - merged, I thought it might be best to just make a couple of uncontroversial PRs for the supporting functionality, like this.

I haven't added tests, as none of the other syms except for defn are tested anyway, but for illustrative sake:

Before:
```clojure
(lint! "(fn* [] 1 2)" conf/default-config)
;; => ()
```

After:
```clojure
(lint! "(fn* [] 1 2)" conf/default-config)
;; => ({:file "<stdin>", :row 1, :col 9, :level :warning, :message "Unused value: 1"})
```
