### PR TITLE
Make all :keys bindings symbols, not keywords

### DIFF
--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -21,7 +21,7 @@
 (defn print!
   "Prints the result from `run!` to `*out*`. Returns `nil`. Alpha,
   subject to change."
-  [{:keys [:config :findings :summary :analysis :report-level]}]
+  [{:keys [config findings summary analysis report-level]}]
   (let [output-cfg (:output config)
         report-level? (if report-level
                         (let [report-level (keyword report-level)]
@@ -38,7 +38,7 @@
             (when (report-level? (:level finding))
               (println (format-fn finding))))
           (when (:summary output-cfg)
-            (let [{:keys [:error :warning :duration]} summary]
+            (let [{:keys [error warning duration]} summary]
               (printf "linting took %sms, " duration)
               (printf "errors: %s" error)
               (when (report-level? :warning)

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -113,7 +113,7 @@
                                                   (utils/format-callstack ctx)))
               :lang (when (= :cljc base-lang) lang))))))
 
-(defn reg-namespace! [{:keys [:analysis-ns-meta :analysis :base-lang :lang] :as _ctx}
+(defn reg-namespace! [{:keys [analysis-ns-meta analysis base-lang lang] :as _ctx}
                       filename row col ns-name in-ns? metadata]
   (when analysis
     (swap! analysis update :namespace-definitions conj
@@ -130,7 +130,7 @@
             :in-ns (when in-ns? in-ns?) ;; don't include when false
             :lang (when (= :cljc base-lang) lang)))))
 
-(defn reg-namespace-usage! [{:keys [:analysis :base-lang :lang] :as _ctx}
+(defn reg-namespace-usage! [{:keys [analysis base-lang lang] :as _ctx}
                             filename row col from-ns to-ns alias metadata]
   (when analysis
     (let [to-ns (export-ns-sym to-ns)]
@@ -145,7 +145,7 @@
               :lang (when (= :cljc base-lang) lang)
               :alias alias)))))
 
-(defn reg-local! [{:keys [:analysis] :as ctx} filename binding]
+(defn reg-local! [{:keys [analysis] :as ctx} filename binding]
   (when (and analysis
              (not (:clj-kondo.impl/generated binding)))
     (swap! analysis update :locals conj
@@ -153,7 +153,7 @@
                        :filename filename
                        :lang (when (= :cljc (:base-lang ctx)) (:lang ctx))))))
 
-(defn reg-local-usage! [{:keys [:analysis] :as ctx} filename binding usage]
+(defn reg-local-usage! [{:keys [analysis] :as ctx} filename binding usage]
   (when (and analysis
              (not (:clj-kondo.impl/generated binding)))
     (swap! analysis update :local-usages conj

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -53,7 +53,7 @@
 (defn analyze-children
   ([ctx children]
    (analyze-children ctx children true))
-  ([{:keys [:callstack :config :top-level?] :as ctx} children add-new-arg-types?]
+  ([{:keys [callstack config top-level?] :as ctx} children add-new-arg-types?]
    (let [top-level? (and top-level?
                          (let [fst (first callstack)]
                            (one-of fst [[clojure.core comment]
@@ -139,7 +139,7 @@
 (defn lift-meta-content*
   "Used within extract-bindings. Disables unresolved symbols while
   linting metadata."
-  [{:keys [:lang] :as ctx} expr]
+  [{:keys [lang] :as ctx} expr]
   (meta/lift-meta-content2
    (if (= :cljs lang)
      (utils/ctx-with-linter-disabled ctx :unresolved-symbol)
@@ -385,8 +385,8 @@
                       :syntax
                       (str "unsupported binding form " expr))))))))
 
-(defn analyze-in-ns [ctx {:keys [:children] :as expr}]
-  (let [{:keys [:row :col]} expr
+(defn analyze-in-ns [ctx {:keys [children] :as expr}]
+  (let [{:keys [row col]} expr
         lang (:lang ctx)
         ns-name (-> children second :children first :value)
         ns (when ns-name
@@ -495,8 +495,8 @@
 (defn analyze-fn-body [ctx body]
   (let [docstring (:docstring ctx)
         macro? (:macro? ctx)
-        {:keys [:arg-bindings
-                :arity :analyzed-arg-vec :arglist-str :arg-vec]
+        {:keys [arg-bindings
+                arity analyzed-arg-vec arglist-str arg-vec]
          return-tag :ret
          arg-tags :args} (analyze-fn-arity ctx body)
         ctx (ctx-with-bindings ctx arg-bindings)
@@ -577,8 +577,8 @@
           (recur rest-exprs))))))
 
 (defn extract-arity-info [ctx parsed-bodies]
-  (reduce (fn [acc {:keys [:fixed-arity :varargs? :min-arity :ret :args :arg-vec
-                           :arglist-str]}]
+  (reduce (fn [acc {:keys [fixed-arity varargs? min-arity ret args arg-vec
+                           arglist-str]}]
             (let [arg-tags (when (some identity args)
                              args)
                   v (assoc-some {}
@@ -911,8 +911,8 @@
         expr))))
 
 (defn analyze-like-let
-  [{:keys [:filename :callstack
-           :let-parent] :as ctx} expr]
+  [{:keys [filename callstack
+           let-parent] :as ctx} expr]
   (let [call (-> callstack first second)
         [current-call parent-call] callstack
         parent-let (one-of parent-call
@@ -959,7 +959,7 @@
   (analyze-redundant-bindings ctx (-> expr :children second))
   (analyze-like-let ctx expr))
 
-(defn analyze-do [{:keys [:filename :callstack] :as ctx} expr]
+(defn analyze-do [{:keys [filename callstack] :as ctx} expr]
   (let [parent-call (second callstack)
         core? (one-of (first parent-call) [clojure.core cljs.core])
         core-sym (when core?
@@ -1387,7 +1387,7 @@
 (declare analyze-defprotocol)
 
 (defn analyze-schema [ctx fn-sym expr defined-by defined-by->lint-as]
-  (let [{:keys [:expr :schemas]}
+  (let [{:keys [expr schemas]}
         (schema/expand-schema ctx
                               fn-sym
                               expr)]
@@ -1460,7 +1460,7 @@
     (when-not (config/skip? config :invalid-arity callstack)
       (let [filename (:filename ctx)]
         (when-not (linter-disabled? ctx :invalid-arity)
-          (when-let [{:keys [:fixed-arities :varargs-min-arity]}
+          (when-let [{:keys [fixed-arities varargs-min-arity]}
                      binding-info]
             ;; (prn :arities types)
             (let [arg-count (count (rest children))]
@@ -2107,7 +2107,7 @@
                       (cons [resolved-namespace resolved-name]
                             cs)))]
     (cond var?
-          (let [{:keys [:row :end-row :col :end-col]} (meta f)]
+          (let [{:keys [row end-row col end-col]} (meta f)]
             (when (:analyze-var-usages? ctx)
               (namespace/reg-var-usage! ctx ns-name
                                         {:type (if arg-count :call :usage)
@@ -2141,7 +2141,7 @@
                                          :in-def (:in-def ctx)
                                          :derived-location (:derived-location (meta expr))})))
           (and arity arg-count)
-          (let [{:keys [:fixed-arities :varargs-min-arity]} arity
+          (let [{:keys [fixed-arities varargs-min-arity]} arity
                 config (:config ctx)
                 callstack (:callstack ctx)]
             (when-not (config/skip? config :invalid-arity callstack)
@@ -2413,11 +2413,11 @@
     (analyze-associative ctx fields fn-name fields)))
 
 (defn analyze-call
-  [{:keys [:top-level? :base-lang :lang :ns :config :dependencies] :as ctx}
-   {:keys [:arg-count
-           :full-fn-name
-           :row :col
-           :expr] :as m}]
+  [{:keys [top-level? base-lang lang ns config dependencies] :as ctx}
+   {:keys [arg-count
+           full-fn-name
+           row col
+           expr] :as m}]
   (let [ns-name (:name ns)
         not-is-dot (and (not= '. full-fn-name)
                         (not= '.. full-fn-name))]
@@ -2930,11 +2930,11 @@
                           (cons call analyzed))))))))))))
 
 (defn analyze-keyword-call
-  [{:keys [:base-lang :lang :ns] :as ctx}
-   {:keys [:arg-count
-           :full-fn-name
-           :row :col
-           :expr]}]
+  [{:keys [base-lang lang ns] :as ctx}
+   {:keys [arg-count
+           full-fn-name
+           row col
+           expr]}]
   (let [ns-name (:name ns)
         children (:children expr)
         kw-node (first children)
@@ -3460,7 +3460,7 @@
   "Analyzes expressions and collects defs and calls into a map. To
   optimize cache lookups later on, calls are indexed by the namespace
   they call to, not the ns where the call occurred."
-  [{:keys [:base-lang :lang :config] :as ctx}
+  [{:keys [base-lang lang config] :as ctx}
    expressions]
   (let [init-ns (when-not (= :edn lang)
                   (analyze-ns-decl (-> ctx
@@ -3540,7 +3540,7 @@
 (defn analyze-input
   "Analyzes input and returns analyzed defs, calls. Also invokes some
   linters and returns their findings."
-  [{:keys [:config :file-analyzed-fn :total-files :files] :as ctx} filename uri input lang dev?]
+  [{:keys [config file-analyzed-fn total-files files] :as ctx} filename uri input lang dev?]
   (when (:debug ctx)
     (utils/stderr "[clj-kondo] Linting file:" filename))
   (let [ctx (assoc ctx :filename filename)

--- a/src/clj_kondo/impl/analyzer/core_async.clj
+++ b/src/clj_kondo/impl/analyzer/core_async.clj
@@ -11,15 +11,15 @@
          (= :vector (tag fst-child)))
       ;; analyze syntax like: ([v ch] 'do_something_with_v_or_ch)
       ;; NOTE: this syntax also supports destructuring:
-      ;; (async/alt!! (doto (async/chan) (async/put! {:a 1}))  ([{:keys [:a]} ch] [a ch]))
+      ;; (async/alt!! (doto (async/chan) (async/put! {:a 1}))  ([{:keys [a]} ch] [a ch]))
       (let [bindings (extract-bindings ctx fst-child)
             ctx (update ctx :bindings into bindings)]
         (mapcat #(analyze-expression** ctx %) rest-children))
       (analyze-expression** ctx expr))))
 
 (defn analyze-alt! [ctx expr]
-  (let [{:keys [:analyze-expression**
-                :extract-bindings]} ctx
+  (let [{:keys [analyze-expression**
+                extract-bindings]} ctx
         children (next (:children expr))
         pairs (partition-all 2 children)]
     (for [[k v] pairs

--- a/src/clj_kondo/impl/analyzer/match.clj
+++ b/src/clj_kondo/impl/analyzer/match.clj
@@ -4,7 +4,7 @@
             [clj-kondo.impl.utils :as utils]))
 
 (defn reg-used-binding!
-  [{:keys [:base-lang :lang :namespaces :ns]} binding]
+  [{:keys [base-lang lang namespaces ns]} binding]
   (swap! namespaces update-in [base-lang lang (:name ns) :used-bindings]
          conj
          ;; don't report this binding as unused nor used

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -287,7 +287,7 @@
                                 child-k))))
                     (recur (nnext children)
                            m))))
-            (let [{:keys [:as :referred :excluded :referred-all :renamed]} m
+            (let [{:keys [as referred excluded referred-all renamed]} m
                   referred (if (and referred-all
                                     (identical? :clj base-lang))
                              (let [referred (cache/with-thread-lock

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -7,7 +7,7 @@
    [clj-kondo.impl.namespace :as namespace]
    [clj-kondo.impl.utils :as utils]))
 
-(defn analyze-fdef [{:keys [:analyze-children :ns] :as ctx} expr]
+(defn analyze-fdef [{:keys [analyze-children ns] :as ctx} expr]
   (let [[sym-expr & body] (next (:children expr))
         ns-nm (-> ns :name)]
     (keys/lint-map-keys ctx {:children body} {:known-key? #{:args :ret :fn}})

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -55,8 +55,8 @@
          ns-name (:name ns)
          keyword-val (:k expr)]
      (when (:analyze-keywords? ctx)
-       (let [{:keys [:destructuring-expr :keys-destructuring?
-                     :keys-destructuring-ns-modifier?]} opts
+       (let [{:keys [destructuring-expr keys-destructuring?
+                     keys-destructuring-ns-modifier?]} opts
              current-ns (some-> ns-name symbol)
              destructuring (when destructuring-expr (resolve-keyword ctx destructuring-expr
                                                                      current-ns))
@@ -119,7 +119,7 @@
 
 (defn analyze-usages2
   ([ctx expr] (analyze-usages2 ctx expr {}))
-  ([ctx expr {:keys [:quote? :syntax-quote?] :as opts}]
+  ([ctx expr {:keys [quote? syntax-quote?] :as opts}]
    (let [ns (:ns ctx)
          dependencies (:dependencies ctx)
          syntax-quote-level (or (:syntax-quote-level ctx) 0)

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -21,7 +21,7 @@
   (io/file cache-dir (name lang) (str ns-sym ".transit.json")))
 
 (defn from-cache-1 [cache-dir lang ns-sym]
-  (when-let [{:keys [:resource :source]}
+  (when-let [{:keys [resource source]}
              (or (when cache-dir
                    (let [f (cache-file cache-dir lang ns-sym)]
                      (when (.exists f)

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -368,18 +368,18 @@
         (contains? (:excluded-vars cfg) [ns-sym fn-sym]))))
 
 (defn deprecated-var-excluded [ctx config var-sym excluded-ns excluded-in-def]
-  (let [{:keys [:namespace-regexes :namespace-syms
-                :def-regexes :def-syms]} (let [excluded (get-in config [:linters :deprecated-var :exclude var-sym])
-                                               namespaces (:namespaces excluded)
-                                               namespace-regexes (filter string? namespaces)
-                                               namespace-syms (set (filter symbol? namespaces))
-                                               defs (:defs excluded)
-                                               def-regexes (filter string? defs)
-                                               def-syms (set (filter symbol? defs))]
-                                           {:namespace-regexes namespace-regexes
-                                            :namespace-syms namespace-syms
-                                            :def-regexes def-regexes
-                                            :def-syms def-syms})
+  (let [{:keys [namespace-regexes namespace-syms
+                def-regexes def-syms]} (let [excluded (get-in config [:linters :deprecated-var :exclude var-sym])
+                                             namespaces (:namespaces excluded)
+                                             namespace-regexes (filter string? namespaces)
+                                             namespace-syms (set (filter symbol? namespaces))
+                                             defs (:defs excluded)
+                                             def-regexes (filter string? defs)
+                                             def-syms (set (filter symbol? defs))]
+                                         {:namespace-regexes namespace-regexes
+                                          :namespace-syms namespace-syms
+                                          :def-regexes def-regexes
+                                          :def-syms def-syms})
         re-find (:re-find-memo ctx)]
     (or (when excluded-in-def
           (let [excluded-in-def (symbol (str excluded-ns) (str excluded-in-def))]
@@ -417,7 +417,7 @@
                    (cond-> nil
                      exclude (assoc :exclude exclude)
                      include (assoc :include include)))]
-    (let [{:keys [:exclude :include]} cfg]
+    (let [{:keys [exclude include]} cfg]
       (if include
         (not (contains? include sym))
         (or (not exclude)

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -23,7 +23,7 @@
 (defn format-output [config]
   (let [output-cfg (:output config)]
     (if-let [^String pattern (-> output-cfg :pattern)]
-      (fn [{:keys [:filename :row :end-row :col :end-col :level :message :type] :as _finding}]
+      (fn [{:keys [filename row end-row col end-col level message type] :as _finding}]
         (-> pattern
             (str/replace "{{filename}}" filename)
             (str/replace "{{row}}" (str row))
@@ -34,7 +34,7 @@
             (str/replace "{{LEVEL}}" (str/upper-case (name level)))
             (str/replace "{{message}}" message)
             (str/replace "{{type}}" (str type))))
-      (fn [{:keys [:filename :row :col :level :message :type langs] :as _finding}]
+      (fn [{:keys [filename row col level message type langs] :as _finding}]
         (str filename ":"
              row ":"
              col ": "
@@ -373,7 +373,7 @@
   (loop []
     (when-let [group (.pollFirst deque)]
       (try
-        (doseq [{:keys [:filename :source :lang :uri]} group]
+        (doseq [{:keys [filename source lang uri]} group]
           (ana/analyze-input ctx filename uri source lang dev?))
         (catch Exception e (binding [*out* *err*]
                              (prn e))))
@@ -458,7 +458,7 @@
                   :else 0))))
        (reduce + 0)))
 
-(defn schedule [ctx {:keys [:filename :source :lang :uri] :as m} dev?]
+(defn schedule [ctx {:keys [filename source lang uri] :as m} dev?]
   (if (:parallel ctx)
     (swap! (:sources ctx) conj m)
     (when (or (:analysis ctx) (not (:skip-lint ctx)))

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -82,7 +82,7 @@
                        'java.lang.AssertionError java.lang.AssertionError}
              :imports {'Exception 'java.io.Exception
                        'System java.lang.System}
-             :load-fn (fn [{:keys [:namespace]}]
+             :load-fn (fn [{:keys [namespace]}]
                         (let [^String ns-str (namespace-munge (name namespace))
                               base-path (.replace ns-str "." "/")]
                           (if-let [f (find-file-on-classpath base-path)]

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -677,9 +677,9 @@
                    (assoc :ns referred-ns
                           :referred-ns referred-ns
                           :refer (:name v))))))))
-      (doseq [[referred-all-ns {:keys [:referred :node] :as refer-all}] refer-alls
+      (doseq [[referred-all-ns {:keys [referred node] :as refer-all}] refer-alls
               :when (not (config/refer-all-excluded? refer-all-excluded-config referred-all-ns))]
-        (let [{:keys [:k :value]} node
+        (let [{:keys [k value]} node
               use? (or (= :use k)
                        (= 'use value))
               finding-type (if use? :use :refer-all)
@@ -806,7 +806,7 @@
 (defn lint-unused-private-vars!
   [ctx]
   (let [config (:config ctx)]
-    (doseq [{:keys [:filename :vars :used-vars :base-lang :lang]
+    (doseq [{:keys [filename vars used-vars base-lang lang]
              ns-nm :name
              ns-config :config} (namespace/list-namespaces ctx)
             :let [config (or ns-config config)

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -36,14 +36,14 @@
 (defn lint-map-keys
   ([ctx expr]
    (lint-map-keys ctx expr nil))
-  ([ctx expr {:keys [:known-key?] :or {known-key? (constantly true)}}]
+  ([ctx expr {:keys [known-key?] :or {known-key? (constantly true)}}]
    (let [filename (:filename ctx)
          t (tag expr)
          children (if (= :namespaced-map t)
                     (-> expr :children first :children)
                     (:children expr))]
      (reduce
-      (fn [{:keys [:seen] :as acc} key-expr]
+      (fn [{:keys [seen] :as acc} key-expr]
         (if-let [k (key-value key-expr false)]
           (do
             (when (contains? seen k)
@@ -76,7 +76,7 @@
 (defn lint-set [ctx expr]
   (let [children (:children expr)]
     (reduce
-     (fn [{:keys [:seen] :as acc} set-element]
+     (fn [{:keys [seen] :as acc} set-element]
        (if-let [k (key-value set-element false)]
          (do (when (contains? seen k)
                (findings/reg-finding!

--- a/src/clj_kondo/impl/macroexpand.clj
+++ b/src/clj_kondo/impl/macroexpand.clj
@@ -171,9 +171,9 @@
     {:varargs? varargs?
      :args args}))
 
-(defn expand-fn [{:keys [:children] :as expr}]
-  (let [{:keys [:row :col] :as m} (meta expr)
-        {:keys [:args :varargs?]} (fn-args children)
+(defn expand-fn [{:keys [children] :as expr}]
+  (let [{:keys [row col] :as m} (meta expr)
+        {:keys [args varargs?]} (fn-args children)
         fn-body (with-meta (list-node children)
                   (assoc m
                          :row row

--- a/src/clj_kondo/impl/metadata.clj
+++ b/src/clj_kondo/impl/metadata.clj
@@ -31,7 +31,7 @@
 
 (defn lift-meta-content2
   ([ctx node] (lift-meta-content2 ctx node false))
-  ([{:keys [:analyze-meta? :lang] :as ctx} node only-usage?]
+  ([{:keys [analyze-meta? lang] :as ctx} node only-usage?]
    (if-let [meta-list (:meta node)]
      (let [meta-list (if (identical? :cljc (:base-lang ctx))
                        (keep #(utils/select-lang ctx % lang) meta-list)

--- a/src/clj_kondo/impl/schema.clj
+++ b/src/clj_kondo/impl/schema.clj
@@ -7,7 +7,7 @@
 
 (defn remove-schemas-from-children [expr]
   (let [children (:children expr)
-        {:keys [:new-children :schemas]}
+        {:keys [new-children schemas]}
         (loop [[fst-child & rest-children] children
                res {:new-children []
                     :schemas []}]
@@ -19,7 +19,7 @@
                          (update res :schemas conj (first rest-children)))
                   (= :vector (utils/tag expr))
                   (recur rest-children
-                         (let [{:keys [:expr :schemas]} (remove-schemas-from-children fst-child)]
+                         (let [{:keys [expr schemas]} (remove-schemas-from-children fst-child)]
                            (-> res
                                (update :schemas into schemas)
                                (update :new-children conj expr))))
@@ -117,11 +117,11 @@
                                   (reg-misplaced-return-schema!
                                    ctx (second after-params)
                                    "Return schema should go before arities."))
-                              {:keys [:expr :schemas]} (if valid-params-position?
-                                                         (remove-schemas-from-children params)
-                                                         ;; (s/defn foo (:- Foo [])) expanded forms will warn missing params
-                                                         {:expr params
-                                                          :schemas []})
+                              {:keys [expr schemas]} (if valid-params-position?
+                                                       (remove-schemas-from-children params)
+                                                       ;; (s/defn foo (:- Foo [])) expanded forms will warn missing params
+                                                       {:expr params
+                                                        :schemas []})
                               new-cchildren (cons expr after-params)
                               new-fst-child (assoc fst-child :children new-cchildren)]
                           (-> res

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -351,12 +351,12 @@
           (when-let [t (:tag maybe-tag)]
             (keyword t))))))
 
-(defn spec-from-list-expr [{:keys [:calls-by-id] :as ctx} expr]
+(defn spec-from-list-expr [{:keys [calls-by-id] :as ctx} expr]
   (when-let [id (:id expr)]
     (when-let [call (get @calls-by-id id)]
       (ret-tag-from-call ctx call expr))))
 
-(defn expr->tag [{:keys [:bindings :lang :quoted] :as ctx} expr]
+(defn expr->tag [{:keys [bindings lang quoted] :as ctx} expr]
   (let [t (tag expr)
         quoted? (or quoted (identical? :edn lang))
         ret (case t

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -229,12 +229,12 @@
     (when (symbol? ?sym)
       ?sym)))
 
-(defn map-node-vals [{:keys [:children]}]
+(defn map-node-vals [{:keys [children]}]
   (take-nth 2 (rest children)))
 
 (defn map-node-get-value-node
   "Return value node from map node matching given keyword `kw`"
-  [{:keys [:children]} kw]
+  [{:keys [children]} kw]
   (loop [kvs (partition 2 children)]
     (let [kv (first kvs)]
       (cond
@@ -365,7 +365,7 @@
                   (when unresolved?
                     (some #(resolve-call* idacs call % fn-name)
                           (into (vec
-                                 (keep (fn [[ns {:keys [:excluded]}]]
+                                 (keep (fn [[ns {:keys [excluded]}]]
                                          (when-not (contains? excluded fn-name)
                                            ns))
                                        refer-alls))

--- a/src/clj_kondo/main.clj
+++ b/src/clj_kondo/main.clj
@@ -145,7 +145,7 @@ Options:
 
 (defn main
   [& options]
-  (let [{:keys [:help :lint :version :pod :dependencies :fail-level :report-level] :as parsed}
+  (let [{:keys [help lint version pod dependencies fail-level report-level] :as parsed}
         (parse-opts options)]
     (or (cond version
               (print-version)
@@ -158,9 +158,9 @@ Options:
               (print-help)
               (not (report-level? report-level))
               (print-help)
-              :else (let [{:keys [:summary]
+              :else (let [{:keys [summary]
                            :as results} (clj-kondo/run! parsed)
-                          {:keys [:error :warning]} summary]
+                          {:keys [error warning]} summary]
                       (when-not dependencies
                         (clj-kondo/print! (assoc results :report-level report-level)))
                       (cond

--- a/test/clj_kondo/analysis/java_test.clj
+++ b/test/clj_kondo/analysis/java_test.clj
@@ -203,7 +203,7 @@
        java-member-definitions))))
 
 (deftest class-usages-test
-  (let [{:keys [:java-class-usages :var-usages]} (analyze ["corpus/java/usages.clj"])]
+  (let [{:keys [java-class-usages var-usages]} (analyze ["corpus/java/usages.clj"])]
     (is (= '(try fn import) (map :name var-usages)))
     (assert-submaps2
       [{:class "clojure.lang.PersistentVector", :uri #"file:.*corpus/java/usages.clj",

--- a/test/clj_kondo/analysis_test.clj
+++ b/test/clj_kondo/analysis_test.clj
@@ -158,7 +158,7 @@
        (:local-usages ana)))))
 
 (deftest deftype-locals-test
-  (let [{:keys [:locals :local-usages]}
+  (let [{:keys [locals local-usages]}
         (analyze "(deftype Foo [a b c] clojure.lang.IFn (invoke [_] [a b]))"
                  {:config {:analysis {:locals true}}})]
     ;; (clj-kondo.impl.utils/stderr :locals (pr-str locals))
@@ -173,7 +173,7 @@
 
 (deftest protocol-impls-test
   (testing "defrecord without protocol"
-    (let [{:keys [:protocol-impls]} (analyze "
+    (let [{:keys [protocol-impls]} (analyze "
 (defrecord MyBar []
   (something [_]
     123)
@@ -185,7 +185,7 @@
        []
        protocol-impls)))
   (testing "defrecord with simple protocols"
-    (let [{:keys [:protocol-impls]} (analyze "
+    (let [{:keys [protocol-impls]} (analyze "
 (defprotocol AProtocol
   (a-method [this])
   (^Bla b-method [this a b]))
@@ -243,7 +243,7 @@
           :row 21 :col 3 :end-row 23 :end-col 9}]
        protocol-impls)))
   (testing "defrecord with aliased protocol"
-    (let [{:keys [:protocol-impls]}
+    (let [{:keys [protocol-impls]}
           (analyze (->> ["(ns some-ns)"
                          "(defprotocol AProtocol"
                          "  (a-method [this])"
@@ -278,7 +278,7 @@
           :row 11 :col 3 :end-row 13 :end-col 9}]
        protocol-impls)))
   (testing "deftype"
-    (let [{:keys [:protocol-impls]} (analyze "
+    (let [{:keys [protocol-impls]} (analyze "
 (defprotocol AProtocol
   (a-method [this])
   (^Bla b-method [this a b]))
@@ -336,7 +336,7 @@
           :row 21 :col 3 :end-row 23 :end-col 9}]
        protocol-impls)))
   (testing "extend-protocol"
-    (let [{:keys [:protocol-impls]} (analyze "
+    (let [{:keys [protocol-impls]} (analyze "
 (defprotocol AProtocol
   (a-method [this])
   (^Bla b-method [this a b]))
@@ -393,7 +393,7 @@
           :row 20 :col 3 :end-row 22 :end-col 9}]
        protocol-impls)))
   (testing "extend-type"
-    (let [{:keys [:protocol-impls]} (analyze "
+    (let [{:keys [protocol-impls]} (analyze "
 (defprotocol AProtocol
   (a-method [this])
   (^Bla b-method [this a b]))
@@ -453,7 +453,7 @@
           :row 23 :col 3 :end-row 25 :end-col 9}]
        protocol-impls)))
   (testing "reify"
-    (let [{:keys [:protocol-impls]} (analyze "
+    (let [{:keys [protocol-impls]} (analyze "
 (defprotocol AProtocol
   (a-method [this])
   (^Bla b-method [this a b]))
@@ -511,7 +511,7 @@
           :row 21 :col 3 :end-row 23 :end-col 9}]
        protocol-impls)))
   (testing "specify!"
-    (let [{:keys [:protocol-impls]} (analyze "
+    (let [{:keys [protocol-impls]} (analyze "
 (defprotocol AProtocol
   (a-method [this])
   (^Bla b-method [this a b]))
@@ -573,7 +573,7 @@
 
 (deftest defmulti-defmethod-test
   (testing "defmulti and defmethod"
-    (let [{:keys [:var-usages :var-definitions]} (analyze "
+    (let [{:keys [var-usages var-definitions]} (analyze "
 (defmulti my-multi :some-key)
 
 (defmethod my-multi \"some-value\"
@@ -599,7 +599,7 @@
        var-usages))))
 
 (deftest overrides-test
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns clojure.core) (def defn- :compare-override-attributes)"
                  {:lang :clj
                   :config {:analysis {:var-definitions {:meta true}}}
@@ -610,7 +610,7 @@
         :macro true
         :varargs-min-arity 2}]
      var-definitions))
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns cljs.core) (def array :compare-override-attributes)"
                  {:lang :cljs
                   :config {:analysis {:var-definitions {:meta true}}}
@@ -618,7 +618,7 @@
     (assert-submaps
      '[{:varargs-min-arity 0}]
      var-definitions))
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns cljs.core) (def defn- :compare-override-attributes)"
                  {:lang :cljc
                   :config {:analysis {:var-definitions {:meta true}}}
@@ -635,14 +635,14 @@
      var-definitions)))
 
 (deftest name-position-test
-  (let [{:keys [:var-definitions :var-usages]} (analyze "(defn foo [] foo)" {:config {:analysis {:locals true}}})]
+  (let [{:keys [var-definitions var-usages]} (analyze "(defn foo [] foo)" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name foo :name-row 1 :name-col 7 :name-end-row 1 :name-end-col 10 :end-row 1 :end-col 18}]
      var-definitions)
     (assert-submaps
      '[{:name foo :name-row 1 :name-col 14 :name-end-row 1 :name-end-col 17} {}]
      var-usages))
-  (let [{:keys [:var-definitions :var-usages]} (analyze "(defprotocol Foo (bar [])) Foo bar" {:config {:analysis {:locals true}}})]
+  (let [{:keys [var-definitions var-usages]} (analyze "(defprotocol Foo (bar [])) Foo bar" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name Foo :name-row 1 :name-col 14 :name-end-row 1 :name-end-col 17 :end-row 1 :end-col 27}
        {:name bar :name-row 1 :name-col 19 :name-end-row 1 :name-end-col 22 :end-row 1 :end-col 26}]
@@ -660,7 +660,7 @@
         :name-row 1,
         :name-col 32}]
      var-usages))
-  (let [{:keys [:namespace-definitions :namespace-usages]} (analyze "(ns foo (:require [bar :as b :refer [x]] [clojure [string :as str]]))" {:config {:analysis {:locals true}}})]
+  (let [{:keys [namespace-definitions namespace-usages]} (analyze "(ns foo (:require [bar :as b :refer [x]] [clojure [string :as str]]))" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name foo
         :row 1,
@@ -692,7 +692,7 @@
         :name-end-row 1
         :name-end-col 58}]
      namespace-usages))
-  (let [{:keys [:var-definitions :var-usages]} (analyze "(def a (atom nil)) (:foo @a)" {:config {:analysis {:locals true}}})]
+  (let [{:keys [var-definitions var-usages]} (analyze "(def a (atom nil)) (:foo @a)" {:config {:analysis {:locals true}}})]
     (assert-submaps
      '[{:name-row 1 :name-col 6 :name-end-row 1 :name-end-col 7 :end-row 1 :end-col 19}]
      var-definitions)
@@ -708,7 +708,7 @@
 
 (deftest scope-usage-test
   (testing "when the var-usage is called as function"
-    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (foo 2)" {:config {:analysis true}})]
+    (let [{:keys [var-usages]} (analyze "(defn foo [a] a) (foo 2)" {:config {:analysis true}})]
       (is (some #(= '{:fixed-arities #{1}
                       :name-end-col 22
                       :name-end-row 1
@@ -725,7 +725,7 @@
                       :to user} % )
                 var-usages))))
   (testing "when the var-usage is not called as function"
-    (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) foo" {:config {:analysis true}})]
+    (let [{:keys [var-usages]} (analyze "(defn foo [a] a) foo" {:config {:analysis true}})]
       (is (some #(= '{:fixed-arities #{1}
                       :name-end-col 21
                       :name-end-row 1
@@ -741,7 +741,7 @@
                       :to user} %)
                 var-usages))))
   #_(testing "when the var-usage call is unknown"
-      (let [{:keys [:var-usages]} (analyze "(defn foo [a] a) (bar 2)" {:config {:analysis true}})]
+      (let [{:keys [var-usages]} (analyze "(defn foo [a] a) (bar 2)" {:config {:analysis true}})]
         (is (some #(= % '{:name-end-row 1
                           :name-end-col 22
                           :name-row 1
@@ -758,8 +758,8 @@
                   var-usages)))))
 
 (deftest analysis-test
-  (let [{:keys [:var-definitions
-                :var-usages]} (analyze "(defn ^:deprecated foo \"docstring\" {:added \"1.2\"} [])")]
+  (let [{:keys [var-definitions
+                var-usages]} (analyze "(defn ^:deprecated foo \"docstring\" {:added \"1.2\"} [])")]
     (assert-submaps
      '[{:filename "<stdin>",
         :row 1,
@@ -786,7 +786,7 @@
         :arity 4}]
      var-usages))
 
-  (let [{:keys [:var-definitions]} (analyze "(defn foo \"docstring with\\n \\\"escaping\\\"\" [])")]
+  (let [{:keys [var-definitions]} (analyze "(defn foo \"docstring with\\n \\\"escaping\\\"\" [])")]
     (assert-submaps
      '[{:filename "<stdin>",
         :row 1,
@@ -800,7 +800,7 @@
         :doc "docstring with\n \"escaping\""}]
      var-definitions))
 
-  (let [{:keys [:var-definitions]} (analyze "(def ^:deprecated x \"docstring\" 1)")]
+  (let [{:keys [var-definitions]} (analyze "(def ^:deprecated x \"docstring\" 1)")]
     (assert-submaps
      '[{:filename "<stdin>",
         :row 1,
@@ -813,8 +813,8 @@
         :doc "docstring",
         :deprecated true}]
      var-definitions))
-  (let [{:keys [:namespace-definitions
-                :namespace-usages]}
+  (let [{:keys [namespace-definitions
+                namespace-usages]}
         (analyze
          "(ns ^:deprecated foo \"docstring\"
             {:added \"1.2\" :no-doc true :author \"Michiel Borkent\"}
@@ -833,10 +833,10 @@
     (assert-submaps
      '[{:filename "<stdin>", :row 3, :col 24, :from foo, :to clojure.string}]
      namespace-usages))
-  (let [{:keys [:namespace-definitions
-                :namespace-usages
-                :var-usages
-                :var-definitions]}
+  (let [{:keys [namespace-definitions
+                namespace-usages
+                var-usages
+                var-definitions]}
         (analyze "(ns foo (:require [clojure.string :as string]))
                   (defn f [] (inc 1 2 3))" {:lang :cljc})]
     (assert-submaps
@@ -927,7 +927,7 @@
         :row 2,
         :to cljs.core}]
      var-usages))
-  (let [{:keys [:var-usages]}
+  (let [{:keys [var-usages]}
         (analyze "(ns foo)
                   (fn [x] x)
                   (fn* [x] x)
@@ -958,7 +958,7 @@
         :from foo,
         :to clojure.core}]
      var-usages))
-  (let [{:keys [:var-usages]}
+  (let [{:keys [var-usages]}
         (analyze "(ns foo)
                   (defn foo [x] x)
                   (def bar foo)"
@@ -966,8 +966,8 @@
     (assert-submaps
      '[]
      var-usages))
-  (let [{:keys [:var-definitions
-                :var-usages]}
+  (let [{:keys [var-definitions
+                var-usages]}
         (analyze "(ns foo)
                   (defn foo [x] (inc x))
                   (def bar foo)"
@@ -1018,7 +1018,7 @@
                                        :analyze-call
                                        {'user/defflow
                                         (str '(require '[clj-kondo.hooks-api :as api])
-                                             '(fn [{:keys [:node]}]
+                                             '(fn [{:keys [node]}]
                                                 (let [[test-name] (rest (:children node))
                                                       new-node (api/list-node
                                                                 [(api/token-node 'def)
@@ -1076,7 +1076,7 @@
                                      :analyze-call
                                      {'user/defflow
                                       (str '(require '[clj-kondo.hooks-api :as api])
-                                           '(fn [{:keys [:node]}]
+                                           '(fn [{:keys [node]}]
                                               (let [[test-name] (rest (:children node))
                                                     new-node (api/list-node
                                                               [(api/token-node 'def)
@@ -1120,7 +1120,7 @@
                                      "    :defined-by 'user/defflow}))")}}}}))))
 
 (deftest analysis-alias-test
-  (let [{:keys [:var-usages]}
+  (let [{:keys [var-usages]}
         (analyze "(ns foo (:require [bar :as b] baz))
                   (b/w)
                   (bar/x)
@@ -1136,7 +1136,7 @@
 (deftest analysis-arglists-test
   (doseq [analysis-opts [true {:arglists true}]]
     (testing (format "analysis opts: %s" analysis-opts)
-      (let [{:keys [:var-definitions]}
+      (let [{:keys [var-definitions]}
             (analyze "(defn f1 [d] d)
                       (defn f2 ([e] e) ([f f'] f))
                       (defprotocol AP (f3 [g] \"doc\") (f4 [h] [i i']))
@@ -1179,7 +1179,7 @@
                          {:arglists true}
                          {:arglists true :var-definitions {:meta true}}]]
     (testing  (format "analysis opts: %s" analysis-opts)
-      (let [{:keys [:var-definitions]}
+      (let [{:keys [var-definitions]}
             (analyze "(defn fnone [x])
                       (defn fattr1 {:arglists '([y])} [x] x)
                       (defn fattr2 ([x] x) ([y y'] y) {:arglists '([y1] [y2 y3])})
@@ -1316,7 +1316,7 @@
       (is (edn/read-string analysis-edn)))))
 
 (deftest test-var-test
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns foo (:require [clojure.test :as t]))
                   (t/deftest foo)")]
     (assert-submaps
@@ -1325,7 +1325,7 @@
      var-definitions)))
 
 (deftest schema-var-test
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns foo (:require [schema.core :as s]))
                   (s/def bar)
                   (s/defn f1 [d] d)
@@ -1341,7 +1341,7 @@
      var-definitions)))
 
 (deftest declare-var-test
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns foo)
                   (declare bar)")]
     (assert-submaps
@@ -1350,7 +1350,7 @@
      var-definitions)))
 
 (deftest deftype-test
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns foo)
                   (deftype Foo [])")]
     (assert-submaps
@@ -1359,7 +1359,7 @@
      var-definitions)))
 
 (deftest defprotocol-test
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns foo)
                   (defprotocol Foo (bar [_]) (baz [_]))")]
     (is (= '#{clojure.core/defprotocol} (set (map :defined-by var-definitions))))
@@ -1371,20 +1371,20 @@
      var-definitions)))
 
 (deftest export-test
-  (let [{:keys [:var-definitions]}
+  (let [{:keys [var-definitions]}
         (analyze "(ns foo)
                   (defn ^:export foo [])")]
     (is (true? (:export (first var-definitions))))))
 
 (deftest nested-libspec-test
-  (let [{:keys [:namespace-usages :var-usages]}
+  (let [{:keys [namespace-usages var-usages]}
         (analyze "(ns foo (:require [clojure [set :refer [union]]])) (union #{1 2 3} #{3 4 5})")]
     (is (= 'clojure.set (:to (first namespace-usages))))
     (is (= 'clojure.set (:to (first var-usages))))))
 
 (deftest refer-var-usages-test
   (testing "from require"
-    (let [{:keys [:namespace-usages :var-usages]}
+    (let [{:keys [namespace-usages var-usages]}
           (analyze "(ns foo (:require [clojure [set :refer [union]]])) (union #{1 2 3} #{3 4 5})")]
       (is (= 'clojure.set (:to (first namespace-usages))))
       (assert-submaps
@@ -1392,7 +1392,7 @@
          {:name union :to clojure.set :name-col 53}]
        var-usages)))
   (testing "from use"
-    (let [{:keys [:namespace-usages :var-usages]}
+    (let [{:keys [namespace-usages var-usages]}
           (analyze "(ns foo (:use [clojure [set :only [union]]])) (union #{1 2 3} #{3 4 5})")]
       (is (= 'clojure.set (:to (first namespace-usages))))
       (assert-submaps
@@ -1401,7 +1401,7 @@
        var-usages))))
 
 (deftest standalone-require-test
-  (let [{:keys [:namespace-usages :var-usages]}
+  (let [{:keys [namespace-usages var-usages]}
         (analyze "(require '[clojure [set :refer [union]]])")]
     (is (= 'clojure.set (:to (first namespace-usages))))
     (assert-submaps
@@ -1410,7 +1410,7 @@
      var-usages)))
 
 (deftest hof-test
-  (let [{:keys [:var-usages]}
+  (let [{:keys [var-usages]}
         (analyze "(defn foo [x y] (reduce foo x [y 3 4]))")]
     (is (some (fn [usage]
                 (and (= 'foo (:name usage))

--- a/test/clj_kondo/core_test.clj
+++ b/test/clj_kondo/core_test.clj
@@ -60,7 +60,7 @@
       (is (nat-int? (:duration s)))
       (is (nat-int? (:files s)))))
   (testing "end locations are reported correctly"
-    (let [{:keys [:findings]}
+    (let [{:keys [findings]}
           (with-in-str
             "(x  )" (clj-kondo/run! {:lint ["-"]}))]
       (assert-submaps
@@ -163,7 +163,7 @@
     (is (= 10 (:end-col first-and-only-finding)))))
 
 (deftest findings-serialization-test
-  (let [{:keys [:findings]}
+  (let [{:keys [findings]}
         (with-in-str "(ns test (:require [\"@material-ui/core\" :default mui]))"
           (clj-kondo/run!
            {:lint   ["-"]}))]

--- a/test/clj_kondo/test_utils.clj
+++ b/test/clj_kondo/test_utils.clj
@@ -19,7 +19,7 @@
 
 (defmethod t/report :end-test-var [_m]
   (when-let [rc *report-counters*]
-    (when-let [{:keys [:fail :error]} @rc]
+    (when-let [{:keys [fail error]} @rc]
       (when (and (= "true" (System/getenv "CLJ_KONDO_FAIL_FAST"))
                  (or (pos? fail) (pos? error)))
         (println "=== Failing fast")


### PR DESCRIPTION
Hey Borkdude, sorry for the big PR. It's actually really straightforward though.

Mainly because I am quite unsophisticated, and use `*` and `#` to navigate to next/prev occurrence of symbols (rather than something smarter) and this breaks that workflow, I wanted to run the `:keyword-binding` linter and correct all the warnings.

Feel free to close if you just prefer it as is. But it is worth noting that the codebase has a mix of styles, so I would argue even if this isn't merged, it might make contributing easier if kondo sticks to one style (and preferably enforces it with a self-lint). Cheers