### PR TITLE
[tools.reader] Use more efficient StringBuilder.append arity

### DIFF
--- a/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/edn.clj
+++ b/inlined/clj_kondo/impl/toolsreader/v1v2v2/clojure/tools/reader/edn.clj
@@ -57,9 +57,7 @@
           (str sb)
           (if (not-constituent? ch)
             (err/throw-bad-char rdr kind ch)
-            (recur (doto sb (.append (read-char rdr))) (peek-char rdr))))))))
-
-
+            (recur (doto sb (.append (clojure.core/char (read-char rdr)))) (peek-char rdr))))))))
 
 (declare read-tagged)
 
@@ -243,7 +241,7 @@
       \\ (recur (doto sb (.append (escape-char sb rdr)))
                 (read-char rdr))
       \" (str sb)
-      (recur (doto sb (.append ch)) (read-char rdr)))))
+      (recur (doto sb (.append (clojure.core/char ch))) (read-char rdr)))))
 
 (defn- read-symbol
   [rdr initch]


### PR DESCRIPTION
_Parent: https://github.com/clj-kondo/clj-kondo/issues/2778._

Casting the argument to `StringBuilder.append` into a primitive char prevents allocations. Same idea as in https://github.com/clj-commons/rewrite-clj/pull/443.

Benchmarking and profiling shows ~5% allocation reduction:

```
Before:
[ 99%] Project analyzed            "Elapsed time: 99207.626459 msecs"
GC stats: 129 collections, collected 54.8GB, spent 8.1 seconds on GC

[ 99%] Project analyzed            "Elapsed time: 95560.555041 msecs"
GC stats: 83 collections, collected 52.8GB, spent 6.2 seconds on GC
```

Diffgraph: https://flamebin.dev/EDBVLn

---

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.