### PR TITLE
Exclude instances of nesting when directly inside threading macros

### DIFF
--- a/test/clj_kondo/redundant_nested_call_test.clj
+++ b/test/clj_kondo/redundant_nested_call_test.clj
@@ -28,4 +28,7 @@
   (is
    (empty?
     (lint! "(ns foo) (concat [1 2] [3 4] (concat [5 6] [7 8]))"
-           '{:config-in-call {clojure.core/concat {:linters {:redundant-nested-call {:level :off}}}}}))))
+           '{:config-in-call {clojure.core/concat {:linters {:redundant-nested-call {:level :off}}}}})))
+  (is
+   (empty?
+    (lint! "(-> {:a 1} (merge {:b 2}) (merge :b 3))"))))


### PR DESCRIPTION
Fixes #2431
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
