### PR TITLE
New linter to warn on unused imported Clojure classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2538](https://github.com/clj-kondo/clj-kondo/issues/2538): Extend `:unresolved-namespace` linter to warn when importing Clojure-defined classes without requiring the namespace ([@jramosg](https://github.com/jramosg))
 - Add type checking support for `sorted-map-by`, `sorted-set`, and `sorted-set-by` functions
 ([@jramosg](https://github.com/jramosg))
 - Add new type `array` and type checking support for the next functions: `to-array`, `alength`,

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -2022,6 +2022,24 @@ This will exclude all bindings starting with `_x`.
 
 *Config:* use `:exclude [foo.bar]` to suppress the above warning.
 
+This linter also warns when a Clojure-defined Java class (e.g. from `deftype`) is imported but the corresponding namespace is not required.
+
+*Example trigger:*
+
+`bar.clj`:
+```clojure
+(ns bar)
+(deftype Bar [])
+```
+
+`foo.clj`:
+```clojure
+(ns foo (:import (bar Bar)))
+(Bar.)
+```
+
+*Example message:* `Imported namespace bar but it was not required.`
+
 You can report duplicate warnings using:
 
 ``` clojure

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -920,7 +920,8 @@
        ctx
        {:type :unresolved-namespace
         :filename filename
-        :message (str "Unresolved namespace " un ". Are you missing a require?")
+        :message (or (:message m)
+                     (str "Unresolved namespace " un ". Are you missing a require?"))
         :row (:row m)
         :col (:col m)
         :end-row (:end-row m)

--- a/test/clj_kondo/unresolved_namespace_import_test.clj
+++ b/test/clj_kondo/unresolved_namespace_import_test.clj
@@ -1,0 +1,51 @@
+(ns clj-kondo.unresolved-namespace-import-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint! with-temp-dir]]
+   [clojure.java.io :as io]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+(deftest imported-but-not-required-test
+  (with-temp-dir [dir "unresolved-namespace-import"]
+    (let [bar-file (io/file dir "bar.clj")
+          foo-file (io/file dir "foo.clj")]
+      (spit bar-file "(ns bar) (deftype Bar [])")
+
+      (testing "imported but not required Clojure-defined class should warn"
+        (spit foo-file "(ns foo (:import (bar Bar))) (Bar.)")
+        (assert-submaps2
+         '({:file #"foo.clj$"
+            :row 1
+            :col 31
+            :level :warning,
+            :message "Imported namespace bar but it was not required."})
+         (lint! [bar-file foo-file])))
+
+      (testing "imported and required Clojure-defined class should not warn"
+        (spit foo-file "(ns foo (:require [bar]) (:import (bar Bar))) (Bar.)")
+        (is (empty? (lint! [bar-file foo-file]))))
+
+      (testing "imported but not required, but in same namespace should not warn"
+        (spit bar-file "(ns bar) (deftype Bar []) (Bar.)")
+        (is (empty? (lint! [bar-file]))))
+
+      (testing "imported real Java class should not warn"
+        (spit foo-file "(ns foo (:import (java.io File))) (File. \"foo\")")
+        (is (empty? (lint! [foo-file]))))
+
+      (testing "multiple usages should only warn once by default"
+        (spit bar-file "(ns bar) (deftype Bar [])")
+        (spit foo-file "(ns foo (:import (bar Bar))) (Bar.) (Bar.)")
+        (assert-submaps2
+         '({:file #"foo.clj$", :row 1, :col 31, :level :warning,
+            :message "Imported namespace bar but it was not required."})
+         (lint! [bar-file foo-file])))
+
+      (testing "respects :report-duplicates true"
+        (spit bar-file "(ns bar) (deftype Bar [])")
+        (spit foo-file "(ns foo (:import (bar Bar))) (Bar.) (Bar.)")
+        (assert-submaps2
+         '({:file #"foo.clj$", :row 1, :col 31, :level :warning,
+            :message "Imported namespace bar but it was not required."}
+           {:file #"foo.clj$", :row 1, :col 38, :level :warning,
+            :message "Imported namespace bar but it was not required."})
+         (lint! [bar-file foo-file] {:linters {:unresolved-namespace {:report-duplicates true}}}))))))


### PR DESCRIPTION
This update enhances the `:unresolved-namespace` linter to issue a warning when a Clojure-defined class is imported without requiring the namespace. Additionally, a new test case is added to verify this behavior, ensuring that users are alerted to potential issues with unused imports. 

Fixes #2538

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
