### PR TITLE
Include if-let etc in :condition-always-true linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2272](https://github.com/clj-kondo/clj-kondo/issues/2272): Report var usage in `if-let` etc condition as always truthy
 - [#2272](https://github.com/clj-kondo/clj-kondo/issues/2272): Report var usage in `if-not` condition as always truthy
 - [#2433](https://github.com/clj-kondo/clj-kondo/issues/2433): false positive redundant ignore with hook
 - Document `:cljc` config option. ([@NoahTheDuke](https://github.com/NoahTheDuke))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -958,7 +958,8 @@
                                                         :analyzed))]
         (lint-two-forms-binding-vector! ctx call bv)
         (concat (:analyzed bindings)
-                (analyze-expression** (update ctx :callstack conj [:vector]) condition)
+                (analyze-expression** (update ctx :callstack conj [:vector])
+                                      (assoc condition :condition true))
                 (if if?
                   ;; in the case of if, the binding is only valid in the first expression
                   (concat

--- a/test/clj_kondo/condition_always_true_test.clj
+++ b/test/clj_kondo/condition_always_true_test.clj
@@ -32,4 +32,12 @@
      :level :warning,
      :message "Condition always true"}]
    (lint! "(if-not odd? 1 2)"
+          '{:linters {:condition-always-true {:level :warning}}}))
+  (assert-submaps2
+   [{:file "<stdin>",
+     :row 1,
+     :col 12,
+     :level :warning,
+     :message "Condition always true"}]
+   (lint! "(if-let [a odd?] 1 2)"
           '{:linters {:condition-always-true {:level :warning}}})))


### PR DESCRIPTION
Include if-let, when-let, if-some, when-some, when-first

Adds to functionality of #2272

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Sorry, not meaning to make separate PRs, just hadn't thought of these until just now.