### PR TITLE
More control on what keywords are allowed inside `:keys` bindings

### DIFF
--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -876,27 +876,19 @@
               :col (:col default)
               :end-row (:end-row default)
               :end-col (:end-col default)}))))
-      (let [{:keys [level namespaced-keywords auto-resolved-keywords]
-             :or {namespaced-keywords true
-                  auto-resolved-keywords true}} (-> ctx :config :linters :keyword-binding)]
+      (let [{:keys [level disallow-all-keywords]} (-> ctx :config :linters :keyword-binding)]
         (when (not (identical? :off level))
           (doseq [binding (filter :keyword (:bindings ns))]
-            (when-some [keyword-str (cond
-                                      (namespace (:keyword binding))
-                                      (when (not namespaced-keywords)
-                                        (str (:keyword binding)))
-
-                                      (:auto-resolved binding)
-                                      (when (not auto-resolved-keywords)
-                                        (str "::" (name (:keyword binding))))
-
-                                      :else
-                                      (str (:keyword binding)))]
+            (when (or disallow-all-keywords
+                      (not (or (namespace (:keyword binding))
+                               (:auto-resolved binding))))
               (findings/reg-finding!
                ctx
                {:type :keyword-binding
                 :filename (:filename binding)
-                :message (str "Keyword binding should be a symbol: " keyword-str)
+                :message (str "Keyword binding should be a symbol: "
+                              (when (:auto-resolved binding) ":")
+                              (:keyword binding))
                 :row (:row binding)
                 :col (:col binding)
                 :end-row (:end-row binding)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -876,19 +876,31 @@
               :col (:col default)
               :end-row (:end-row default)
               :end-col (:end-col default)}))))
-      (when (not (identical? :off (-> ctx :config :linters :keyword-binding :level)))
-        (doseq [binding (filter :keyword (:bindings ns))]
-          (when-not (or (namespace (:keyword binding))
-                        (:auto-resolved binding))
-            (findings/reg-finding!
-             ctx
-             {:type :keyword-binding
-              :filename (:filename binding)
-              :message (str "Keyword binding should be a symbol: " (keyword (:name binding)))
-              :row (:row binding)
-              :col (:col binding)
-              :end-row (:end-row binding)
-              :end-col (:end-col binding)})))))))
+      (let [{:keys [level namespaced-keywords auto-resolved-keywords]
+             :or {namespaced-keywords true
+                  auto-resolved-keywords true}} (-> ctx :config :linters :keyword-binding)]
+        (when (not (identical? :off level))
+          (doseq [binding (filter :keyword (:bindings ns))]
+            (when-some [keyword-str (cond
+                                      (namespace (:keyword binding))
+                                      (when (not namespaced-keywords)
+                                        (str (:keyword binding)))
+
+                                      (:auto-resolved binding)
+                                      (when (not auto-resolved-keywords)
+                                        (str "::" (name (:keyword binding))))
+
+                                      :else
+                                      (str (:keyword binding)))]
+              (findings/reg-finding!
+               ctx
+               {:type :keyword-binding
+                :filename (:filename binding)
+                :message (str "Keyword binding should be a symbol: " keyword-str)
+                :row (:row binding)
+                :col (:col binding)
+                :end-row (:end-row binding)
+                :end-col (:end-col binding)}))))))))
 
 (defn lint-unused-private-vars!
   [ctx]

--- a/test/clj_kondo/keyword_binding_test.clj
+++ b/test/clj_kondo/keyword_binding_test.clj
@@ -28,8 +28,17 @@
    (lint! mixed-example)))
 
 (deftest namespaced-keyword-test
-  (testing "keywords with namespaced are ignored"
+  (testing "keywords with namespace are ignored by default"
     (assert-submaps2
      [{:file "<stdin>", :row 1, :col 24, :level :warning, :message "Keyword binding should be a symbol: :baz"}]
      (lint! "(let [{:keys [:foo/bar :baz ::baz]} {}] bar)"
-            {:linters {:keyword-binding {:level :warning}}}))))
+            {:linters {:keyword-binding {:level :warning}}})))
+  (testing "keywords with namespace are not ignored when specified otherwise"
+    (assert-submaps2
+     [{:file "<stdin>", :row 1, :col 15, :level :warning, :message "Keyword binding should be a symbol: :foo/bar"}
+      {:file "<stdin>", :row 1, :col 24, :level :warning, :message "Keyword binding should be a symbol: :baz"}
+      {:file "<stdin>", :row 1, :col 29, :level :warning, :message "Keyword binding should be a symbol: ::baz"}]
+     (lint! "(let [{:keys [:foo/bar :baz ::baz]} {}] bar)"
+            {:linters {:keyword-binding {:namespaced-keywords false
+                                         :auto-resolved-keywords false
+                                         :level :warning}}}))))

--- a/test/clj_kondo/keyword_binding_test.clj
+++ b/test/clj_kondo/keyword_binding_test.clj
@@ -27,18 +27,25 @@
    [{:file "<stdin>", :row 4, :col 18, :level :warning, :message "Keyword binding should be a symbol: :a"}]
    (lint! mixed-example)))
 
+(def namespaced-keyword-example
+  "(ns keyword-binding
+     (:require [foo.bar :as-alias fb]))
+
+   (let [{:keys [:foo/a :b ::fb/c ::d]} {}] a)")
+
 (deftest namespaced-keyword-test
   (testing "keywords with namespace are ignored by default"
     (assert-submaps2
-     [{:file "<stdin>", :row 1, :col 24, :level :warning, :message "Keyword binding should be a symbol: :baz"}]
-     (lint! "(let [{:keys [:foo/bar :baz ::baz]} {}] bar)"
+     [{:file "<stdin>", :row 4, :col 25, :level :warning, :message "Keyword binding should be a symbol: :b"}]
+     (lint! namespaced-keyword-example
             {:linters {:keyword-binding {:level :warning}}})))
+
   (testing "keywords with namespace are not ignored when specified otherwise"
     (assert-submaps2
-     [{:file "<stdin>", :row 1, :col 15, :level :warning, :message "Keyword binding should be a symbol: :foo/bar"}
-      {:file "<stdin>", :row 1, :col 24, :level :warning, :message "Keyword binding should be a symbol: :baz"}
-      {:file "<stdin>", :row 1, :col 29, :level :warning, :message "Keyword binding should be a symbol: ::baz"}]
-     (lint! "(let [{:keys [:foo/bar :baz ::baz]} {}] bar)"
-            {:linters {:keyword-binding {:namespaced-keywords false
-                                         :auto-resolved-keywords false
+     [{:file "<stdin>", :row 4, :col 18, :level :warning, :message "Keyword binding should be a symbol: :foo/a"}
+      {:file "<stdin>", :row 4, :col 25, :level :warning, :message "Keyword binding should be a symbol: :b"}
+      {:file "<stdin>", :row 4, :col 28, :level :warning, :message "Keyword binding should be a symbol: ::fb/c"}
+      {:file "<stdin>", :row 4, :col 35, :level :warning, :message "Keyword binding should be a symbol: ::d"}]
+     (lint! namespaced-keyword-example
+            {:linters {:keyword-binding {:disallow-all-keywords true
                                          :level :warning}}}))))


### PR DESCRIPTION
This is a proposal for more control on what keywords are allowed inside `:keys` bindings, because "one size does not fit all".

This PR is a support for a follow up to the discussion at https://github.com/clj-kondo/clj-kondo/issues/1918

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
