### PR TITLE
don't omit findings when :cljc :features specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2813](https://github.com/clj-kondo/clj-kondo/issues/2813): fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename` ([@jramosg](https://github.com/jramosg))
 - [#2814](https://github.com/clj-kondo/clj-kondo/issues/2814): fix false positive `:protocol-method-arity-mismatch` when a `definterface` declares the same method name with multiple arities ([@jramosg](https://github.com/jramosg))
 - [#2817](https://github.com/clj-kondo/clj-kondo/issues/2817): warn on `recur` inside a vector, map or set literal — `recur` is never in tail position there
+- [##2821](https://github.com/clj-kondo/clj-kondo/issues/2821): do not omit findings when `:cljc` `:features` specified ([@lread](https://github.com/lread))
 
 ## 2026.04.15
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3685,10 +3685,8 @@
               ctx (assoc ctx
                          :inline-configs (atom [])
                          :main-ns (atom nil))
-              cljc-config (:cljc config)
               features (when (identical? :cljc lang)
-                         (or (:features cljc-config)
-                             [:clj :cljs]))
+                         (config/cljc-features config ))
               parsed (binding [*reader-features* features]
                        (p/parse-string input))
               fname (fs/file-name filename)

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -528,6 +528,11 @@
 (defn deprecated-namespace-excluded? [config required]
   (contains? config required))
 
+(defn cljc-features
+  [config]
+  (or (some-> config :cljc :features)
+      [:clj :cljs]))
+
 ;;;; Scratch
 
 ;; (comment

--- a/src/clj_kondo/impl/core.clj
+++ b/src/clj_kondo/impl/core.clj
@@ -715,23 +715,25 @@
   (let [print-debug? (:debug config)
         filter-output (not-empty (-> config :output :include-files))
         remove-output (not-empty (-> config :output :exclude-files))
-        re-find (:re-find-memo ctx)]
+        re-find (:re-find-memo ctx)
+        cljc-features-count (count (config/cljc-features config))]
     (for [[[_filename _row _col type cljc] findings] findings
-          :when (or
-                 ;; always pass when not .cljc
-                 (not cljc)
-                 ;; always pass when it's not one of these
-                 (and (not= :redundant-do type)
-                      (not= :redundant-call type)
-                      (not= :redundant-let type)
-                      (not= :redundant-let-binding type)
-                      (not= :single-logical-operand type)
-                      (not= :redundant-nested-call type)
-                      (not= :redundant-ignore type)
-                      (not= :redundant-fn-wrapper type)
-                      (not= :unused-excluded-var type))
-                 ;; but if we get here, then the amount of findings has to be bigger than 1
-                 (> (count findings) 1))
+          :when (or ;; keep findings when:
+                  ;; 1) not multi-dialect
+                  (not cljc)
+                  ;; 2) not linter of interest (and multi-dialect)
+                  (and (not= :redundant-do type)
+                       (not= :redundant-call type)
+                       (not= :redundant-let type)
+                       (not= :redundant-let-binding type)
+                       (not= :single-logical-operand type)
+                       (not= :redundant-nested-call type)
+                       (not= :redundant-ignore type)
+                       (not= :redundant-fn-wrapper type)
+                       (not= :unused-excluded-var type))
+                  ;; 3) findings count matches features analyzed (and multi-dialect and linter of interest)
+                  ;;    (we exclude when all dialects do not agree on finding for a linter of interest).
+                  (= (count findings) cljc-features-count))
           f (collapse-cljc-findings findings)
           :let [filename (:filename f)
                 tp (:type f)

--- a/test/clj_kondo/redundant_nested_call_test.clj
+++ b/test/clj_kondo/redundant_nested_call_test.clj
@@ -29,3 +29,15 @@
   (is
    (empty?
     (lint! "(-> {:a 1} (merge {:b 2}) (merge {:b 3}))"))))
+
+(deftest redundant-nested-call-cljc-test
+  (doseq [config [{}
+                  {:cljc {:features [:clj :cljs]}}
+                  {:cljc {:features [:cljs]}}
+                  {:cljc {:features [:clj]}}]]
+    (testing (str "config: " config)
+      (assert-submaps2
+        [{:file "foo.cljc" :row 1 :col 8 :level :info :message "Redundant nested call: str"}]
+        (lint! "(str 1 (str 2))"
+               config
+               "--filename" "foo.cljc")))))


### PR DESCRIPTION
For specific linters, clj-kondo only includes a finding if that finding is the same across all configured `:cljc` `:features`.

Code no longer assumes that `:cljc` `:features` config is default value.

Also: I found the logic a bit hard to understand in `filter-findings`, so added some comments.

Fixes #2821

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
