### PR TITLE
Fix regression for unused binding warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
-- [#2713](https://github.com/clj-kondo/clj-kondo/issues/2713): Fix regression: incorrect unused binding warnings for symbols used in quote-unquote expressions (`'~expr`) ([@jramosg](https://github.com/jramosg))
+- [#2713](https://github.com/clj-kondo/clj-kondo/issues/2713): Fix regression: getting unused binding warning in `~'~` unquote expressions ([@jramosg](https://github.com/jramosg))
 - [#2711](https://github.com/clj-kondo/clj-kondo/issues/2711): Unused value inside `defmethod` ([@jramosg](https://github.com/jramosg))
 - [#2709](https://github.com/clj-kondo/clj-kondo/issues/2709): NEW linter: `:redundant-primitive-coercion` to warn when primitive coercion functions are applied to expressions already of that type
 - [#2600](https://github.com/clj-kondo/clj-kondo/issues/2600): NEW linter: `unused-excluded-var` to warn on unused vars in `:refer-clojure :exclude` ([@jramosg](https://github.com/jramosg))

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3185,7 +3185,9 @@
                              "Unquote (~) not syntax-quoted"
                              "Unquote-splicing (~@) not syntax-quoted")))))
           (let [new-level (if level (dec level) -1)
-                ctx (assoc ctx :syntax-quote-level new-level)]
+                ctx (-> ctx
+                        (assoc :syntax-quote-level new-level)
+                        (dissoc :quoted))]
             (analyze-children ctx children)))
         :namespaced-map (do
                           (lint-unused-value ctx expr)

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -143,9 +143,8 @@
          ctx (assoc ctx :syntax-quote-level new-syntax-quote-level)
          ctx (if syntax-quote-tag?
                (update ctx :callstack #(cons [:syntax-quote] %))
-               ctx)
-         unquote-tags #{:unquote :unquote-splicing}]
-     (if (and (= 1 syntax-quote-level) unquote-tag?)
+               ctx)]
+     (if (and (>= syntax-quote-level 1) unquote-tag?)
        (common/analyze-expression** ctx expr)
        (if quote?
          (do
@@ -153,11 +152,9 @@
              (analyze-keyword ctx expr opts))
            (doall (mapcat
                    #(analyze-usages2 ctx %
-                                     (if (unquote-tags (tag %))
-                                       (dissoc opts :quote?)
-                                       (assoc opts
-                                              :quote? quote?
-                                              :syntax-quote? syntax-quote?)))
+                                     (assoc opts
+                                            :quote? quote?
+                                            :syntax-quote? syntax-quote?))
                    (:children expr))))
          (let [syntax-quote?
                (or syntax-quote?
@@ -184,17 +181,17 @@
                                                                       (str "Destructured :or refers to binding of same map: "
                                                                            symbol-val)))))
                      (namespace/reg-used-binding! ctx
-                                                    (-> ns :name)
-                                                    b
-                                                    (when (:analyze-locals? ctx)
-                                                      (assoc-some expr-meta
-                                                                  :name-row (:row expr-meta)
-                                                                  :name-col (:col expr-meta)
-                                                                  :name-end-row (:end-row expr-meta)
-                                                                  :name-end-col (:end-col expr-meta)
-                                                                  :name symbol-val
-                                                                  :filename (:filename ctx)
-                                                                  :str (:string-value expr)))))
+                                                  (-> ns :name)
+                                                  b
+                                                  (when (:analyze-locals? ctx)
+                                                    (assoc-some expr-meta
+                                                                :name-row (:row expr-meta)
+                                                                :name-col (:col expr-meta)
+                                                                :name-end-row (:end-row expr-meta)
+                                                                :name-end-col (:end-col expr-meta)
+                                                                :name symbol-val
+                                                                :filename (:filename ctx)
+                                                                :str (:string-value expr)))))
                    (let [{resolved-ns :ns
                           resolved-name :name
                           resolved-alias :alias


### PR DESCRIPTION
Corrected the handling of unused binding warnings for symbols used in quote-unquote expressions. This change ensures that bindings within macros are accurately tracked, preventing false positives in linting results.

Fixes #2713 - Regression in v2025.12.23: Getting `unused binding` warning in `~'~` unquote expressions 

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
