### PR TITLE
Fix #2811: report correct location for :missing-map-value 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] update lein-clj-kondo -->
 <!-- - [ ] update carve -->
 
+## Unreleased
+
+- [#2811](https://github.com/clj-kondo/clj-kondo/issues/2811): report correct location for `:missing-map-value` when the malformed map is nested in a set or in map-key position, and no longer suppress subsequent lint errors in the file
+
 ## 2026.04.15
 
 - [#2788](https://github.com/clj-kondo/clj-kondo/issues/2788): NEW linter: `:not-nil?` which suggests `(some? x)` instead of `(not (nil? x))`, and similar patterns with `when-not` and `if-not` (default level: `:off`)

--- a/src/clj_kondo/impl/linters/keys.clj
+++ b/src/clj_kondo/impl/linters/keys.clj
@@ -28,8 +28,9 @@
     :list (map-without-nils #(key-value % in-quote?) (:children node))
     :set (some-> (map-without-nils #(key-value % in-quote?) (:children node))
                  (set))
-    :map (some->> (map-without-nils #(key-value % in-quote?) (:children node))
-                  (apply hash-map))
+    :map (when (even? (count (:children node)))
+           (some->> (map-without-nils #(key-value % in-quote?) (:children node))
+                    (apply hash-map)))
     :quote (recur (first (:children node)) true)
     nil))
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1184,7 +1184,17 @@ foo/foo ;; this does use the private var
          (lint! "(fn [x] {:post} x)")))
   (assert-submaps
    '({:row 1, :col 22, :level :error, :message "missing value for key :c"})
-   (lint! "(let [{:keys [:a :b] :c} {}] [a b])")))
+   (lint! "(let [{:keys [:a :b] :c} {}] [a b])"))
+  (testing "malformed map nested in set or map-key position reports location (issue #2811)"
+    (assert-submaps
+     '({:row 1, :col 4, :level :error, :message "missing value for key :oops"})
+     (lint! "#{{:oops}}"))
+    (assert-submaps
+     '({:row 1, :col 3, :level :error, :message "missing value for key :badkey"})
+     (lint! "{{:badkey} 123}"))
+    (assert-submaps
+     '({:row 1, :col 7, :level :error, :message "missing value for key :badval"})
+     (lint! "{123 {:badval}}"))))
 
 (deftest set-duplicate-keys-test
   (is (= '({:file "<stdin>",


### PR DESCRIPTION
Malformed maps (odd child count) nested in a set or in map-key position caused key-value to throw IllegalArgumentException from (apply hash-map), which escaped linting and reported the error at 0:0 while suppressing subsequent findings. Guard the apply so malformed maps return nil for dedup purposes; the inner lint-map-keys pass still emits the finding with the correct location.