### PR TITLE
Fix: redundant-call's level check didn't work

### DIFF
--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -554,7 +554,7 @@
                                               :type :redundant-fn-wrapper
                                               :message "Redundant fn wrapper")))))
       (when (and called-fn
-                 (not (identical? :off (-> call-config :linters :redundant-call)))
+                 (not (identical? :off (-> call-config :linters :redundant-call :level)))
                  (= 1 (:arity call))
                  ;; handled based on argument type
                  (not (utils/one-of fn-sym [clojure.core/str cljs.core/str]))


### PR DESCRIPTION
Just a small thing - looks like an oversight when it was originally written.
Should have a small perf improvement.