### PR TITLE
Fix #2617 - Add types for `repeatedly` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2432](https://github.com/clj-kondo/clj-kondo/issues/2432): Don't warn for `:redundant-fn-wrapper` in case of inlined function
 - [#2599](https://github.com/clj-kondo/clj-kondo/issues/2599): detect invalid arity for invoking collection as higher order function
 - [#2661](https://github.com/clj-kondo/clj-kondo/issues/2661): Fix false positive `:unexpected-recur` when `recur` is used inside `clojure.core.match/match` ([@jramosg](https://github.com/jramosg))
+- [#2617](https://github.com/clj-kondo/clj-kondo/issues/2617): Add types for `repeatedly` ([@jramosg](https://github.com/jramosg))
 
 ## 2025.10.23
 

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -843,7 +843,11 @@
    ;; 5086 'with-precision
    ;; 5109 'subseq
    ;; 5126 'rsubseq
-   ;; 5143 'repeatedly
+   ;; 5143
+   'repeatedly {:arities {1 {:args [:ifn]
+                             :ret :seq}
+                          2 {:args [:nat-int :ifn]
+                             :ret :seq}}}
    ;; 5152 'add-classpath
    ;; 5165 'hash
    ;; 5175 'mix-collection-hash

--- a/test/clj_kondo/types_test.clj
+++ b/test/clj_kondo/types_test.clj
@@ -1152,6 +1152,20 @@
    (lint! "(let [x (atom {:a 1})]
              (get x :a))" config)))
 
+(deftest repeatedly-test
+  (let [config {:linters {:type-mismatch {:level :error}}}]
+    (testing "Valid usages of repeatedly"
+      (is (empty? (lint! "(repeatedly 10 #(println :foo))" config)) "Valid usage should not warn")
+      (is (empty? (lint! "(repeatedly #(println :foo))" config)) "Valid usage should not warn"))
+    (testing "Invalid usages of repeatedly"
+      (assert-submaps
+       '({:row 1 :col 13 :message "Expected: natural integer, received: function."}
+         {:row 1 :col 29 :message "Expected: function, received: positive integer."})
+       (lint! "(repeatedly #(println :foo) 10)" config))
+      (assert-submaps
+       '({:row 1 :col 13 :message "Expected: function, received: positive integer."})
+       (lint! "(repeatedly 10)" config)))))
+
 ;;;; Scratch
 
 (comment


### PR DESCRIPTION
# Fix #2617
Define arities and return types for the `repeatedly` function in the Clojure core type definitions. This enhances type inference and improves linting capabilities for valid and invalid usages of the function in the codebase.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
