### PR TITLE
Avoid false positive `:redundant-ignore` for inline `:redefined-var`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2621](https://github.com/clj-kondo/clj-kondo/issues/2621): load imports from symlinked config dir ([@walterl](https://github.com/walterl))
 - [#2798](https://github.com/clj-kondo/clj-kondo/issues/2798): report correct filename and error details when `StackOverflowError` occurs during analysis
 
+
 ## 2026.01.19
 
 - [#2735](https://github.com/clj-kondo/clj-kondo/issues/2735): NEW linter: `:duplicate-refer` which warns on duplicate entries in `:refer` of `:require`. ([@jramosg](https://github.com/jramosg))
@@ -53,7 +54,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - `unused-excluded-var`: Add location metadata to excluded vars in `ns-unmap`. This fixes some findings with not location. ([@jramosg](https://github.com/jramosg))
 - [#2747](https://github.com/clj-kondo/clj-kondo/issues/2747): Fix: Gensym bindings in nested syntax quotes are now correctly recognized ([@jramosg](https://github.com/jramosg))when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2746](https://github.com/clj-kondo/clj-kondo/issues/2746): Fix regression: primitive array class syntax (e.g., `byte/1`, `int/2`) now correctly recognized as class literals in type checking ([@jramosg](https://github.com/jramosg))
-- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
+- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg)) 
 - [#2749](https://github.com/clj-kondo/clj-kondo/issues/2749): Fix false positive for throw in CLJS when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2732](https://github.com/clj-kondo/clj-kondo/issues/2732): `unreachable-code`: warn when `:default` does not come last in reader conditionals ([@jramosg](https://github.com/jramosg))
@@ -643,7 +644,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## 2022.04.23
 
 - [#1653](https://github.com/clj-kondo/clj-kondo/issues/1653): new linter `:keyword-binding` - warns when a keyword
-  is used in a `:keys` binding vector. This linter is `:off` by default. See [docs](doc/linters.md#keyword-in-binding-vector).
+is used in a `:keys` binding vector. This linter is `:off` by default. See [docs](doc/linters.md#keyword-in-binding-vector).
 - [#996](https://github.com/clj-kondo/clj-kondo/issues/996): new linter `:discouraged-var`. See [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/linters.md#discouraged-var).
 - [#1618](https://github.com/clj-kondo/clj-kondo/issues/1618): new `:config-in-ns` configuration option. See [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#config-in-ns).
 - Support `:ns-groups` configuration option. See [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#namespace-groups)
@@ -735,7 +736,7 @@ Analysis:
 - Relax `:reduce-without-init` for functions known to be safe [#1519](https://github.com/clj-kondo/clj-kondo/issues/1519)
 - Symbol arg to `fdef` can be arbitrary namespace [#1532](https://github.com/clj-kondo/clj-kondo/issues/1532)
 - Improve potemkin generated var-definition analysis [#1521](https://github.com/clj-kondo/clj-kondo/issues/1521) ([@ericdallo](https://github.com/ericdallo))
-- Stabilize cache version independent from kondo version [#1520](https://github.com/clj-kondo/clj-kondo/issues/1520). This allows you to re-use the cache over multiple kondo versions.
+-  Stabilize cache version independent from kondo version [#1520](https://github.com/clj-kondo/clj-kondo/issues/1520). This allows you to re-use the cache over multiple kondo versions.
 - `:output {:progress true}` should print to stderr [#1523](https://github.com/clj-kondo/clj-kondo/issues/1523)
 - Only print informative messages when `--debug` is enabled. [#1514](https://github.com/clj-kondo/clj-kondo/issues/1514)
 - Add Sublime Text instructions [#827](https://github.com/clj-kondo/clj-kondo/issues/827) ([@KyleErhabor](https://github.com/KyleErhabor))
@@ -757,6 +758,7 @@ Analysis:
 - Fix exclude-defmulti-args for CLJS [#1503](https://github.com/clj-kondo/clj-kondo/issues/1503)
 - Fix warning location of namespaced map [#1475](https://github.com/clj-kondo/clj-kondo/issues/1475)
 - False positive :docstring-no-summary on multiline docstrings [#1507](https://github.com/clj-kondo/clj-kondo/issues/1507)
+
 
 ## 2021.12.16
 
@@ -806,7 +808,7 @@ Analysis:
 - Local `fn` type inference
   [#1412](https://github.com/clj-kondo/clj-kondo/issues/1412)
 - Analysis: allow user to request all or specific metadata be returned [#1280](https://github.com/clj-kondo/clj-kondo/issues/1280) ([@lread](https://github.com/lread))
-- `rseq` called on other type than vector or sorted-map now gives type error [#1432](https://github.com/clj-kondo/clj-kondo/issues/1432)
+-  `rseq` called on other type than vector or sorted-map now gives type error [#1432](https://github.com/clj-kondo/clj-kondo/issues/1432)
 
 ### Enhanced / fixed
 
@@ -1124,7 +1126,7 @@ Thanks [@zilti](https://github.com/zilti), [@dharrigan](https://github.com/dharr
 ## v2020.09.09
 
 Thanks to [@cldwalker](https://github.com/cldwalker), [@bfontaine](https://github.com/bfontaine), [@snoe](https://github.com/snoe), [@andreyorst](https://github.com/andreyorst), [@jeroenvandijk](https://github.com/jeroenvandijk),
-[@jaihindhreddy](https://github.com/jaihindhreddy), [@sittim](https://github.com/sittim) and [@sogaiu](https://github.com/sogaiu) for contributing to this release. Thanks to the people who helped designing the new features in Github issue conversations. Thanks to [Clojurists Together](https://www.clojuriststogether.org/) for sponsoring this release.
+[@jaihindhreddy](https://github.com/jaihindhreddy), [@sittim](https://github.com/sittim) and [@sogaiu](https://github.com/sogaiu) for contributing to this release. Thanks to the people who helped designing the new features in Github issue conversations.  Thanks to [Clojurists Together](https://www.clojuriststogether.org/) for sponsoring this release.
 
 ### New
 
@@ -1132,26 +1134,26 @@ Thanks to [@cldwalker](https://github.com/cldwalker), [@bfontaine](https://githu
   linting an entire classpath. [#632](https://github.com/clj-kondo/clj-kondo/issues/632), [#972](https://github.com/clj-kondo/clj-kondo/issues/972)
 - Detect error when calling a local that's not a function. [#948](https://github.com/clj-kondo/clj-kondo/issues/948)
 
-  ```clojure
-  (let [inc "foo"]
-    (inc 1))
-    ^--- String cannot be called as a function
-  ```
+    ``` clojure
+    (let [inc "foo"]
+      (inc 1))
+      ^--- String cannot be called as a function
+    ```
 
 - Support ignore hints [#872](https://github.com/clj-kondo/clj-kondo/issues/872):
 
-  ```clojure
-  (inc 1 2 3)
-  ^--- clojure.core/inc is called with 3 args but expects 1
+    ``` clojure
+    (inc 1 2 3)
+    ^--- clojure.core/inc is called with 3 args but expects 1
 
-  #_:clj-kondo/ignore
-  (inc 1 2 3)
-  ^--- arity warning ignored
+    #_:clj-kondo/ignore
+    (inc 1 2 3)
+    ^--- arity warning ignored
 
-  #_{:clj-kondo/ignore[:invalid-arity]}
-  (do (inc 1 2 3))
-  ^--- only redundant do is reported, but invalid arity is ignored
-  ```
+    #_{:clj-kondo/ignore[:invalid-arity]}
+    (do (inc 1 2 3))
+    ^--- only redundant do is reported, but invalid arity is ignored
+    ```
 
   Also see [config.md](doc/config.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2811](https://github.com/clj-kondo/clj-kondo/issues/2811): report correct location for `:missing-map-value` when the malformed map is nested in a set or in map-key position, and no longer suppress subsequent lint errors in the file
 - [#2813](https://github.com/clj-kondo/clj-kondo/issues/2813): fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename` ([@jramosg](https://github.com/jramosg))
 - [#2814](https://github.com/clj-kondo/clj-kondo/issues/2814): fix false positive `:protocol-method-arity-mismatch` when a `definterface` declares the same method name with multiple arities ([@jramosg](https://github.com/jramosg))
+- [#2818](https://github.com/clj-kondo/clj-kondo/issues/2818): avoid false positive `:redundant-ignore` for inline `:redefined-var` in intentional redefinition patterns ([@jramosg](https://github.com/jramosg))
 
 ## 2026.04.15
 
@@ -43,7 +44,6 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2621](https://github.com/clj-kondo/clj-kondo/issues/2621): load imports from symlinked config dir ([@walterl](https://github.com/walterl))
 - [#2798](https://github.com/clj-kondo/clj-kondo/issues/2798): report correct filename and error details when `StackOverflowError` occurs during analysis
 
-
 ## 2026.01.19
 
 - [#2735](https://github.com/clj-kondo/clj-kondo/issues/2735): NEW linter: `:duplicate-refer` which warns on duplicate entries in `:refer` of `:require`. ([@jramosg](https://github.com/jramosg))
@@ -53,7 +53,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - `unused-excluded-var`: Add location metadata to excluded vars in `ns-unmap`. This fixes some findings with not location. ([@jramosg](https://github.com/jramosg))
 - [#2747](https://github.com/clj-kondo/clj-kondo/issues/2747): Fix: Gensym bindings in nested syntax quotes are now correctly recognized ([@jramosg](https://github.com/jramosg))when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2746](https://github.com/clj-kondo/clj-kondo/issues/2746): Fix regression: primitive array class syntax (e.g., `byte/1`, `int/2`) now correctly recognized as class literals in type checking ([@jramosg](https://github.com/jramosg))
-- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg)) 
+- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2749](https://github.com/clj-kondo/clj-kondo/issues/2749): Fix false positive for throw in CLJS when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2732](https://github.com/clj-kondo/clj-kondo/issues/2732): `unreachable-code`: warn when `:default` does not come last in reader conditionals ([@jramosg](https://github.com/jramosg))
@@ -643,7 +643,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## 2022.04.23
 
 - [#1653](https://github.com/clj-kondo/clj-kondo/issues/1653): new linter `:keyword-binding` - warns when a keyword
-is used in a `:keys` binding vector. This linter is `:off` by default. See [docs](doc/linters.md#keyword-in-binding-vector).
+  is used in a `:keys` binding vector. This linter is `:off` by default. See [docs](doc/linters.md#keyword-in-binding-vector).
 - [#996](https://github.com/clj-kondo/clj-kondo/issues/996): new linter `:discouraged-var`. See [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/linters.md#discouraged-var).
 - [#1618](https://github.com/clj-kondo/clj-kondo/issues/1618): new `:config-in-ns` configuration option. See [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#config-in-ns).
 - Support `:ns-groups` configuration option. See [docs](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#namespace-groups)
@@ -735,7 +735,7 @@ Analysis:
 - Relax `:reduce-without-init` for functions known to be safe [#1519](https://github.com/clj-kondo/clj-kondo/issues/1519)
 - Symbol arg to `fdef` can be arbitrary namespace [#1532](https://github.com/clj-kondo/clj-kondo/issues/1532)
 - Improve potemkin generated var-definition analysis [#1521](https://github.com/clj-kondo/clj-kondo/issues/1521) ([@ericdallo](https://github.com/ericdallo))
--  Stabilize cache version independent from kondo version [#1520](https://github.com/clj-kondo/clj-kondo/issues/1520). This allows you to re-use the cache over multiple kondo versions.
+- Stabilize cache version independent from kondo version [#1520](https://github.com/clj-kondo/clj-kondo/issues/1520). This allows you to re-use the cache over multiple kondo versions.
 - `:output {:progress true}` should print to stderr [#1523](https://github.com/clj-kondo/clj-kondo/issues/1523)
 - Only print informative messages when `--debug` is enabled. [#1514](https://github.com/clj-kondo/clj-kondo/issues/1514)
 - Add Sublime Text instructions [#827](https://github.com/clj-kondo/clj-kondo/issues/827) ([@KyleErhabor](https://github.com/KyleErhabor))
@@ -757,7 +757,6 @@ Analysis:
 - Fix exclude-defmulti-args for CLJS [#1503](https://github.com/clj-kondo/clj-kondo/issues/1503)
 - Fix warning location of namespaced map [#1475](https://github.com/clj-kondo/clj-kondo/issues/1475)
 - False positive :docstring-no-summary on multiline docstrings [#1507](https://github.com/clj-kondo/clj-kondo/issues/1507)
-
 
 ## 2021.12.16
 
@@ -807,7 +806,7 @@ Analysis:
 - Local `fn` type inference
   [#1412](https://github.com/clj-kondo/clj-kondo/issues/1412)
 - Analysis: allow user to request all or specific metadata be returned [#1280](https://github.com/clj-kondo/clj-kondo/issues/1280) ([@lread](https://github.com/lread))
--  `rseq` called on other type than vector or sorted-map now gives type error [#1432](https://github.com/clj-kondo/clj-kondo/issues/1432)
+- `rseq` called on other type than vector or sorted-map now gives type error [#1432](https://github.com/clj-kondo/clj-kondo/issues/1432)
 
 ### Enhanced / fixed
 
@@ -1125,7 +1124,7 @@ Thanks [@zilti](https://github.com/zilti), [@dharrigan](https://github.com/dharr
 ## v2020.09.09
 
 Thanks to [@cldwalker](https://github.com/cldwalker), [@bfontaine](https://github.com/bfontaine), [@snoe](https://github.com/snoe), [@andreyorst](https://github.com/andreyorst), [@jeroenvandijk](https://github.com/jeroenvandijk),
-[@jaihindhreddy](https://github.com/jaihindhreddy), [@sittim](https://github.com/sittim) and [@sogaiu](https://github.com/sogaiu) for contributing to this release. Thanks to the people who helped designing the new features in Github issue conversations.  Thanks to [Clojurists Together](https://www.clojuriststogether.org/) for sponsoring this release.
+[@jaihindhreddy](https://github.com/jaihindhreddy), [@sittim](https://github.com/sittim) and [@sogaiu](https://github.com/sogaiu) for contributing to this release. Thanks to the people who helped designing the new features in Github issue conversations. Thanks to [Clojurists Together](https://www.clojuriststogether.org/) for sponsoring this release.
 
 ### New
 
@@ -1133,26 +1132,26 @@ Thanks to [@cldwalker](https://github.com/cldwalker), [@bfontaine](https://githu
   linting an entire classpath. [#632](https://github.com/clj-kondo/clj-kondo/issues/632), [#972](https://github.com/clj-kondo/clj-kondo/issues/972)
 - Detect error when calling a local that's not a function. [#948](https://github.com/clj-kondo/clj-kondo/issues/948)
 
-    ``` clojure
-    (let [inc "foo"]
-      (inc 1))
-      ^--- String cannot be called as a function
-    ```
+  ```clojure
+  (let [inc "foo"]
+    (inc 1))
+    ^--- String cannot be called as a function
+  ```
 
 - Support ignore hints [#872](https://github.com/clj-kondo/clj-kondo/issues/872):
 
-    ``` clojure
-    (inc 1 2 3)
-    ^--- clojure.core/inc is called with 3 args but expects 1
+  ```clojure
+  (inc 1 2 3)
+  ^--- clojure.core/inc is called with 3 args but expects 1
 
-    #_:clj-kondo/ignore
-    (inc 1 2 3)
-    ^--- arity warning ignored
+  #_:clj-kondo/ignore
+  (inc 1 2 3)
+  ^--- arity warning ignored
 
-    #_{:clj-kondo/ignore[:invalid-arity]}
-    (do (inc 1 2 3))
-    ^--- only redundant do is reported, but invalid arity is ignored
-    ```
+  #_{:clj-kondo/ignore[:invalid-arity]}
+  (do (inc 1 2 3))
+  ^--- only redundant do is reported, but invalid arity is ignored
+  ```
 
   Also see [config.md](doc/config.md).
 

--- a/extract/clj_kondo/impl/extract_var_info.clj
+++ b/extract/clj_kondo/impl/extract_var_info.clj
@@ -61,6 +61,7 @@
        :files (atom 0)
        :findings findings
        :ignores (atom {})
+       :redefined-var-ignore-ids (atom {})
        :java-class-usages (atom [])
        :namespaces namespaces
        :used-namespaces (atom {:clj #{}
@@ -86,6 +87,7 @@
        :files (atom 0)
        :findings (atom [])
        :ignores (atom {})
+        :redefined-var-ignore-ids (atom {})
        :java-class-usages (atom [])
        :namespaces namespaces
        :used-namespaces (atom {:clj #{}

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -227,6 +227,7 @@
                  ;; memoized version of re-find that takes a pattern string and a match string
                  ;; regex creation is cached
                  ;; matches on regex are cached
+                 #_{:clj-kondo/ignore [:discouraged-var]}
                  (let [re-pattern-memo (utils/memoize' re-pattern)]
                    (utils/memoize' (fn [pattern-str file-str]
                                      (re-find (re-pattern-memo pattern-str) file-str))))}
@@ -263,18 +264,19 @@
                     (l/lint-class-usage ctx idacs)
                     (l/lint-protocol-impls! ctx idacs)
                     ;; redundant ignore should go last!
-                    (l/lint-redundant-ignores ctx))))
+                    (l/lint-redundant-ignores ctx)
+                    )))
             _ (when custom-lint-fn
                 (binding [utils/*ctx* ctx]
                   (custom-lint-fn (cond->
-                                   {:config config
-                                    :reg-finding!
-                                    (fn [m]
-                                      (findings/reg-finding!
-                                       (assoc utils/*ctx*
-                                              :lang (or (:lang m)
-                                                        (core-impl/lang-from-file
-                                                         (:filename m) lang))) m))}
+                                      {:config config
+                                       :reg-finding!
+                                       (fn [m]
+                                         (findings/reg-finding!
+                                          (assoc utils/*ctx*
+                                                 :lang (or (:lang m)
+                                                           (core-impl/lang-from-file
+                                                            (:filename m) lang))) m))}
                                     analysis-cfg
                                     (assoc :analysis @analysis)))))
             all-findings @findings
@@ -285,9 +287,9 @@
             duration (- (System/currentTimeMillis) start-time)
             summary (assoc summary :duration duration :files @files)]
         (cond->
-         {:findings all-findings
-          :config config
-          :summary summary}
+            {:findings all-findings
+             :config config
+             :summary summary}
           analysis
           (assoc :analysis @analysis))))))
 

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -197,6 +197,7 @@
                  :used-namespaces used-nss
                  :file-analyzed-fn file-analyzed-fn
                  :ignores (atom {})
+                 :redefined-var-ignore-ids (atom {})
                  :id-gen (when analyze-locals? (atom 0))
                  :analyze-var-usages? analyze-var-usages?
                  :analyze-locals? analyze-locals?

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -227,7 +227,6 @@
                  ;; memoized version of re-find that takes a pattern string and a match string
                  ;; regex creation is cached
                  ;; matches on regex are cached
-                 #_{:clj-kondo/ignore [:discouraged-var]}
                  (let [re-pattern-memo (utils/memoize' re-pattern)]
                    (utils/memoize' (fn [pattern-str file-str]
                                      (re-find (re-pattern-memo pattern-str) file-str))))}
@@ -264,19 +263,18 @@
                     (l/lint-class-usage ctx idacs)
                     (l/lint-protocol-impls! ctx idacs)
                     ;; redundant ignore should go last!
-                    (l/lint-redundant-ignores ctx)
-                    )))
+                    (l/lint-redundant-ignores ctx))))
             _ (when custom-lint-fn
                 (binding [utils/*ctx* ctx]
                   (custom-lint-fn (cond->
-                                      {:config config
-                                       :reg-finding!
-                                       (fn [m]
-                                         (findings/reg-finding!
-                                          (assoc utils/*ctx*
-                                                 :lang (or (:lang m)
-                                                           (core-impl/lang-from-file
-                                                            (:filename m) lang))) m))}
+                                   {:config config
+                                    :reg-finding!
+                                    (fn [m]
+                                      (findings/reg-finding!
+                                       (assoc utils/*ctx*
+                                              :lang (or (:lang m)
+                                                        (core-impl/lang-from-file
+                                                         (:filename m) lang))) m))}
                                     analysis-cfg
                                     (assoc :analysis @analysis)))))
             all-findings @findings
@@ -287,9 +285,9 @@
             duration (- (System/currentTimeMillis) start-time)
             summary (assoc summary :duration duration :files @files)]
         (cond->
-            {:findings all-findings
-             :config config
-             :summary summary}
+         {:findings all-findings
+          :config config
+          :summary summary}
           analysis
           (assoc :analysis @analysis))))))
 

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -199,7 +199,7 @@
                                    filename (let [thing (if (meta var-sym) var-sym expr)]
                                               thing)
                                    :syntax
-                                   (str "Symbols starting or ending with dot (.) are reserved by Clojure: " var-sym))))
+                                   (str "Symbols starting or ending with dot (.) are reserved by Clojure: " var-sym) )))
      (when-not (:skip-reg-var ctx)
        (let [;; don't use reg-finding! in swap since contention can cause it to fire multiple times
              [old-namespaces _]
@@ -218,10 +218,10 @@
                                  (update :vars assoc
                                          var-sym
                                          (assoc
-                                          (merge metadata (select-keys
-                                                           prev-var
-                                                           [:row :col :end-row :end-col]))
-                                          :top-ns top-ns))
+                                           (merge metadata (select-keys
+                                                            prev-var
+                                                            [:row :col :end-row :end-col]))
+                                           :top-ns top-ns))
                                  (assoc :classfiles
                                         (if classfile
                                           (update classfiles classfile (fnil conj []) var-sym)
@@ -500,19 +500,19 @@
     (let [ns-groups (cons unresolved-ns (config/ns-groups-eduction ctx config unresolved-ns filename))
           excluded (config/unresolved-namespace-excluded-config config)]
       (when-not
-       (or
-        (some #(config/unresolved-namespace-excluded excluded %)
-              ns-groups)
-        ;; unresolved namespaces in an excluded unresolved symbols call are not reported
-        (config/unresolved-symbol-excluded ctx config callstack :dummy))
-        (let [unresolved-ns (vary-meta unresolved-ns
-                                       ;; since the user namespaces is present in each filesrc/clj_kondo/impl/namespace.clj
-                                       ;; we must include the filename here
-                                       ;; see #73
-                                       assoc :filename filename)]
-          (swap! namespaces update-in [base-lang lang ns-sym :unresolved-namespaces unresolved-ns]
-                 (fnil conj [])
-                 unresolved-ns))))))
+          (or
+           (some #(config/unresolved-namespace-excluded excluded %)
+                 ns-groups)
+           ;; unresolved namespaces in an excluded unresolved symbols call are not reported
+           (config/unresolved-symbol-excluded ctx config callstack :dummy))
+          (let [unresolved-ns (vary-meta unresolved-ns
+                                         ;; since the user namespaces is present in each filesrc/clj_kondo/impl/namespace.clj
+                                         ;; we must include the filename here
+                                         ;; see #73
+                                         assoc :filename filename)]
+            (swap! namespaces update-in [base-lang lang ns-sym :unresolved-namespaces unresolved-ns]
+                   (fnil conj [])
+                   unresolved-ns))))))
 
 (defn get-namespace [ctx base-lang lang ns-sym]
   (get-in @(:namespaces ctx) [base-lang lang ns-sym]))
@@ -746,9 +746,9 @@
                     (when alias?
                       (reg-used-alias! ctx ns-name ns-sym))
                     (cond->
-                     {:ns ns*
-                      :name var-name
-                      :interop? (and cljs? (boolean interop))}
+                        {:ns ns*
+                         :name var-name
+                         :interop? (and cljs? (boolean interop))}
                       alias?
                       (assoc :alias ns-sym)
                       core?
@@ -885,14 +885,15 @@
                          :allow-forward-reference? (:in-comment ctx)
                          :clojure-excluded? clojure-excluded?}))))))))))))
 
-#_(do
-    (def resolve-name* resolve-name)
+#_
+(do
+  (def resolve-name* resolve-name)
 
-    (defn resolve-name [ctx call? ns-name name-sym expr]
-      (prn :resolve)
-      (let [x (resolve-name* ctx call? ns-name name-sym expr)]
-        (prn x)
-        x)))
+  (defn resolve-name [ctx call? ns-name name-sym expr]
+    (prn :resolve)
+    (let [x (resolve-name* ctx call? ns-name name-sym expr)]
+      (prn x)
+      x)))
 
 ;;;; Scratch
 

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -135,6 +135,31 @@
          "/"
          (->> name clojure.core/name str/lower-case))))
 
+(defn- mark-ignores-used-by-ids! [{:keys [ignores]} ignore-ids]
+  (letfn [(mark-used [entry]
+            (cond-> entry
+              (ignore-ids (:clj-kondo/ignore-id entry))
+              (assoc :used true)))]
+    (when (seq ignore-ids)
+      (swap! ignores
+             #(utils/update-vals %
+                                 (fn [by-lang]
+                                   (utils/update-vals
+                                    by-lang (fn [entries] (mapv mark-used entries)))))))))
+
+(defn- reg-redefined-var-ignore-id!
+  [{:keys [redefined-var-ignore-ids]} base-lang lang ns-sym var-sym ignore-id]
+  (when ignore-id
+    (swap! redefined-var-ignore-ids update-in
+           [base-lang lang ns-sym var-sym] (fnil conj #{}) ignore-id)))
+
+(defn- mark-redefined-var-ignores-used!
+  [{:keys [redefined-var-ignore-ids] :as ctx} base-lang lang ns-sym var-sym]
+  (let [path [base-lang lang ns-sym var-sym]]
+    (when-let [ignore-ids (get-in @redefined-var-ignore-ids path)]
+      (mark-ignores-used-by-ids! ctx ignore-ids)
+      (swap! redefined-var-ignore-ids update-in (pop path) dissoc var-sym))))
+
 (defn reg-var!
   ([ctx ns-sym var-sym expr]
    (reg-var! ctx ns-sym var-sym expr nil))
@@ -174,7 +199,7 @@
                                    filename (let [thing (if (meta var-sym) var-sym expr)]
                                               thing)
                                    :syntax
-                                   (str "Symbols starting or ending with dot (.) are reserved by Clojure: " var-sym) )))
+                                   (str "Symbols starting or ending with dot (.) are reserved by Clojure: " var-sym))))
      (when-not (:skip-reg-var ctx)
        (let [;; don't use reg-finding! in swap since contention can cause it to fire multiple times
              [old-namespaces _]
@@ -193,10 +218,10 @@
                                  (update :vars assoc
                                          var-sym
                                          (assoc
-                                           (merge metadata (select-keys
-                                                            prev-var
-                                                            [:row :col :end-row :end-col]))
-                                           :top-ns top-ns))
+                                          (merge metadata (select-keys
+                                                           prev-var
+                                                           [:row :col :end-row :end-col]))
+                                          :top-ns top-ns))
                                  (assoc :classfiles
                                         (if classfile
                                           (update classfiles classfile (fnil conj []) var-sym)
@@ -212,7 +237,12 @@
                  classfiles (:classfiles ns)
                  classfile (var-classfile metadata)
                  hard-def? (and (not (:declared metadata))
-                                (not (:in-comment ctx)))]
+                                (not (:in-comment ctx)))
+                 redefined-var-ignore? (utils/ignored? expr :redefined-var)
+                 ignore-id (:clj-kondo/ignore-id m)]
+             (when (and top-level? hard-def? redefined-var-ignore?)
+               (reg-redefined-var-ignore-id!
+                ctx base-lang lang ns-sym var-sym ignore-id))
              (when (identical? :clj lang)
                (when-let [clashing-vars (->> (get classfiles classfile)
                                              (remove #{var-sym})
@@ -245,6 +275,8 @@
                                     core-ns)))]
                    (when (or (pos? curr-var-count)
                              (not= ns-sym redefined-ns))
+                     (mark-redefined-var-ignores-used!
+                      ctx base-lang lang ns-sym var-sym)
                      (findings/reg-finding!
                       ctx
                       (node->line filename
@@ -468,19 +500,19 @@
     (let [ns-groups (cons unresolved-ns (config/ns-groups-eduction ctx config unresolved-ns filename))
           excluded (config/unresolved-namespace-excluded-config config)]
       (when-not
-          (or
-           (some #(config/unresolved-namespace-excluded excluded %)
-                 ns-groups)
-           ;; unresolved namespaces in an excluded unresolved symbols call are not reported
-           (config/unresolved-symbol-excluded ctx config callstack :dummy))
-          (let [unresolved-ns (vary-meta unresolved-ns
-                                         ;; since the user namespaces is present in each filesrc/clj_kondo/impl/namespace.clj
-                                         ;; we must include the filename here
-                                         ;; see #73
-                                         assoc :filename filename)]
-            (swap! namespaces update-in [base-lang lang ns-sym :unresolved-namespaces unresolved-ns]
-                   (fnil conj [])
-                   unresolved-ns))))))
+       (or
+        (some #(config/unresolved-namespace-excluded excluded %)
+              ns-groups)
+        ;; unresolved namespaces in an excluded unresolved symbols call are not reported
+        (config/unresolved-symbol-excluded ctx config callstack :dummy))
+        (let [unresolved-ns (vary-meta unresolved-ns
+                                       ;; since the user namespaces is present in each filesrc/clj_kondo/impl/namespace.clj
+                                       ;; we must include the filename here
+                                       ;; see #73
+                                       assoc :filename filename)]
+          (swap! namespaces update-in [base-lang lang ns-sym :unresolved-namespaces unresolved-ns]
+                 (fnil conj [])
+                 unresolved-ns))))))
 
 (defn get-namespace [ctx base-lang lang ns-sym]
   (get-in @(:namespaces ctx) [base-lang lang ns-sym]))
@@ -714,9 +746,9 @@
                     (when alias?
                       (reg-used-alias! ctx ns-name ns-sym))
                     (cond->
-                        {:ns ns*
-                         :name var-name
-                         :interop? (and cljs? (boolean interop))}
+                     {:ns ns*
+                      :name var-name
+                      :interop? (and cljs? (boolean interop))}
                       alias?
                       (assoc :alias ns-sym)
                       core?
@@ -853,15 +885,14 @@
                          :allow-forward-reference? (:in-comment ctx)
                          :clojure-excluded? clojure-excluded?}))))))))))))
 
-#_
-(do
-  (def resolve-name* resolve-name)
+#_(do
+    (def resolve-name* resolve-name)
 
-  (defn resolve-name [ctx call? ns-name name-sym expr]
-    (prn :resolve)
-    (let [x (resolve-name* ctx call? ns-name name-sym expr)]
-      (prn x)
-      x)))
+    (defn resolve-name [ctx call? ns-name name-sym expr]
+      (prn :resolve)
+      (let [x (resolve-name* ctx call? ns-name name-sym expr)]
+        (prn x)
+        x)))
 
 ;;;; Scratch
 

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -32986,6 +32986,18 @@
   :langs (),
   :message "Use defn instead of def + fn",
   :row 4}
+ {:end-row 230,
+  :type :redundant-ignore,
+  :level :info,
+  :lang :clj,
+  :filename "src/clj_kondo/core.clj",
+  :linters nil,
+  :col 20,
+  :end-col 58,
+  :cljc nil,
+  :langs (:clj),
+  :message "Redundant ignore",
+  :row 230}
  {:end-row 91,
   :type :unresolved-var,
   :level :warning,

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -32986,18 +32986,6 @@
   :langs (),
   :message "Use defn instead of def + fn",
   :row 4}
- {:end-row 229,
-  :type :redundant-ignore,
-  :level :info,
-  :lang :clj,
-  :filename "src/clj_kondo/core.clj",
-  :linters nil,
-  :col 20,
-  :end-col 58,
-  :cljc nil,
-  :langs (:clj),
-  :message "Redundant ignore",
-  :row 229}
  {:end-row 91,
   :type :unresolved-var,
   :level :warning,

--- a/test/clj_kondo/impl/analyzer_test.clj
+++ b/test/clj_kondo/impl/analyzer_test.clj
@@ -70,6 +70,7 @@
              :namespaces (atom {})
              :findings (atom [])
              :ignores (atom {})
+             :redefined-var-ignore-ids (atom {})
              :base-lang :clj
              :lang :clj
              :bindings {}
@@ -121,6 +122,7 @@
                              :findings (atom [])
                              :namespaces (atom {})
                              :ignores (atom {})
+                             :redefined-var-ignore-ids (atom {})
                              :bindings {}
                              :main-ns (atom nil)}]
                     (ana/analyze-input (assoc ctx :filename "test.clj") "test.clj" "file:test.clj" source :clj false)

--- a/test/clj_kondo/redundant_ignore_test.clj
+++ b/test/clj_kondo/redundant_ignore_test.clj
@@ -1,5 +1,6 @@
 (ns clj-kondo.redundant-ignore-test
-  (:require [clj-kondo.test-utils :refer [lint! assert-submaps2]]
+  (:require [clj-kondo.test-utils :refer [lint! assert-submaps2 with-temp-dir]]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]))
 
 (def config {:linters {:redundant-ignore {:level :warning}
@@ -42,3 +43,43 @@
   [#?(:cljs z)]) ;; x is only used in cljs, but unused is ignored for clj, so no warning
 "
                      config "--filename" "foo.cljc"))))
+
+(deftest issue-2818-redundant-ignore-cross-file-redefined-var-test
+  (with-temp-dir [tmp "clj-kondo-issue-2818"]
+    (let [dev-file (io/file tmp "src" "demo" "env_dev.clj")
+          prod-file (io/file tmp "src" "demo" "env_prod.clj")]
+      (.mkdirs (.getParentFile dev-file))
+      (spit dev-file
+            (str "(ns demo.env)\n\n"
+                 "#_{:clj-kondo/ignore [:redefined-var]}\n"
+                 "(def defaults {:mode :dev})\n"))
+      (spit prod-file
+            (str "(ns demo.env)\n\n"
+                 "(def defaults {:mode :prod})\n"))
+      (let [findings (lint! [dev-file prod-file] config)]
+        (is (empty? (filter #(= "Redundant ignore" (:message %)) findings)))))))
+
+(deftest issue-2818-redundant-ignore-same-file-redefined-var-test
+  (is (empty?
+       (filter #(= "Redundant ignore" (:message %))
+               (lint! "(ns demo.same-file-control)
+
+#_{:clj-kondo/ignore [:redefined-var]}
+(def defaults {:mode :a})
+
+#_{:clj-kondo/ignore [:redefined-var]}
+(def defaults {:mode :b})"
+                      config)))))
+
+(deftest issue-2818-redundant-ignore-truly-redefined-var-test
+  (assert-submaps2
+   '({:file "<stdin>"
+      :row 3
+      :col 3
+      :level :warning
+      :message "Redundant ignore"})
+   (lint! "(ns demo.truly-redundant)
+
+#_{:clj-kondo/ignore [:redefined-var]}
+(def defaults {:mode :only-once})"
+          config)))


### PR DESCRIPTION
This change introduces mechanisms to track and mark ignored IDs for redefined vars. It enhances the linting process by ensuring that redundant ignores are properly identified and managed, improving linting accuracy and reducing false positives in the analysis.

Fixes #2818

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
