### PR TITLE
Add linter for imported but not required namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2779](https://github.com/clj-kondo/clj-kondo/issues/2779), [#2780](https://github.com/clj-kondo/clj-kondo/issues/2780), [#2781](https://github.com/clj-kondo/clj-kondo/issues/2781), [#2782](https://github.com/clj-kondo/clj-kondo/issues/2782), [#2783](https://github.com/clj-kondo/clj-kondo/issues/2783), [#2785](https://github.com/clj-kondo/clj-kondo/issues/2785), [#2786](https://github.com/clj-kondo/clj-kondo/issues/2786), [#2794](https://github.com/clj-kondo/clj-kondo/issues/2794): Performance optimizations.
 - Performance: cache hook-fn lookups to avoid repeated SCI evaluation
 - [#2621](https://github.com/clj-kondo/clj-kondo/issues/2621): load imports from symlinked config dir ([@walterl](https://github.com/walterl))
+- [#2798](https://github.com/clj-kondo/clj-kondo/issues/2798): report correct filename and error details when `StackOverflowError` occurs during analysis
 
 
 ## 2026.01.19

--- a/corpus/stackoverflow_hook/.clj-kondo/config.edn
+++ b/corpus/stackoverflow_hook/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:macroexpand {foo/my-macro foo/my-macro}}}

--- a/corpus/stackoverflow_hook/.clj-kondo/foo.clj
+++ b/corpus/stackoverflow_hook/.clj-kondo/foo.clj
@@ -1,0 +1,5 @@
+(ns foo)
+
+;; Returns (do (my-macro ...)) which re-triggers expansion infinitely
+(defmacro my-macro [& body]
+  (list 'do (list* 'foo/my-macro body)))

--- a/corpus/stackoverflow_hook/foo.clj
+++ b/corpus/stackoverflow_hook/foo.clj
@@ -1,0 +1,5 @@
+(ns foo)
+
+(defmacro my-macro [& body])
+
+(my-macro (+ 1 2))

--- a/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/edn.clj
+++ b/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/edn.clj
@@ -57,9 +57,7 @@
           (str sb)
           (if (not-constituent? ch)
             (err/throw-bad-char rdr kind ch)
-            (recur (doto sb (.append (read-char rdr))) (peek-char rdr))))))))
-
-
+            (recur (doto sb (.append (clojure.core/char (read-char rdr)))) (peek-char rdr))))))))
 
 (declare read-tagged)
 
@@ -243,7 +241,7 @@
       \\ (recur (doto sb (.append (escape-char sb rdr)))
                 (read-char rdr))
       \" (str sb)
-      (recur (doto sb (.append ch)) (read-char rdr)))))
+      (recur (doto sb (.append (clojure.core/char ch))) (read-char rdr)))))
 
 (defn- read-symbol
   [rdr initch]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2590,7 +2590,7 @@
                                                   :row row
                                                   :col col
                                                   :type :hook
-                                                  :message (.getMessage e)}
+                                                  :message (or (.getMessage e) (str e))}
                                                  (select-keys (ex-data e)
                                                               [:level :row :col])))
                                                nil))))))
@@ -3694,6 +3694,16 @@
           (if dev?
             (throw e)
             (run! #(findings/reg-finding! ctx %) (->findings e filename))))
+        (catch Error e
+          (if dev?
+            (throw e)
+            (findings/reg-finding! ctx
+                                   {:filename filename
+                                    :col 0
+                                    :row 0
+                                    :type :file
+                                    :message (str "Could not process file: "
+                                                  (or (.getMessage e) (str e)))})))
         (finally
           (swap! files inc)
           (let [output-cfg (:output config)]

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -16,7 +16,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def dev? (= "true" (System/getenv "CLJ_KONDO_DEV")))
+(def dev? (delay (= "true" (System/getenv "CLJ_KONDO_DEV"))))
 
 (def cache-version "v1")
 
@@ -497,7 +497,7 @@
                     (when-not (:skip-lint ctx)
                       (utils/stderr "[clj-kondo]" jar-name "was already linted, skipping"))
                     (do (run! #(schedule ctx (assoc % :lang (lang-from-file (:filename %) default-language))
-                                         dev?)
+                                         @dev?)
                               (sources-from-jar ctx file canonical? use-import-dir))
                         (when-not (:skip-lint ctx)
                           (swap! (:mark-linted ctx) conj [skip-mark path])))))
