### PR TITLE
Report toolsreader exceptions as new :reader-error linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#2493](https://github.com/clj-kondo/clj-kondo/issues/2493): reduce image size of native image
+- [#2492](https://github.com/clj-kondo/clj-kondo/issues/2492): New linter: `:reader-error`, reports reader errors encountered during analysis.
 
 ## 2025.02.20
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -53,6 +53,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Inline def](#inline-def)
     - [Invalid arity](#invalid-arity)
     - [Conflicting arity](#conflicting-arity)
+    - [Reader error](#reader-error)
     - [Reduce without initial value](#reduce-without-initial-value)
     - [Loop without recur](#loop-without-recur)
     - [Line length](#line-length)
@@ -991,6 +992,20 @@ Normally a call to this macro will give an invalid arity error for `(select-keys
 *Example trigger:* `(fn ([x] x) ([y]) x)`.
 
 *Example message:* `More than one function overload with arity 2.`.
+
+### Reader error
+
+*Keyword:* `:reader-error`.
+
+*Description:* warn on reader errors, such as unsupported escape sequences.
+
+*Default level:* `:error`.
+
+*Example trigger:* `"\a"`.
+
+*Example message:* `Unsupported escape character: \a.`.
+
+These are reader error exception messages thrown by the `clojure.tools.reader` reader during the analysis phase.
 
 ### Reduce without initial value
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -176,6 +176,7 @@
               :redundant-ignore {:level :info}
               :schema-misplaced-return {:level :warning}
               :do-template {:level :warning}
+              :reader-error {:level :error}
               }
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->

--- a/test/clj_kondo/reader_error_test.clj
+++ b/test/clj_kondo/reader_error_test.clj
@@ -1,0 +1,19 @@
+(ns clj-kondo.reader-error-test
+  (:require [clj-kondo.test-utils :as tu :refer [lint!]]
+            [clojure.test :as t :refer [deftest is]]))
+
+(deftest reader-escape-char-error-test
+  (is (= [{:file "<stdin>",
+           :row 2,
+           :col 3,
+           :level :error,
+           :message "Unsupported escape character: \\a."}
+          {:file "<stdin>",
+           :row 3,
+           :col 2,
+           :level :error,
+           :message "Unsupported escape character: \\v."}]
+         (lint! "12356
+  \"\\a\" 
+ {\"\\v\" \"\\V\"}"
+                {:linters {:reader-error {:level :error}}}))))


### PR DESCRIPTION
Hi,

can you please review patch to correctly report reader errors encountered during the analysis phase. It fixes #2492.

The tools reader may throw `:reader-errors` during the analysis phase with misleading text coordinates because it does not have access to the full text. The fix tries to address this by catching the exception during the analysis phase and register it with the correct coordinates under a new `reader-error` linter.

Test added to test the same. Please feel free to suggest any other alternative.

Thanks  

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
