### PR TITLE
Fix #2439: uneval applies to next form which may depend on reader features

### DIFF
--- a/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
@@ -173,7 +173,8 @@
 
 (defn- read-with-ignore-hint [reader]
   (let [[node] (parse-printables reader :uneval 1 true)
-        im (ignore-meta [node])]
+        im (ignore-meta [node])
+        ]
     (cond im
           (vary-meta (parse-next reader)
                      into im)
@@ -181,7 +182,8 @@
                (= :reader-macro (node/tag node))
                (let [sv (-> node :children first :string-value)]
                  (str/starts-with? sv "?")))
-          (let [children (when reader/*reader-features*
+          (let [features reader/*reader-features*
+                children (when features
                            (->> node :children last :children
                                 (take-nth 2)
                                 (keep :k)
@@ -189,11 +191,11 @@
             ;; If the reader conditional contains all features or :default,
             ;; then it can be ignored.
             ;; Otherwise, add :clj-kondo/uneval metadata to discard later.
-            (if (or (not reader/*reader-features*)
-                    (every? children reader/*reader-features*)
+            (if (or (not features)
+                    (every? children features)
                     (contains? children :default))
               (parse-next reader)
-              (vary-meta node assoc :clj-kondo/uneval (set (remove children reader/*reader-features*)))))
+              (vary-meta node assoc :clj-kondo/uneval (set (remove children features)))))
           :else
           (parse-next reader))))
 

--- a/parser/clj_kondo/impl/rewrite_clj/reader.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/reader.clj
@@ -9,7 +9,7 @@
   (:import [java.io PushbackReader]))
 
 (def ^:dynamic *reader-exceptions* nil)
-(def ^:dynamic *reader-features* [:clj :cljs])
+(def ^:dynamic *reader-features* nil)
 
 ;; ## Decisions
 

--- a/parser/clj_kondo/impl/rewrite_clj/reader.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/reader.clj
@@ -9,6 +9,7 @@
   (:import [java.io PushbackReader]))
 
 (def ^:dynamic *reader-exceptions* nil)
+(def ^:dynamic *reader-features* [:clj :cljs])
 
 ;; ## Decisions
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -34,7 +34,7 @@
    [clj-kondo.impl.parser :as p]
    [clj-kondo.impl.rewrite-clj.node.seq :as seq]
    [clj-kondo.impl.rewrite-clj.node.token :as token]
-   [clj-kondo.impl.rewrite-clj.reader :refer [*reader-exceptions*]]
+   [clj-kondo.impl.rewrite-clj.reader :refer [*reader-exceptions* *reader-features*]]
    [clj-kondo.impl.schema :as schema]
    [clj-kondo.impl.types :as types]
    [clj-kondo.impl.utils :as utils :refer
@@ -3321,7 +3321,11 @@
               ctx (assoc ctx
                          :inline-configs (atom [])
                          :main-ns (atom nil))
-              parsed (binding [*reader-exceptions* reader-exceptions]
+              cljc-config (:cljc config)
+              features (or (:features cljc-config)
+                           *reader-features*)
+              parsed (binding [*reader-exceptions* reader-exceptions
+                               *reader-features* features]
                        (p/parse-string input))
               fname (fs/file-name filename)
               ctx (case fname
@@ -3338,12 +3342,9 @@
               (run! #(findings/reg-finding! ctx %) (->findings e filename))))
           (case lang
             :cljc
-            (let [cljc-config (:cljc config)
-                  features (or (:features cljc-config)
-                               [:clj :cljs])]
-              (doseq [lang features]
-                (analyze-expressions (assoc ctx :base-lang :cljc :lang lang :filename filename)
-                                     (:children (select-lang ctx parsed lang)))))
+            (doseq [lang features]
+              (analyze-expressions (assoc ctx :base-lang :cljc :lang lang :filename filename)
+                                   (:children (select-lang ctx parsed lang))))
             (:clj :cljs :edn)
             (let [ctx (assoc ctx :base-lang lang :lang lang :filename filename
                              :uri uri)]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3331,8 +3331,9 @@
                          :inline-configs (atom [])
                          :main-ns (atom nil))
               cljc-config (:cljc config)
-              features (or (:features cljc-config)
-                           *reader-features*)
+              features (when (identical? :cljc lang)
+                         (or (:features cljc-config)
+                             [:clj :cljs]))
               parsed (binding [*reader-exceptions* reader-exceptions
                                *reader-features* features]
                        (p/parse-string input))

--- a/test/clj_kondo/impl/parser_test.clj
+++ b/test/clj_kondo/impl/parser_test.clj
@@ -5,7 +5,8 @@
             [clojure.test :as t :refer [deftest is are]]))
 
 (deftest omit-unevals-test
-  (is (zero? (count (:children (parse-string "#_#_1 2"))))))
+  (is (zero? (count (:children (parse-string "#_#_1 2")))))
+  (is (= 3 (count (:children (parse-string "#_#?(:clj 1) 2 3"))))))
 
 (deftest namespaced-maps-test
   (is (= '#:it{:a 1} (utils/sexpr (utils/parse-string "#::it {:a 1}"))))

--- a/test/clj_kondo/impl/parser_test.clj
+++ b/test/clj_kondo/impl/parser_test.clj
@@ -1,12 +1,15 @@
 (ns clj-kondo.impl.parser-test
   (:require [clj-kondo.impl.parser :as parser :refer [parse-string]]
-            [clj-kondo.impl.rewrite-clj.reader :refer [*reader-exceptions*]]
+            [clj-kondo.impl.rewrite-clj.reader :refer [*reader-exceptions*
+                                                       *reader-features*]]
             [clj-kondo.impl.utils :as utils]
             [clojure.test :as t :refer [deftest is are]]))
 
 (deftest omit-unevals-test
   (is (zero? (count (:children (parse-string "#_#_1 2")))))
-  (is (= 3 (count (:children (parse-string "#_#?(:clj 1) 2 3"))))))
+  (is (= 3 (count (:children
+                   (binding [*reader-features* #{:clj :cljs}]
+                     (parse-string "#_#?(:clj 1) 2 3")))))))
 
 (deftest namespaced-maps-test
   (is (= '#:it{:a 1} (utils/sexpr (utils/parse-string "#::it {:a 1}"))))

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -170,7 +170,16 @@
   (is (empty? (lint! "^#?(:clj :a :cljsr :b) [1 2 3]"
                      "--lang" "cljc")))
   (assert-submaps [{:row 1, :col 1, :level :error, :message "Reader conditionals are only allowed in .cljc files"}]
-                  (lint! "#?(:clj 1)" "--lang" "clj")))
+                  (lint! "#?(:clj 1)" "--lang" "clj"))
+  (assert-submaps2 [{:file "<stdin>",
+                     :row 1,
+                     :col 19,
+                     :level :error,
+                     :message "Expected: number, received: keyword. [clj]"}]
+                   (lint! "(+ 1 #_#?(:clj 2) :three 4)"
+                          {:linters {:type-mismatch {:level :error}}
+                           :output {:langs true}}
+                          "--lang" "cljc")))
 
 (deftest exclude-clojure-test
   (let [linted (lint! (io/file "corpus" "exclude_clojure.clj"))]


### PR DESCRIPTION
Closes https://github.com/clj-kondo/clj-kondo/issues/2439

Situation:

Reader conditionals are consumed by the Clojure reader. If there's a matching branch, it's returned. If there's no matching branch, the reader moves on. Discard reader macros consume the next form. So when the discard macro attempts to get the next form and there's a reader conditional with no matching branch, the form after the reader conditional is returned.

(+ 1 #_#?(:clj 2) :three 4)
Read as (+ 1 #_ 2 :three 4). The :clj branch of the #? form is used so the next form is 2, #_ ignores it, the result is (+ 1 :three 4).
(+ 1 #_#?(:foo 2) :three 4)
Read as (+ 1 #_ :three 4). The :clj branch of the #? form doesn't exist so the next form is :three, #_ ignores it, the result is (+ 1 4).
(+ 1 #_#?(:clj 2 :default 100) :three 4)
Read as (+ 1 #_ 2 :three 4). The :clj branch of the #? form is used so the next form is 2, #_ ignores it, the result is (+ 1 :three 4).
(+ 1 #_#?(:cljs 2 :default 100) :three 4)
Read as (+ 1 #_ 2 :three 4). The :default branch of the #? form is used so the next form is 100, #_ ignores it, the result is (+ 1 :three 4).
Approach:

During parsing, if an uneval/discard reader macro is encountered, check if the next node is a reader conditional and if it contains all of the branches of the current reader features (tracked in a new dynamic variable reader/*reader-features*) or :default. If so, mark it with :clj-kondo/uneval and return. Otherwise, skip as normal.

During analysis, in select-lang, if a form with :clj-kondo/uneval metadata is encountered then:

If there's a matching branch in the reader conditional, #_ would discard it, so skip it.
If there's no matching branch in the reader conditional, #_ would discard the form after the reader conditional, so skip 2 forms.
This is slightly awkward because parsing doesn't pass around a ctx object giving access to which lang we're in (and we don't want to parse twice).