### PR TITLE
Fix unresolved-namespace :name data

### DIFF
--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -86,7 +86,8 @@
                                           resolved-ns)
            (namespace/reg-unresolved-namespace! ctx ns-name
                                                 (with-meta (symbol (namespace symbol-val))
-                                                  (meta expr)))))))))
+                                                  (assoc (meta expr)
+                                                         :name (-> symbol-val name symbol))))))))))
 
 (defn analyze-namespaced-map [ctx ^NamespacedMapNode expr]
   (let [children (:children expr)
@@ -197,7 +198,8 @@
                                (namespace/reg-unresolved-namespace!
                                 ctx ns-name
                                 (with-meta n
-                                  (meta expr)))))
+                                  (assoc (meta expr)
+                                         :name (-> symbol-val name symbol))))))
                            (if (:unresolved? v)
                              (let [symbol-str (str symbol-val)]
                                (if (and (not= "." symbol-str)

--- a/test/clj_kondo/unresolved_namespace_test.clj
+++ b/test/clj_kondo/unresolved_namespace_test.clj
@@ -1,6 +1,7 @@
 (ns clj-kondo.unresolved-namespace-test
   (:require
-   [clj-kondo.test-utils :refer [lint! assert-submaps2]]
+   [clj-kondo.core :as clj-kondo]
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
    [clojure.java.io :as io]
    [clojure.test :as t :refer [deftest is testing]]))
 
@@ -59,6 +60,34 @@ x/bar ;; <- no warning")))
     (lint! "(foo-db/dude)"
            '{:ns-groups [{:name db :pattern "-db$"}]
              :linters {:unresolved-namespace {:exclude [db]}}}))))
+
+(defn ^:private analyze!
+  ([input] (analyze! input nil))
+  ([input config]
+   (:findings
+    (with-in-str
+      input
+      (clj-kondo/run! (merge
+                       {:lint ["-"]}
+                       config))))))
+
+(deftest unresolved-namespace-extra-analysis-test
+  (testing "in a function call"
+    (assert-submaps2
+     [{:row 1 :col 2
+       :level :warning
+       :ns 'clojure.string
+       :name 'includes?
+       :message "Unresolved namespace clojure.string. Are you missing a require?"}]
+     (analyze! "(clojure.string/includes? \"foo\" \"o\")")))
+  (testing "not in a function call"
+    (assert-submaps2
+     [{:row 1 :col 2
+       :level :warning
+       :ns 'clojure.java.classpath
+       :name 'classpath
+       :message "Unresolved namespace clojure.string. Are you missing a require?"}]
+     (analyze! "clojure.java.classpath/classpath"))))
 
 (deftest excluded-implies-already-required
   (assert-submaps2

--- a/test/clj_kondo/unresolved_namespace_test.clj
+++ b/test/clj_kondo/unresolved_namespace_test.clj
@@ -82,11 +82,11 @@ x/bar ;; <- no warning")))
      (analyze! "(clojure.string/includes? \"foo\" \"o\")")))
   (testing "not in a function call"
     (assert-submaps2
-     [{:row 1 :col 2
+     [{:row 1 :col 1
        :level :warning
        :ns 'clojure.java.classpath
        :name 'classpath
-       :message "Unresolved namespace clojure.string. Are you missing a require?"}]
+       :message "Unresolved namespace clojure.java.classpath. Are you missing a require?"}]
      (analyze! "clojure.java.classpath/classpath"))))
 
 (deftest excluded-implies-already-required


### PR DESCRIPTION
This fix cases where `:name` was nil on some findings, afetting clojure-lsp analysis for unresolved-namespaces.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
