### PR TITLE
dev: adapt env to home-config-test expectations

### DIFF
--- a/script/test
+++ b/script/test
@@ -2,6 +2,9 @@
 
 set -eo pipefail
 
+# home-config-test currently relies on this env var not being set:
+unset XDG_CONFIG_HOME
+
 # shellcheck disable=1091
 source script/extract-versions
 


### PR DESCRIPTION
`home-config-test` will fail if `XDF_CONFIG_HOME` env var is set, so unset it before launching tests.

Closes #2826

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
