### PR TITLE
[rewrite-clj] A few more performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Type system: Add type support for future-related functions (`future`, `future-call`, `future-done?`, `future-cancel`, `future-cancelled?`) ([@jramosg](https://github.com/jramosg))
 - [#2770](https://github.com/clj-kondo/clj-kondo/issues/2770): Fix: linter-specific ignores now correctly respect the specified linters instead of suppressing all linters for `:unused-excluded-var` and `:unresolved-excluded-var`
 - [#2773](https://github.com/clj-kondo/clj-kondo/issues/2773): Align executable path for images to be `/bin/clj-kondo` ([@harryzcy](https://github.com/harryzcy))
-- [#2779](https://github.com/clj-kondo/clj-kondo/issues/2779), [#2780](https://github.com/clj-kondo/clj-kondo/issues/2780), [#2781](https://github.com/clj-kondo/clj-kondo/issues/2781), [#2782](https://github.com/clj-kondo/clj-kondo/issues/2782), [#2783](https://github.com/clj-kondo/clj-kondo/issues/2783), [#2785](https://github.com/clj-kondo/clj-kondo/issues/2785), [#2786](https://github.com/clj-kondo/clj-kondo/issues/2786): Performance optimizations.
+- [#2779](https://github.com/clj-kondo/clj-kondo/issues/2779), [#2780](https://github.com/clj-kondo/clj-kondo/issues/2780), [#2781](https://github.com/clj-kondo/clj-kondo/issues/2781), [#2782](https://github.com/clj-kondo/clj-kondo/issues/2782), [#2783](https://github.com/clj-kondo/clj-kondo/issues/2783), [#2785](https://github.com/clj-kondo/clj-kondo/issues/2785), [#2786](https://github.com/clj-kondo/clj-kondo/issues/2786), [#2794](https://github.com/clj-kondo/clj-kondo/issues/2794): Performance optimizations.
 - Performance: cache hook-fn lookups to avoid repeated SCI evaluation
 
 

--- a/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
@@ -49,18 +49,16 @@
 (defn read-string-data
   [reader]
   (ignore reader)
-  (let [buf (StringBuffer.)]
-    (loop [escape? false
-           lines []]
-      (if-let [c (r/read-char reader)]
-        (cond (and (not escape?) (= c \"))
-              (flush-into lines buf)
+  (loop [escape? false, lines [], buf (StringBuilder.)]
+    (if-let [c (r/read-char reader)]
+      (cond (and (not escape?) (= c \"))
+            (conj lines (str buf))
 
-              (= c \newline)
-              (recur escape? (flush-into lines buf))
+            (= c \newline)
+            (recur escape? (conj lines (str buf)) (StringBuilder.))
 
-              :else
-              (do
-                (.append buf c)
-                (recur (and (not escape?) (= c \\)) lines)))
-        (throw-reader reader "Unexpected EOF while reading string.")))))
+            :else
+            (do
+              (.append buf (char c))
+              (recur (and (not escape?) (= c \\)) lines buf)))
+      (throw-reader reader "Unexpected EOF while reading string."))))

--- a/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/utils.clj
@@ -39,13 +39,6 @@
         (recur (conj char-seq c)))
       (apply str char-seq))))
 
-(defn flush-into
-  "Flush buffer and add string to the given vector."
-  [lines ^StringBuffer buf]
-  (let [s (str buf)]
-    (.setLength buf 0)
-    (conj lines s)))
-
 (defn read-string-data
   [reader]
   (ignore reader)

--- a/parser/clj_kondo/impl/rewrite_clj/reader.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/reader.clj
@@ -16,30 +16,30 @@
 (defn boundary?
   "Check whether a given char is a token boundary."
   [c]
-  (contains?
-    #{\" \: \; \' \@ \^ \` \~
-      \( \) \[ \] \{ \} \\ nil}
-    c))
+  ;; Note: indexOf here is more efficient that a hashset of characters.
+  (or (nil? c) (> (.indexOf "\":;'@^`~()[]{}\\" (int c)) -1)))
 
 (defn comma?
   [^java.lang.Character c]
-  (= \, c))
+  (identical? \, c))
 
 (defn whitespace?
   [^java.lang.Character c]
-  (and c
-       (or (comma? c)
-           (Character/isWhitespace c))))
+  (cond (nil? c) false
+        (identical? \, c) true
+        :else (Character/isWhitespace c)))
 
 (defn linebreak?
   [^java.lang.Character c]
-  (contains? #{\newline \return} c))
+  (or (identical? c \newline) (identical? c \return)))
 
 (defn space?
   [^java.lang.Character c]
   (and c
        (Character/isWhitespace c)
-       (not (contains? #{\newline \return \,} c))))
+       (not (identical? c \newline))
+       (not (identical? c \return))
+       (not (identical? c \,))))
 
 (defn whitespace-or-boundary?
   [c]
@@ -59,7 +59,7 @@
       (if-let [c (r/read-char reader)]
         (if (p? c)
           (do
-            (.append buf c)
+            (.append buf (char c))
             (recur))
           (do
             (r/unread reader c)


### PR DESCRIPTION
_Parent: #2778._

Optimizations backported from rewrite-clj upstream (https://github.com/clj-commons/rewrite-clj/pull/443, https://github.com/clj-commons/rewrite-clj/pull/444). 

Diffgraph: https://flamebin.dev/eJ9Ntw?read-token=QxM2EuIeKE2a1IWtIM

Benhcmark comparison for `metabase+clojure-lsp.clj`. Take with a grain of salt, it fluctuates quite a bit:

```
master:
[ 99%] Project analyzed            "Elapsed time: 86983.645209 msecs"
GC stats: 79 collections, collected 47.3GB, spent 5.4 seconds on GC

PR:
[ 99%] Project analyzed            "Elapsed time: 80004.784084 msecs"
GC stats: 77 collections, collected 46.5GB, spent 4.7 seconds on GC
```

---

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
