### PR TITLE
fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename` (2813)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#2811](https://github.com/clj-kondo/clj-kondo/issues/2811): report correct location for `:missing-map-value` when the malformed map is nested in a set or in map-key position, and no longer suppress subsequent lint errors in the file
-- [#2813](https://github.com/clj-kondo/clj-kondo/issues/2813): fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename`
+- [#2813](https://github.com/clj-kondo/clj-kondo/issues/2813): fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename` ([@jramosg](https://github.com/jramosg))
 - [#2814](https://github.com/clj-kondo/clj-kondo/issues/2814): fix false positive `:protocol-method-arity-mismatch` when a `definterface` declares the same method name with multiple arities ([@jramosg](https://github.com/jramosg))
 
 ## 2026.04.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#2811](https://github.com/clj-kondo/clj-kondo/issues/2811): report correct location for `:missing-map-value` when the malformed map is nested in a set or in map-key position, and no longer suppress subsequent lint errors in the file
+- [#2813](https://github.com/clj-kondo/clj-kondo/issues/2813): fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename`
 
 ## 2026.04.15
 

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -798,6 +798,7 @@
                        (not (utils/linter-disabled? ns :unused-excluded-var)))
             :let [{:keys [lang base-lang referred-vars vars bindings]} ns
                   used (set (concat (keys vars)
+                                    (keys referred-vars)
                                     (map :name (vals referred-vars))
                                     (map :name bindings)))
                   ctx (assoc ctx :lang lang :base-lang base-lang)]

--- a/test/clj_kondo/unused_excluded_var_test.clj
+++ b/test/clj_kondo/unused_excluded_var_test.clj
@@ -62,6 +62,12 @@
   (testing "excluded var shadowed by require"
     (is (empty? (lint! "(ns foo (:refer-clojure :exclude [comp]) (:require [other-ns :refer [comp]])) comp"))))
 
+  (testing "excluded var shadowed by :refer + :rename (issue #2813)"
+    (is (empty? (lint! "(ns foo (:refer-clojure :exclude [defrecord])
+                         (:require [other-ns :refer [defrecord+]
+                                              :rename {defrecord+ defrecord}]))
+                         defrecord"))))
+
   (testing "excluded var not used when shadowed by require with different name"
     (assert-submaps2
      [{:row 2


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

False positive `:unused-excluded-var` when `:refer-clojure` `:exclude` is
used alongside `:refer `with `:rename`.
For renames,  the key of referred-vars is the renamed name, the
`:name` is the original. So the excluded symbol `defrecord` never
appeared in used.

Fixes #2813


- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
