### PR TITLE
Add :duplicate-require-key linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## 2026.01.19
 
+- [#2744](https://github.com/clj-kondo/clj-kondo/issues/2744): NEW linter: `:duplicate-require-key` which warns when the same key (like `:refer`, `:as`, `:exclude`, etc.) appears multiple times in a single require clause. ([@jramosg](https://github.com/jramosg))
 - [#2735](https://github.com/clj-kondo/clj-kondo/issues/2735): NEW linter: `:duplicate-refer` which warns on duplicate entries in `:refer` of `:require`. ([@jramosg](https://github.com/jramosg))
 - [#2734](https://github.com/clj-kondo/clj-kondo/issues/2734): NEW linter: `:aliased-referred-var`, which warns when a var is both referred and accessed via an alias in the same namespace. ([@jramosg](https://github.com/jramosg))
 - [#2745](https://github.com/clj-kondo/clj-kondo/issues/2745): NEW linter: `:is-message-not-string` which warns when `clojure.test/is` receives a non-string message argument. This linter replaces the previous type-mismatch enforcement for `is` message arguments and can be disabled to allow non-string values. ([@jramosg](https://github.com/jramosg))

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -795,6 +795,24 @@ Explanation by Bozhidar Batsov:
 
 *Example message:* `Duplicate refer: union`
 
+### Duplicate require key
+
+*Keyword:* `:duplicate-require-key`.
+
+*Description:* warns when the same key (like `:refer`, `:as`, `:exclude`, etc.) appears multiple times in a single require clause. Clojure silently uses only the last occurrence, which can lead to unexpected behavior.
+
+*Example trigger:*
+
+``` clojure
+(ns foo
+  (:require [clojure.set :refer [union] :refer [difference]]))
+```
+
+*Example message:* `Duplicate require option: :refer. Only the last value will be used.`
+
+*Rationale:* When duplicate keys appear in a require clause, Clojure uses only the last value, making earlier occurrences unreachable. This is often unintentional and can be confusing. For example, in the code above, `union` becomes unreachable while `difference` is accessible.
+
+
 ### Duplicate set key
 
 *Keyword:* `:duplicate-set-key`.

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -36,6 +36,7 @@
               :duplicate-map-key {:level :error}
               :duplicate-set-key {:level :error}
               :duplicate-require {:level :warning}
+              :duplicate-require-key {:level :warning}
               :duplicate-field {:level :error}
               :duplicate-key-args {:level :warning}
               :missing-map-value {:level :error}

--- a/test/clj_kondo/duplicate_require_key_test.clj
+++ b/test/clj_kondo/duplicate_require_key_test.clj
@@ -1,0 +1,96 @@
+(ns clj-kondo.duplicate-require-key-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest duplicate-require-key-test
+  (testing "duplicate :refer key in ns require"
+    (assert-submaps2
+     '[{:row 2, :col 41, :level :warning, :message "Duplicate require option: :refer. Only the last value will be used."}]
+     (lint! "(ns foo
+  (:require [clojure.set :refer [union] :refer [difference]]))
+(difference #{:a} #{:b})"
+            "{:linters {:unused-namespace {:level :off}
+                        :unused-referred-var {:level :off}
+                        :refer {:level :off}}}")))
+
+  (testing "duplicate :as key in ns require"
+    (assert-submaps2
+     '[{:row 2, :col 32, :level :warning, :message "Duplicate require option: :as. Only the last value will be used."}]
+     (lint! "(ns foo
+  (:require [clojure.set :as s :as str]))
+(str/union #{:a} #{:b})"
+            "{:linters {:unused-namespace {:level :off}}}")))
+
+  (testing "multiple duplicate keys"
+    (assert-submaps2
+     '[{:row 2, :col 41, :level :warning, :message "Duplicate require option: :refer. Only the last value will be used."}
+       {:row 2, :col 67, :level :warning, :message "Duplicate require option: :as. Only the last value will be used."}]
+     (lint! "(ns foo
+  (:require [clojure.set :refer [union] :refer [difference] :as s :as str]))"
+            "{:linters {:unused-namespace {:level :off}
+                        :unused-referred-var {:level :off}
+                        :refer {:level :off}}}")))
+
+  (testing "no warning when keys are different"
+    (is (empty? (lint! "(ns foo
+  (:require [clojure.set :refer [union] :as s]))"
+                       "{:linters {:unused-namespace {:level :off}
+                                   :unused-referred-var {:level :off}
+                                   :refer {:level :off}}}"))))
+
+  (testing "duplicate :exclude key"
+    (assert-submaps2
+     '[{:row 2, :col 55, :level :warning, :message "Duplicate require option: :exclude. Only the last value will be used."}]
+     (lint! "(ns foo
+  (:require [clojure.set :refer :all :exclude [union] :exclude [intersection]]))"
+            "{:linters {:unused-namespace {:level :off}
+                        :refer-all {:level :off}}}")))
+
+  (testing "duplicate :rename key"
+    (assert-submaps2
+     '[{:row 2, :col 56, :level :warning, :message "Duplicate require option: :rename. Only the last value will be used."}]
+     (lint! "(ns foo
+  (:require [clojure.set :refer :all :rename {union u} :rename {intersection i}]))"
+            "{:linters {:unused-namespace {:level :off}
+                        :refer-all {:level :off}}}")))
+
+  (testing "duplicate require option in standalone require"
+    (assert-submaps2
+     '[{:row 1, :col 39, :level :warning, :message "Duplicate require option: :refer. Only the last value will be used."}]
+     (lint! "(require '[clojure.set :refer [union] :refer [difference]])"
+            "{:linters {:unused-namespace {:level :off}
+                        :unused-referred-var {:level :off}
+                        :refer {:level :off}}}")))
+
+  (testing "duplicate :refer-macros key"
+    (assert-submaps2
+     '[{:row 2, :col 48, :level :warning, :message "Duplicate require option: :refer-macros. Only the last value will be used."}]
+     (lint! "(ns foo
+  (:require [clojure.core :refer-macros [defn] :refer-macros [defmacro]]))"
+            "{:linters {:unused-namespace {:level :off}
+                        :unused-referred-var {:level :off}
+                        :refer {:level :off}}}")))
+
+  (testing "linter can be disabled"
+    (is (empty? (lint! "(ns foo
+  (:require [clojure.set :refer [union] :refer [difference]]))"
+                       "{:linters {:unused-namespace {:level :off}
+                                   :unused-referred-var {:level :off}
+                                   :refer {:level :off}
+                                   :duplicate-require-key {:level :off}}}"))))
+
+  (testing "linter can be disabled with inline ignore"
+    (is (empty? (lint! "(ns foo
+  #_:clj-kondo/ignore
+  (:require [clojure.set :refer [union] :refer [difference]]))"
+                       "{:linters {:unused-namespace {:level :off}
+                                   :unused-referred-var {:level :off}
+                                   :refer {:level :off}}}"))))
+
+  (testing "linter can be disabled with inline ignore on specific require"
+    (is (empty? (lint! "(ns foo
+  (:require #_:clj-kondo/ignore [clojure.set :refer [union] :refer [difference]]))"
+                       "{:linters {:unused-namespace {:level :off}
+                                   :unused-referred-var {:level :off}
+                                   :refer {:level :off}}}")))))

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -2689,6 +2689,11 @@ foo"))))
   (assert-submaps
    '({:file "<stdin>",
       :row 1,
+      :col 49,
+      :level :warning,
+      :message "Duplicate require option: :refer. Only the last value will be used."}
+     {:file "<stdin>",
+      :row 1,
       :col 56,
       :level :warning,
       :message "use alias or :refer [capitalize join]"})


### PR DESCRIPTION
Detects when the same key (like :refer, :as, :exclude, etc.) appears multiple times in a single require clause. Clojure uses only the last occurrence, making earlier values unreachable.

Closes #2744

- Add lint-duplicate-require-keys! function to detect duplicate keys
- Add :duplicate-require-key linter to default config
- Add comprehensive tests including inline ignore support
- Update main_test.clj to expect duplicate-require-key warning
- Update linters.md documentation
- Update CHANGELOG.md

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
