### PR TITLE
Follow symlinks when globbing for configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2606](https://github.com/clj-kondo/clj-kondo/issues/2606): make it easy for users to know how inline-config files should be version controlled ([@lread](https://github.com/lread))
 - [#2610](https://github.com/clj-kondo/clj-kondo/issues/2610): ignores may show up unordered due to macros
 - [#2615](https://github.com/clj-kondo/clj-kondo/issues/2615): emit `inline-configs` `config.edn` in a git-diff-friendly way ([@lread](https://github.com/lread))
+- [#2621](https://github.com/clj-kondo/clj-kondo/issues/2621): load imports from symlinked config dir ([@walterl](https://github.com/walterl))
 
 ## 2025.07.28
 

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -140,7 +140,8 @@
                 (map str)
                 (filter #(not (contains? local-config-paths-set %))))
           (fs/glob cfg-dir glob
-                   {:max-depth (if (str/starts-with? glob "imports")
+                   {:follow-links true
+                    :max-depth (if (str/starts-with? glob "imports")
                                  4
                                  3)}))))
 

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -36,17 +36,19 @@ Options:
     directory. If --cache is false, this option will be ignored.
 
   --cache: if false, won't use cache. Otherwise, will try to resolve cache
-  using `--cache-dir`. If `--cache-dir` is not set, cache is resolved using the
-  nearest `.clj-kondo` directory in the current and parent directories.
+    using `--cache-dir`. If `--cache-dir` is not set, cache is resolved using the
+    nearest `.clj-kondo` directory in the current and parent directories.
 
-  --config <config>: extra config that is merged. May be a file or an EDN expression. See https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md.
+  --config <config>: extra config that is merged. May be a file or an EDN expression.
+    See https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md.
 
   --config-dir <config-dir>: use this config directory instead of auto-detected
     .clj-kondo dir.
 
   --parallel: lint sources in parallel.
 
-  --dependencies: don't report any findings. Useful for populating cache while linting dependencies.
+  --dependencies: don't report any findings. Useful for populating cache while linting
+    dependencies.
 
   --copy-configs: copy configs from dependencies while linting.
 


### PR DESCRIPTION
Fixes #2621 by passing the `:follow-links true` option to the `fs/glob` call in `clj-kondo.impl.core/auto-configs`.

Due to the nature of this fix, a test that sets up the convoluted scenario in which the bug manifests seemed like overkill.

Snuck in some minor formatting changes to the CLI help text too.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.