### PR TITLE
Fix #2661: match parent check for recur in tail position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2532](https://github.com/clj-kondo/clj-kondo/issues/2532): Disable `:duplicate-require` in `require` + `:reload` / `:reload-all`
 - [#2432](https://github.com/clj-kondo/clj-kondo/issues/2432): Don't warn for `:redundant-fn-wrapper` in case of inlined function
 - [#2599](https://github.com/clj-kondo/clj-kondo/issues/2599): detect invalid arity for invoking collection as higher order function
+- [#2661](https://github.com/clj-kondo/clj-kondo/issues/2661): Fix false positive `:unexpected-recur` when `recur` is used inside `clojure.core.match/match`
 
 ## 2025.10.23
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1176,7 +1176,8 @@
                          rest first-callstack-elt-ignoring-macros second)]
           (when (and len idx
                      (not= (dec len) idx)
-                     (not (one-of parent [if case cond if-let if-not if-some condp])))
+                     (not (one-of parent [if case cond if-let if-not if-some 
+                                          condp match])))
             (findings/reg-finding!
              ctx
              (node->line


### PR DESCRIPTION
# Fix #2661 
Updated the parent check in the analyzer to include 'match' in the list of constructs that prevent tail position for 'recur'. This ensures proper linting behavior for recur statements within match expressions, improving code analysis accuracy.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
