### PR TITLE
Make inline-configs lock file vcs friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Sort findings on filename, row, column and now additionally on message too
 - [#2602](https://github.com/clj-kondo/clj-kondo/issues/2602): Sort auto-imported configs to avoid differences based on OS or file system
 - [#2603](https://github.com/clj-kondo/clj-kondo/issues/2603): warn on `:inline-def` with nested `deftest`
+- [#2606](https://github.com/clj-kondo/clj-kondo/issues/2606): make it easy for users to know how inline-config files should be version controlled ([@lread](https://github.com/lread))
 
 ## 2025.07.28
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ If you want to use a different directory to read and write the cache, use the
 `--cache-dir` option. To disable the cache even if you have a `.clj-kondo`
 directory, use `--cache false`.
 
+For your project's version control, we recommend that you commit everything
+under the `./.clj-kondo/` dir, except for the cache dir. Add `.cache` to
+your `.gitignore` to ignore all `.cache` dirs, including the one under
+`./.clj-kondo`. Adjust accordingly if you are using a different `--cache-dir`.
+
 ## [Configuration](doc/config.md)
 
 ## [Editor integration](doc/editor-integration.md)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3491,7 +3491,7 @@
                                                   (when-let [ext (fs/extension (:filename ctx))]
                                                     (str "." ext))) "config.edn")]
                     (if (and configs (not (false? (:auto-load-configs config))))
-                      (binding [cache/*lock-file-name* ".lock"]
+                      (binding [cache/*lock-file-name* (str (io/file ".cache" ".config-lock"))]
                         (cache/with-thread-lock
                           (cache/with-cache ;; lock config dir for concurrent writes
                             cfg-dir


### PR DESCRIPTION
Clj-kondo users should not be committing the `inline-configs` lock file.

Move it from `./.clj-kondo/.lock` to `./.clj-kondo/.cache/.config-lock` where `./.clj-kondo` will be affected by `--config-dir` but `.cache` will not be affected by `--cache` nor `--cache-dir`.

This keeps the lock file in a constant spot relative to `inline-configs` dir, but now also a directory that clj-kondo users have been advised to git ignore.

Also: add advice on version control to docs.

Closes #2606

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