@@ -512,9 +512,9 @@
                                    :uri (->uri nil nil fn)
                                    :source (slurp file)
                                    :lang (lang-from-file path default-language)}
-                              dev?)))))
+                              @dev?)))))
             ;; assume directory
-            (run! #(schedule ctx (assoc % :lang (lang-from-file (:filename %) default-language)) dev?)
+            (run! #(schedule ctx (assoc % :lang (lang-from-file (:filename %) default-language)) @dev?)
                   (sources-from-dir ctx file canonical? use-import-dir)))
           (= "-" path)
           (when-not (excluded? ctx filename-fallback)
@@ -522,7 +522,7 @@
                            :source (slurp *in*)
                            :lang (if filename-fallback
                                    (lang-from-file filename-fallback default-language)
-                                   default-language)} dev?))
+                                   default-language)} @dev?))
           (classpath? path)
           (run! #(process-file ctx % default-language canonical? filename-fallback use-import-dir)
                 (str/split path path-separator-pat))
@@ -540,7 +540,7 @@
                                     :row 0
                                     :message "file does not exist"}))))
       (catch Throwable e
-        (if dev?
+        (if @dev?
           (throw e)
           (when-not (:skip-lint ctx)
             (findings/reg-finding! ctx {:filename (if canonical?
@@ -597,7 +597,7 @@
     (when (and (:parallel ctx)
                (or (:analysis ctx)
                    (not (:skip-lint ctx))))
-      (parallel-analyze ctx @(:sources ctx) dev?))
+      (parallel-analyze ctx @(:sources ctx) @dev?))
     (when (and cache-dir (:dependencies ctx))
       (doseq [[mark path] @(:mark-linted ctx)]
         (let [skip-file (io/file cache-dir "skip" mark)]

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -185,15 +185,19 @@
                          (when (:allow-string-hooks ctx)
                            x)
                          (let [ns (namespace x)]
-                           (format "(require '%s %s)\n(deref (var %s))"
+                           (format "(require '%s %s)\n(var %s)"
                                    ns
                                    (if api/*reload* :reload "")
                                    x)))
-                  macro (binding [utils/*ctx* ctx]
-                          (sci/eval-string* (store/get-ctx) code))]
-              (fn [{:keys [node]}]
-                {:node (macroexpand macro node
-                                    (:bindings utils/*ctx*))}))))))))
+                  the-var (binding [utils/*ctx* ctx]
+                            (sci/eval-string* (store/get-ctx) code))]
+              (when (and the-var (not (string? x)) (not (:macro (meta the-var))))
+                (binding [*out* *err*]
+                  (println (str "WARNING: macroexpand hook " x " is not a macro"))))
+              (when-let [macro (if (var? the-var) @the-var the-var)]
+                (fn [{:keys [node]}]
+                  {:node (macroexpand macro node
+                                      (:bindings utils/*ctx*))})))))))))
 
 (def ^:private hook-not-found (Object.))
 

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -27483,7 +27483,7 @@
   :langs (),
   :message "Prefer placing return type hint on arg vector: String",
   :row 38}
- {:end-row 77,
+ {:end-row 75,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27492,8 +27492,8 @@
   :end-col 15,
   :langs (),
   :message "unused binding opts",
-  :row 77}
- {:end-row 123,
+  :row 75}
+ {:end-row 121,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27502,8 +27502,8 @@
   :end-col 17,
   :langs (),
   :message "unused binding backslash",
-  :row 123}
- {:end-row 123,
+  :row 121}
+ {:end-row 121,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27512,8 +27512,8 @@
   :end-col 22,
   :langs (),
   :message "unused binding opts",
-  :row 123}
- {:end-row 167,
+  :row 121}
+ {:end-row 165,
   :type :non-arg-vec-return-type-hint,
   :level :warning,
   :filename
@@ -27523,8 +27523,8 @@
   :langs (),
   :message
   "Prefer placing return type hint on arg vector: PersistentVector",
-  :row 167}
- {:end-row 205,
+  :row 165}
+ {:end-row 203,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27533,8 +27533,8 @@
   :end-col 19,
   :langs (),
   :message "unused binding opts",
-  :row 205}
- {:end-row 216,
+  :row 203}
+ {:end-row 214,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27543,8 +27543,8 @@
   :end-col 23,
   :langs (),
   :message "unused binding sb",
-  :row 216}
- {:end-row 238,
+  :row 214}
+ {:end-row 236,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27553,8 +27553,8 @@
   :end-col 14,
   :langs (),
   :message "unused binding opts",
-  :row 238}
- {:end-row 264,
+  :row 236}
+ {:end-row 262,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27563,8 +27563,8 @@
   :end-col 17,
   :langs (),
   :message "unused binding initch",
-  :row 264}
- {:end-row 264,
+  :row 262}
+ {:end-row 262,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27573,8 +27573,8 @@
   :end-col 22,
   :langs (),
   :message "unused binding opts",
-  :row 264}
- {:end-row 278,
+  :row 262}
+ {:end-row 276,
   :type :unused-private-var,
   :level :warning,
   :filename
@@ -27584,8 +27584,8 @@
   :langs (),
   :message
   "Unused private var clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.edn/wrapping-reader",
-  :row 278}
- {:end-row 299,
+  :row 276}
+ {:end-row 297,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27594,8 +27594,8 @@
   :end-col 14,
   :langs (),
   :message "unused binding opts",
-  :row 299}
- {:end-row 354,
+  :row 297}
+ {:end-row 352,
   :type :unused-binding,
   :level :warning,
   :filename
@@ -27604,8 +27604,8 @@
   :end-col 31,
   :langs (),
   :message "unused binding initch",
-  :row 354}
- {:end-row 358,
+  :row 352}
+ {:end-row 356,
   :type :missing-else-branch,
   :level :warning,
   :filename
@@ -27614,8 +27614,8 @@
   :end-col 68,
   :langs (),
   :message "Missing else branch.",
-  :row 357}
- {:end-row 418,
+  :row 355}
+ {:end-row 416,
   :type :missing-else-branch,
   :level :warning,
   :filename
@@ -27624,8 +27624,8 @@
   :end-col 74,
   :langs (),
   :message "Missing else branch.",
-  :row 415}
- {:end-row 425,
+  :row 413}
+ {:end-row 423,
   :type :missing-else-branch,
   :level :warning,
   :filename
@@ -27634,7 +27634,7 @@
   :end-col 70,
   :langs (),
   :message "Missing else branch.",
-  :row 422}
+  :row 420}
  {:end-row 13,
   :ns
   clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.impl.utils,

--- a/test/clj_kondo/hooks_test.clj
+++ b/test/clj_kondo/hooks_test.clj
@@ -2,7 +2,7 @@
   (:require
    [babashka.fs :as fs]
    [clj-kondo.core :as clj-kondo]
-   [clj-kondo.test-utils :refer [lint! assert-submaps assert-submaps2 native?]]
+   [clj-kondo.test-utils :refer [lint! assert-submaps assert-submaps2 native? normalize-filename]]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -522,3 +522,12 @@ my-ns/special-map \"
     (clj-kondo/run! {:lint [(fs/file "corpus" "issue-2636" "src" "usage.clj")]
                      :config (edn/read-string (slurp (fs/file "corpus" "issue-2636" ".clj-kondo" "config.edn")))
                      :config-dir (fs/file "corpus" "issue-2636" ".clj-kondo")}))))
+
+(deftest stackoverflow-in-hook-result-test
+  (testing "StackOverflowError during analysis reports correct filename, not directory"
+    (let [findings (lint! (fs/file "corpus" "stackoverflow_hook" "foo.clj")
+                          "--config-dir" (fs/file "corpus" "stackoverflow_hook" ".clj-kondo"))
+          errors (filter #(= :error (:level %)) findings)]
+      (is (seq errors))
+      (is (every? #(= "corpus/stackoverflow_hook/foo.clj" (normalize-filename (:file %))) errors))
+      (is (some #(str/includes? (:message %) "StackOverflowError") errors)))))


### PR DESCRIPTION
This change introduces a new linter that warns when a Clojure-defined Java class is imported but the corresponding namespace is not required. The linter is added to the configuration and documented in the linters overview. Tests are included to verify its functionality and behavior in various scenarios.

Fixes #2538

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
