### PR TITLE
Fix cache lock contention with concurrent clj-kondo processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2773](https://github.com/clj-kondo/clj-kondo/issues/2773): Align executable path for images to be `/bin/clj-kondo` ([@harryzcy](https://github.com/harryzcy))
 - [#2779](https://github.com/clj-kondo/clj-kondo/issues/2779), [#2780](https://github.com/clj-kondo/clj-kondo/issues/2780), [#2781](https://github.com/clj-kondo/clj-kondo/issues/2781), [#2782](https://github.com/clj-kondo/clj-kondo/issues/2782), [#2783](https://github.com/clj-kondo/clj-kondo/issues/2783), [#2785](https://github.com/clj-kondo/clj-kondo/issues/2785), [#2786](https://github.com/clj-kondo/clj-kondo/issues/2786): Performance optimizations.
 - Performance: cache hook-fn lookups to avoid repeated SCI evaluation
+- [#2795](https://github.com/clj-kondo/clj-kondo/issues/2795): Fix: cache lock contention with concurrent clj-kondo processes (e.g. editor integration + pre-commit hook) no longer causes an unhandled exception; clj-kondo now warns to stderr and continues linting without the cache ([@jramosg](https://github.com/jramosg))
 
 
 ## 2026.01.19

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -198,9 +198,16 @@
 
 (defn sync-cache [idacs config-dir cache-dir]
   (if cache-dir
-    (with-thread-lock
-      (with-cache cache-dir 6
-        (sync-cache* idacs config-dir cache-dir)))
+    (try
+      (with-thread-lock
+        (with-cache cache-dir 6
+          (sync-cache* idacs config-dir cache-dir)))
+      (catch Exception e
+        (if (str/includes? (ex-message e) "locked")
+          (do (binding [*out* *err*]
+                (println "[clj-kondo] WARNING: cache is locked by another process; skipping cache sync."))
+              idacs)
+          (throw e))))
     (sync-cache* idacs config-dir cache-dir)))
 
 ;;;; Scratch


### PR DESCRIPTION
When an editor integration (e.g. Calva) lints files in the background concurrently with a pre-commit hook running clj-kondo, both processes compete for the .clj-kondo cache file lock. After 6 retries (~1.5s), clj-kondo would throw an unhandled exception causing the commit to fail.

This change makes cache contention a recoverable condition: when the lock cannot be obtained, clj-kondo now warns to stderr and continues linting without cache rather than aborting with an exception. This allows concurrent invocations (editor + hook, or multiple hooks) to coexist gracefully with degraded but functional behavior.

Fixes #2795

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
