### PR TITLE
Add type support for future-related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - Performance improvement: refactor `lint-cond-constants!` to eliminate `sexpr` usage ([@jramosg](https://github.com/jramosg))
 - [#2762](https://github.com/clj-kondo/clj-kondo/issues/2762): Fix false positive: `throw` with string in CLJS no longer warns about type mismatch ([@jramosg](https://github.com/jramosg))
+- Type system: Add type support for future-related functions (`future`, `future-call`, `future-done?`, `future-cancel`, `future-cancelled?`) ([@jramosg](https://github.com/jramosg))
 
 
 ## 2026.01.19

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -49,6 +49,7 @@
     :sorted-map
     :boolean
     :atom
+    :future
     :regex
     :char
     :seqable-or-transducer
@@ -97,6 +98,7 @@
    :sequential #{:coll :seqable}
    :sorted-map #{:map :seqable :associative :coll :ifn :ilookup}
    :atom #{:ideref}
+   :future #{:ideref}
    :var #{:ideref :ifn}
    :array #{:seqable :ilookup}})
 
@@ -128,11 +130,11 @@
    :sequential #{:seq :list :vector :ifn :associative :stack :ilookup}
    :map #{:sorted-map}
    :set #{:sorted-set}
-   :ideref #{:atom :var :ifn}
+   :ideref #{:atom :future :var :ifn}
    :ilookup #{:map :set :sorted-set :sorted-map :coll :seqable :ifn :associative
               :vector :sequential :stack :array}})
 
-(def misc-types #{:boolean :atom :regex :char :class :inst})
+(def misc-types #{:boolean :atom :future :regex :char :class :inst})
 
 (defn nilable? [k]
   (= "nilable" (namespace k)))
@@ -170,6 +172,7 @@
    :char "character"
    :boolean "boolean"
    :atom "atom"
+   :future "future"
    :ideref "deref"
    :fn "function"
    :ifn "function"
@@ -253,6 +256,8 @@
     (class) :class
     (Class java.lang.Class) :nilable/class
     (Date java.util.Date) :nilable/inst
+    (Future java.util.concurrent.Future) :nilable/future
+    (future) :future
     nil))
 
 (defn number->tag [v]

--- a/src/clj_kondo/impl/types/clojure/core.clj
+++ b/src/clj_kondo/impl/types/clojure/core.clj
@@ -1016,7 +1016,9 @@
    ;; 6359 'condp
    ;; 6530
    'future? any->boolean
-   ;; 6536 'future-done?
+   ;; 6536
+   'future-done? {:arities {1 {:args [:future]
+                               :ret :boolean}}}
    ;; 6543 'letfn
    ;; 6556
    'fnil {:arities {2 {:args [:ifn :any]
@@ -1063,10 +1065,17 @@
                           :ret :vector}}}
    ;; 6942 'slurp
    ;; 6954 'spit
-   ;; 6963 'future-call
+   ;; 6963
+   'future-call {:arities {1 {:args [:ifn]
+                              :ret :future}}}
    ;; 6990 'future
-   ;; 7000 'future-cancel
-   ;; 7006 'future-cancelled?
+   'future {:arities {:varargs {:ret :future}}}
+   ;; 7000
+   'future-cancel {:arities {1 {:args [:future]
+                                :ret :boolean}}}
+   ;; 7006
+   'future-cancelled? {:arities {1 {:args [:future]
+                                    :ret :boolean}}}
    ;; 7012 'pmap
    ;; 7037 'pcalls
    ;; 7044 'pvalues
@@ -1264,6 +1273,10 @@
   (supers java.io.File)
   ;; => #{java.lang.Object java.io.Serializable java.lang.Comparable}
   (make-array Integer/TYPE 3)
-   ;; => #object["[I" 0x54dee272 "[I@54dee272"]
+  ;; => #object["[I" 0x54dee272 "[I@54dee272"]
 
+  (future-cancel (future (Thread/sleep 10000)))
+  ;; => true
+
+  ;; scratch 
   )

--- a/test/clj_kondo/types_test.clj
+++ b/test/clj_kondo/types_test.clj
@@ -1590,6 +1590,53 @@
       :message "Expected: sequential collection, received: set."})
    (lint! "(update-in {:a {:b 42}} #{:a :b} inc)" config)))
 
+(deftest future-type-test
+  (testing "future returns future type"
+    (is (empty? (lint! "(let [f (future 42)] (deref f))" config)))
+    (assert-submaps2
+    '({:file "<stdin>",
+       :row 1,
+       :col 27,
+       :level :error,
+       :message "Expected: number, received: future."})
+     (lint! "(let [f (future 42)] (inc f))" config)))
+  (testing "future-call returns future type"
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] (deref f))" config)))
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] @f)" config))))
+  (testing "future-done? accepts future"
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] (future-done? f))" config))))
+  (testing "future-cancel accepts future and returns boolean"
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] (future-cancel f))" config)))
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] (if (future-cancel f) :ok :not-ok))" config))))
+  (testing "future-cancelled? accepts future and returns boolean"
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] (future-cancelled? f))" config)))
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] (if (future-cancelled? f) :ok :not-ok))" config))))
+  (testing "future? returns boolean"
+    (is (empty? (lint! "(let [f (future-call (fn [] 42))] (if (future? f) :ok :not-ok))" config))))
+  (testing "type errors with wrong types"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 1,
+        :col 26,
+        :level :error,
+        :message "Expected: future, received: positive integer."})
+     (lint! "(let [x 1] (future-done? x))" config))
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 1,
+        :col 34,
+        :level :error,
+        :message "Expected: future, received: atom."})
+     (lint! "(let [a (atom 1)] (future-cancel a))" config)))
+  (testing "java.util.concurrent.Future type hint"
+    (is (empty? (lint! "(defn foo [^java.util.concurrent.Future f] (future-done? f))" config)))
+    (is (empty? (lint! "(defn foo [^java.util.concurrent.Future f] @f)" config)))
+    (assert-submaps2
+     '({:file "<stdin>",
+        :level :error,
+        :message "Expected: atom, received: future or nil."})
+     (lint! "(defn foo [^java.util.concurrent.Future f] (swap! f inc))" config))))
+
 ;;;; Scratch
 
 (comment)


### PR DESCRIPTION
This update introduces type support for functions related to futures, including `future`, `future-call`, `future-done?`, `future-cancel`, and `future-cancelled?`. Additionally, tests have been added to ensure correct linting behavior for these types, enhancing the type system and improving overall code quality.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
