### PR TITLE
Fix false positive for throw in CLJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] update lein-clj-kondo -->
 <!-- - [ ] update carve -->
 
-## Unreleased
-
-- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
+ ## Unreleased
+ 
+ - [#2749](https://github.com/clj-kondo/clj-kondo/issues/2749): Fix false positive for throw in CLJS when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
+ - [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2734](https://github.com/clj-kondo/clj-kondo/issues/2734): NEW linter: `:aliased-referred-var`, which warns when a var is both referred and accessed via an alias in the same namespace. ([@jramosg](https://github.com/jramosg))
 - [#2732](https://github.com/clj-kondo/clj-kondo/issues/2732): `unreachable-code`: warn when `:default` does not come last in reader conditionals ([@jramosg](https://github.com/jramosg))
 - [#2735](https://github.com/clj-kondo/clj-kondo/issues/2735): NEW linter: `:duplicate-refer` which warns on duplicate entries in `:refer` of `:require`. ([@jramosg](https://github.com/jramosg))

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -1250,6 +1250,7 @@
       (assoc-in ['instance? :arities 2 :args] [#{:class :fn} :any])
       (assoc-in ['bases :arities 1 :args] [#{:class :fn}])
       (assoc-in ['supers :arities 1 :args] [#{:class :fn}])
+      (assoc 'throw {:arities {1 {:args [:any]}}})
       (assoc 'keyword {:arities {1 {:args [#{:string :keyword :symbol}]
                                     :ret :keyword}
                                  2 {:args [#{:nilable/string :keyword :symbol}

--- a/test/clj_kondo/types_test.clj
+++ b/test/clj_kondo/types_test.clj
@@ -1074,11 +1074,16 @@
 (foo 1)"
                      config))))
 
-(deftest issue-2172-throw-test
-  (is (assert-submaps2
-       '({:file "<stdin>", :row 1, :col 8, :level :error, :message "Expected: throwable, received: positive integer."})
-       (lint! "(throw 1)" config)))
-  (is (empty? (lint! "(throw #_:clj-kondo/ignore 1)" config))))
+(deftest throw-test
+  (testing "throw expects a throwable in clj"
+    (is (assert-submaps2
+         '({:file "<stdin>", :row 1, :col 8, :level :error, :message "Expected: throwable, received: positive integer."})
+         (lint! "(throw 1)" config)))
+    (testing "it is ignored with clj-kondo/ignore"
+      (is (empty? (lint! "(throw #_:clj-kondo/ignore 1)" config)))))
+
+  (testing "throw accepts any type in cljs"
+    (is (empty? (lint! "(throw 1)" config "--lang" "cljs"))))) 
 
 (deftest do-test
   (is (assert-submaps2
@@ -1575,4 +1580,5 @@
 
 ;;;; Scratch
 
-(comment)
+(comment
+  )


### PR DESCRIPTION
Update the linter to allow throwing non-throwable values in CLJS. This change ensures that the linter does not incorrectly flag valid usage patterns in ClojureScript, improving developer experience and reducing unnecessary warnings.

Fixes False positive in CLJS for throwing non-exception Fixes #2749

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
