### PR TITLE
Update the "Exporting and importing configuration" in `config.md`

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -664,16 +664,11 @@ For example, if the `claypoole` library itself wanted to export config, it would
 Clj-kondo, when asked, will copy clj-kondo configs found in library dependencies.
 As an example, let's add [clj-kondo/config](#sample-exports) as a dependency.
 
-1. Include `clj-kondo/config` in your `deps.edn`:
-    ```Clojure
-    {:deps {clj-kondo/config {:git/url "https://github.com/clj-kondo/config"
-                              :sha "c37c13ea09b6aaf23db3a7a9a0574f422bb0b4c2"}}}
-    ```
-2. Ensure a `.clj-kondo` directory exists, if necessary:
+1. Ensure a `.clj-kondo` directory exists, if necessary:
     ```
     $ mkdir .clj-kondo
     ```
-3. Then ask clj-kondo to copy configs like so:
+2. Then ask clj-kondo to copy configs like so:
     ```
     $ clj-kondo --lint "$(clojure -Spath)" --copy-configs --skip-lint
     Configs copied:
@@ -683,7 +678,7 @@ As an example, let's add [clj-kondo/config](#sample-exports) as a dependency.
     - .clj-kondo/clj-kondo/rum
     - .clj-kondo/clj-kondo/slingshot
     ```
-4. Now enrichen clj-kondo's linting cache via:
+3. Now enrichen clj-kondo's linting cache via:
     ```
     $ clj-kondo --lint $(clojure -Spath) --dependencies --parallel
     ```


### PR DESCRIPTION
This PR drops the step with a now long-deprecated dependency in the "Exporting and importing configuration" section of the "Config" documentation.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
Not applicable.

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
Not applicable.

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
Not applicable.