### PR TITLE
Include if-not in :condition-always-true linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] update lein-clj-kondo -->
 <!-- - [ ] update carve -->
 
+## Unreleased
+
+- [#2272](https://github.com/clj-kondo/clj-kondo/issues/2272): Report var usage in `if-not` condition as always truthy
+
 ## 2024.11.14
 
 - [#2212](https://github.com/clj-kondo/clj-kondo/issues/2212): NEW linter: `:redundant-nested-call` ([@tomdl89](https://github.com/tomdl89)), set to level `:info` by default

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1739,10 +1739,18 @@
        (node->line (:filename ctx) expr
                    linter
                    msg)))
-    (let [[condition & args] args]
+    (let [[condition & clauses] args]
       (when condition
         (analyze-expression** ctx (assoc condition :condition true)))
-      (analyze-children ctx args false))))
+      (analyze-children ctx clauses false))))
+
+(defn analyze-if-not
+  "Analyzes if-not macro"
+  [ctx expr]
+  (let [[condition & clauses] (rest (:children expr))]
+    (when condition
+      (analyze-expression** ctx (assoc condition :condition true)))
+    (analyze-children ctx clauses false)))
 
 (defn analyze-constructor
   "Analyzes (new Foo ...) constructor call."
@@ -2477,6 +2485,7 @@
                           (if top-level? (analyze-import ctx expr)
                               (analyze-children ctx children))
                           if (analyze-if ctx expr)
+                          if-not (analyze-if-not ctx expr)
                           new (analyze-constructor ctx expr)
                           set! (analyze-set! ctx expr)
                           = (analyze-= ctx expr)

--- a/test/clj_kondo/condition_always_true_test.clj
+++ b/test/clj_kondo/condition_always_true_test.clj
@@ -24,4 +24,12 @@
      :level :warning,
      :message "Condition always true"}]
    (lint! "(when #'inc 2)"
+          '{:linters {:condition-always-true {:level :warning}}}))
+  (assert-submaps2
+   [{:file "<stdin>",
+     :row 1,
+     :col 9,
+     :level :warning,
+     :message "Condition always true"}]
+   (lint! "(if-not odd? 1 2)"
           '{:linters {:condition-always-true {:level :warning}}})))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

I just linked this to the original issue (#2272) as I think this should have been implemented there.

This might also be an appropriate time to upgrade this linter from :off to :warning, as the docs say "will be `:warning` in a future release"?