### PR TITLE
Fix definterface methods with multiple arities (#2814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#2811](https://github.com/clj-kondo/clj-kondo/issues/2811): report correct location for `:missing-map-value` when the malformed map is nested in a set or in map-key position, and no longer suppress subsequent lint errors in the file
+- [#2814](https://github.com/clj-kondo/clj-kondo/issues/2814): fix false positive `:protocol-method-arity-mismatch` when a `definterface` declares the same method name with multiple arities ([@jramosg](https://github.com/jramosg))
 
 ## 2026.04.15
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1612,6 +1612,14 @@
               "Missing catch or finally in try")))
           analyzed)))))
 
+(defn- method-arities-by-name [meths defined-by->lint-as]
+  (let [interface? (= 'clojure.core/definterface defined-by->lint-as)]
+    (reduce (fn [acc [fn-name fixed-arities]]
+              (update acc fn-name (fnil into #{})
+                      (cond->> fixed-arities
+                        interface? (map inc))))
+            {} meths)))
+
 (defn analyze-defprotocol [{:keys [ns] :as ctx} expr defined-by defined-by->lint-as]
   ;; for syntax, see https://clojure.org/reference/protocols#_basics
   (let [children (next (:children expr))
@@ -1627,8 +1635,7 @@
                               ;; skip last docstring
                               #(when (= :vector (tag %)) %))]
     (docstring/lint-docstring! ctx doc-node docstring)
-    (let [interface? (= 'clojure.core/definterface defined-by->lint-as)
-          meths (for [c (next children)
+    (let [meths (for [c (next children)
                       :when (= :list (tag c)) ;; skip first docstring
                       :let [children (:children c)
                             name-node (first children)
@@ -1692,9 +1699,8 @@
                                   (:user-meta name-meta))
                      :doc docstring
                      :methods (mapv first meths)
-                     :method-arities (cond-> (into {} meths)
-                                       interface?
-                                       (utils/update-vals #(set (map inc %))))
+                     :method-arities (method-arities-by-name
+                                      meths  defined-by->lint-as)
                      :defined-by defined-by
                      :defined-by->lint-as defined-by->lint-as))))))
 

--- a/test/clj_kondo/protocol_method_arity_mismatch_test.clj
+++ b/test/clj_kondo/protocol_method_arity_mismatch_test.clj
@@ -254,6 +254,35 @@
   (foo [this x] a)
   (bar [this] a))")))))
 
+(deftest definterface-overloaded-method-test
+  (testing "no warning when definterface declares the same method with multiple arities (#2814)"
+    (is (empty?
+         (lint! "(ns test.foo)
+
+(definterface IStore
+  (put [_v])
+  (put [_k _v]))
+
+(deftype Store []
+  IStore
+  (put [_this _object] nil)
+  (put [_this _k _object] nil))"))))
+  (testing "wrong arity is still detected when definterface overloads a method"
+    (assert-submaps2
+     '({:level :warning,
+        :message "Protocol method put is implemented with arity 4 but expects 2, 3"})
+     (lint! "(ns test.foo)
+
+(definterface IStore
+  (put [_v])
+  (put [_k _v]))
+
+(deftype Store []
+  IStore
+  (put [_this _object] nil)
+  (put [_this _k _object] nil)
+  (put [_this _a _b _c] nil))"))))
+
 (deftest config-disabled-test
   (testing "linter can be disabled via config"
     (is (empty?


### PR DESCRIPTION
Extract `method-arities-by-name` to accumulate
all arities per method name, and fold the
`definterface` `inc` adjustment inline with `cond->>`

`(into {} meths)` silently dropped earlier entries when a
`definterface` declared the same method name with
different arities, so only the last arity survived.

Fixes https://github.com/clj-kondo/clj-kondo/issues/2814
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
