### PR TITLE
Add new linter for conditional build up

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -16,6 +16,7 @@ configuration. For general configurations options, go [here](config.md).
         - [Case symbol test constant](#case-symbol-test-constant)
     - [Clj-kondo config](#clj-kondo-config)
     - [Cond-else](#cond-else)
+    - [Conditional build up] (#conditional-build-up)
     - [Condition always true](#condition-always-true)
     - [Conflicting-alias](#conflicting-alias)
     - [Consistent-alias](#consistent-alias)

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -16,7 +16,7 @@ configuration. For general configurations options, go [here](config.md).
         - [Case symbol test constant](#case-symbol-test-constant)
     - [Clj-kondo config](#clj-kondo-config)
     - [Cond-else](#cond-else)
-    - [Conditional build up] (#conditional-build-up)
+    - [Conditional build-up](#conditional-build-up)
     - [Condition always true](#condition-always-true)
     - [Conflicting-alias](#conflicting-alias)
     - [Consistent-alias](#consistent-alias)
@@ -303,6 +303,28 @@ doesn't check for literally `true` values of vars since this is often a dev/prod
 *Example trigger:* `(if odd? :odd :even)`.
 
 *Example message:* `Condition always true`.
+
+### Conditional build-up
+
+*Keyword:* `:conditional-build-up`.
+
+*Description:* warn when a `let` repeatedly rebinds the same local map using forms like `(if pred (assoc m ...) m)`, which can often be written more clearly with `cond->`.
+
+*Default level:* `:info`.
+
+*Example trigger:*
+
+``` clojure
+(let [m {}
+      m (if (:a input) (assoc m :a 1) m)
+      m (if (:b input) (assoc m :b 2) m)
+      m (if (:c input) (assoc m :c 3) m)
+      m (if (:d input) (assoc m :d 4) m)
+      m (if (:e input) (assoc m :e 5) m)]
+  m)
+```
+
+*Example message:* `Prefer cond-> to build a map with successive conditional assocs.`
 
 ### Conflicting-alias
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -816,6 +816,95 @@
                                             :message (str "Redundant let binding: " binding-val)))))
       (when (seq rest-bindings) (recur rest-bindings)))))
 
+(defn- conditional-build-up-step?
+  [value-node map-sym]
+  (when (and value-node map-sym (= :list (tag value-node)))
+    (let [if-children (:children value-node)]
+      (when (= 4 (count if-children))
+        (let [if-operator (nth if-children 0)
+              then-branch (nth if-children 2)
+              else-branch (nth if-children 3)]
+          (when (and (= :token (tag if-operator))
+                     (= 'if (:value if-operator))
+                     (= :list (tag then-branch))
+                     else-branch)
+            (let [then-children (:children then-branch)
+                  then-operator (first then-children)
+                  assoc-map-arg (second then-children)]
+              (boolean
+               (and (<= 4 (count then-children))
+                    (= :token (tag then-operator))
+                    (= 'assoc (:value then-operator))
+                    (= :token (tag assoc-map-arg))
+                    (= map-sym (:value assoc-map-arg))
+                    (= :token (tag else-branch))
+                    (= map-sym (:value else-branch)))))))))))
+
+(defn- references-symbol?
+  [node sym]
+  (when node
+    (or (and (= :token (tag node))
+             (= sym (:value node)))
+        (some #(references-symbol? % sym) (:children node)))))
+
+(defn- base-binding-candidate?
+  [value-node map-sym]
+  (and value-node
+       (not (conditional-build-up-step? value-node map-sym))
+       (not (references-symbol? value-node map-sym))))
+
+(defn- lint-conditional-build-up!
+  [ctx binding-vector-node]
+  (when (and binding-vector-node
+             (not (linter-disabled? ctx :conditional-build-up))
+             (= :vector (tag binding-vector-node)))
+    (loop [vec-children (:children binding-vector-node)
+           current-name-sym nil
+           has-base-binding? false
+           conditional-rebind-count 0
+           best-count 0]
+      (if (< (count vec-children) 2)
+        (when (> (max conditional-rebind-count best-count) 1)
+          (findings/reg-finding!
+           ctx
+           (node->line (:filename ctx) binding-vector-node :conditional-build-up
+                       "Prefer cond-> to build a map with successive conditional assocs.")))
+        (let [name-node (first vec-children)
+              value-node (second vec-children)
+              rest-children (nnext vec-children)
+              new-name-sym (when (and name-node (= :token (tag name-node)))
+                             (let [v (:value name-node)]
+                               (when (simple-symbol? v) v)))
+              best-count' (max best-count conditional-rebind-count)]
+          (cond
+            (or (nil? new-name-sym)
+                (nil? value-node))
+            (recur rest-children nil false 0 best-count')
+
+            (or (nil? current-name-sym)
+                (not= new-name-sym current-name-sym))
+            (recur rest-children
+                   new-name-sym
+                   (base-binding-candidate? value-node new-name-sym)
+                   0
+                   best-count')
+
+            (and has-base-binding?
+                 (conditional-build-up-step? value-node new-name-sym))
+            (let [count' (inc conditional-rebind-count)]
+              (recur rest-children
+                     new-name-sym
+                     has-base-binding?
+                     count'
+                     (max best-count' count')))
+
+            :else
+            (recur rest-children
+                   new-name-sym
+                   (base-binding-candidate? value-node new-name-sym)
+                   0
+                   best-count')))))))
+
 (defn analyze-let-like-bindings [ctx binding-vector scoped-expr]
   (let [resolved-as-clojure-var-name (:resolved-as-clojure-var-name ctx)
         for-like? (one-of resolved-as-clojure-var-name [for doseq])
@@ -959,7 +1048,9 @@
         analyzed))))
 
 (defn analyze-let [ctx expr]
-  (analyze-redundant-bindings ctx (-> expr :children second))
+  (let [bv (-> expr :children second)]
+    (analyze-redundant-bindings ctx bv)
+    (lint-conditional-build-up! ctx bv))
   (analyze-like-let ctx expr))
 
 (defn analyze-do [{:keys [filename callstack] :as ctx} expr]

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -816,16 +816,25 @@
                                             :message (str "Redundant let binding: " binding-val)))))
       (when (seq rest-bindings) (recur rest-bindings)))))
 
+(defn- references-symbol?
+  [node sym]
+  (when node
+    (or (and (= :token (tag node))
+             (= sym (:value node)))
+        (some #(references-symbol? % sym) (:children node)))))
+
 (defn- conditional-build-up-step?
   [value-node map-sym]
   (when (and value-node map-sym (= :list (tag value-node)))
     (let [if-children (:children value-node)]
       (when (= 4 (count if-children))
         (let [if-operator (nth if-children 0)
+              if-predicate (nth if-children 1)
               then-branch (nth if-children 2)
               else-branch (nth if-children 3)]
           (when (and (= :token (tag if-operator))
                      (= 'if (:value if-operator))
+                     (not (references-symbol? if-predicate map-sym))
                      (= :list (tag then-branch))
                      else-branch)
             (let [then-children (:children then-branch)
@@ -839,13 +848,6 @@
                     (= map-sym (:value assoc-map-arg))
                     (= :token (tag else-branch))
                     (= map-sym (:value else-branch)))))))))))
-
-(defn- references-symbol?
-  [node sym]
-  (when node
-    (or (and (= :token (tag node))
-             (= sym (:value node)))
-        (some #(references-symbol? % sym) (:children node)))))
 
 (defn- base-binding-candidate?
   [value-node map-sym]

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -195,7 +195,8 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
-              :unquote-not-syntax-quoted {:level :warning}}
+              :unquote-not-syntax-quoted {:level :warning}
+              :conditional-build-up {:level :info}}
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>

--- a/test/clj_kondo/conditional_build_up_test.clj
+++ b/test/clj_kondo/conditional_build_up_test.clj
@@ -1,0 +1,135 @@
+(ns clj-kondo.conditional-build-up-test
+  (:require
+    [clj-kondo.test-utils :refer [lint! assert-submaps2]]
+    [clojure.test :refer [deftest is testing]]))
+
+(def config
+  {:linters {:conditional-build-up {:level :warning}}})
+
+
+(deftest conditional-build-up-test
+  (testing "two consecutive conditional assocs (minimum case)"
+    (assert-submaps2
+      [{:file "<stdin>"
+        :row 1
+        :col 6
+        :level :warning
+        :message "Prefer cond-> to build a map with successive conditional assocs."}]
+      (lint! "(let [m {:k0 0}
+                   m (if (pos? in) (assoc m :k1 1) m)
+                   m (if (even? in) (assoc m :k2 2) m)]
+               m)"
+             config)))
+
+  (testing "three consecutive conditional assocs"
+    (assert-submaps2
+      [{:file "<stdin>"
+        :row 1
+        :col 6
+        :level :warning
+        :message "Prefer cond-> to build a map with successive conditional assocs."}]
+      (lint! "(let [m {:k0 0}
+                   m (if (p1 in) (assoc m :k1 1) m)
+                   m (if (p2 in) (assoc m :k2 2) m)
+                   m (if (p3 in) (assoc m :k3 3) m)]
+               m)"
+             config)))
+
+  (testing "warning with :error level"
+    (assert-submaps2
+      [{:file "<stdin>"
+        :row 1
+        :col 6
+        :level :error
+        :message "Prefer cond-> to build a map with successive conditional assocs."}]
+      (lint! "(let [m {:k0 0}
+                   m (if (pos? in) (assoc m :k1 1) m)
+                   m (if (even? in) (assoc m :k2 2) m)]
+               m)"
+             {:linters {:conditional-build-up {:level :error}}}))))
+
+
+(deftest no-warning-test
+  (testing "only one conditional assoc (below threshold)"
+    (is (empty? (lint! "(let [m {:k0 0}
+                              m (if (pos? in) (assoc m :k1 1) m)]
+                          m)"
+                       config))))
+
+  (testing "variable changes at each step (no consecutive rebind)"
+    (is (empty? (lint! "(let [m {:k0 0}
+                              n (if (pos? in) (assoc m :k1 1) m)
+                              o (if (even? in) (assoc n :k2 2) n)]
+                          o)"
+                       config))))
+
+  (testing "else branch returns a different value from the variable itself"
+    (is (empty? (lint! "(let [m {:k0 0}
+                              m (if (pos? in) (assoc m :k1 1) m)
+                              m (if (even? in) (assoc m :k2 2) {:other 3})]
+                          m)"
+                       config))))
+
+  (testing "intermediate non-conditional step breaks the sequence"
+    (is (empty? (lint! "(let [m {:k0 0}
+                              m (if (pos? in) (assoc m :k1 1) m)
+                              m (assoc m :k1-5 1.5)
+                              m (if (even? in) (assoc m :k2 2) m)]
+                          m)"
+                       config))))
+
+  (testing "single if with multiple assocs in the then branch"
+    (is (empty? (lint! "(let [m {:k0 (f0 in)}
+                              m (if (p1 in)
+                                  (assoc m :k1 (f1 in) :k2 (f2 in))
+                                  m)]
+                          m)"
+                       config))))
+
+  (testing "if without else (only 3 children, not recognized as a step)"
+    (is (empty? (lint! "(let [m {:k0 0}
+                              m (if (pos? in) (assoc m :k1 1))
+                              m (if (even? in) (assoc m :k2 2))]
+                          m)"
+                       {:linters {:conditional-build-up {:level :warning}
+                                  :missing-else-branch {:level :off}}}))))
+
+  (testing "base binding references the variable itself (not a valid candidate)"
+    (is (empty? (lint! "(let [m (f m)
+                              m (if (pos? in) (assoc m :k1 1) m)
+                              m (if (even? in) (assoc m :k2 2) m)]
+                          m)"
+                       config))))
+
+  (testing "destructuring in binding resets tracking"
+    (is (empty? (lint! "(let [[a b] [1 2]
+                              m (if (pos? a) (assoc {} :k1 1) {})
+                              m (if (even? b) (assoc m :k2 2) m)]
+                          m)"
+                       config))))
+
+  (testing "linter disabled via config"
+    (is (empty? (lint! "(let [m {:k0 0}
+                              m (if (pos? in) (assoc m :k1 1) m)
+                              m (if (even? in) (assoc m :k2 2) m)]
+                          m)"
+                       {:linters {:conditional-build-up {:level :off}}}))))
+
+  (testing "idiomatic cond-> does not produce a warning"
+    (is (empty? (lint! "(defn foo-ok [in]
+                          (cond-> {:k0 (f0 in)}
+                            (p1 in) (assoc :k1 (f1 in))
+                            (p2 in) (assoc :k2 (f2 in))))"
+                       config))))
+
+  (testing "map literal with when on values does not produce a warning"
+    (is (empty? (lint! "(defn foo-ok [in]
+                          {:k0 (f0 in)
+                           :k1 (when (p1 in) (f1 in))
+                           :k2 (when (p2 in) (f2 in))})"
+                       config))))
+
+  (testing "direct assoc without let does not produce a warning"
+    (is (empty? (lint! "(defn foo-ok [in]
+                          (assoc {:k0 (f0 in)} :k1 (f1 in)))"
+                       config)))))

--- a/test/clj_kondo/conditional_build_up_test.clj
+++ b/test/clj_kondo/conditional_build_up_test.clj
@@ -6,7 +6,6 @@
 (def config
   {:linters {:conditional-build-up {:level :warning}}})
 
-
 (deftest conditional-build-up-positive-test
   (testing "two consecutive conditional assocs (minimum case)"
     (assert-submaps2
@@ -162,6 +161,19 @@
                m)"
              {:linters {:conditional-build-up {:level :error}}})))
 
+  (testing "standard conditional step combined with splicing reader-conditional triggers chain for both dialects"
+    (assert-submaps2
+      [{:level :warning
+        :message "Prefer cond-> to build a map with successive conditional assocs."}]
+      (lint! "(let [m {:k0 (f0 in)}
+                    m (if (p1 in) (assoc m :k1 (f1 in)) m)
+                    #?@(:clj
+                        [m (if (p2 in) (assoc m :clj-k2 (f2 in)) m)]
+                        :cljs
+                        [m (if (p3 in) (assoc m :cljs-k3 (f3 in)) m)])]
+                m)"
+             config "--lang" "cljc")))
+
 
 (deftest conditional-build-up-negative-test
   (testing "only one conditional assoc (below threshold)"
@@ -176,6 +188,13 @@
                               o (if (even? in) (assoc n :k2 2) n)]
                           o)"
                        config))))
+
+  (testing "predicate references map symbol"
+    (is (empty? (lint! "(let [m {}
+                              m (if (:a m) (assoc m :a 1) m)
+                              m (if (:b m) (assoc m :b 2) m)]
+                          m)"
+                        config))))
 
   (testing "else branch returns a different value from the variable itself"
     (is (empty? (lint! "(let [m {:k0 0}

--- a/test/clj_kondo/conditional_build_up_test.clj
+++ b/test/clj_kondo/conditional_build_up_test.clj
@@ -7,7 +7,7 @@
   {:linters {:conditional-build-up {:level :warning}}})
 
 
-(deftest conditional-build-up-test
+(deftest conditional-build-up-positive-test
   (testing "two consecutive conditional assocs (minimum case)"
     (assert-submaps2
       [{:file "<stdin>"
@@ -35,6 +35,120 @@
                m)"
              config)))
 
+  (testing "nested expressions inside assoc still count"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [m {:k0 (f0 in)}
+               m (if (p1 in) (assoc m :k1 (if (p2 in) (f1 in) (f2 in))) m)
+               m (if (p3 in) (assoc m :k2 (f3 in)) m)]
+           m))")))
+
+  
+  (testing "different symbol name also triggers"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [acc {:k0 (f0 in)}
+               acc (if (p1 in) (assoc acc :k1 (f1 in)) acc)
+               acc (if (p2 in) (assoc acc :k2 (f2 in)) acc)]
+           acc))"))))
+
+  (testing "starts from empty map literal"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [m {}
+               m (if (p1 in) (assoc m :k1 (f1 in)) m)
+               m (if (p2 in) (assoc m :k2 (f2 in)) m)
+               m (if (p3 in) (assoc m :k3 (f3 in)) m)]
+           m))")))
+
+  (testing "starts from (hash-map)"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [m (hash-map)
+               m (if (p1 in) (assoc m :k1 (f1 in)) m)
+               m (if (p2 in) (assoc m :k2 (f2 in)) m)]
+           m))")))
+
+  (testing "starts from (sorted-map)"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [m (sorted-map)
+               m (if (p1 in) (assoc m :k1 (f1 in)) m)
+               m (if (p2 in) (assoc m :k2 (f2 in)) m)]
+           m))")))
+
+  (testing "starts from (zipmap ...)"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [m (zipmap [] [])
+               m (if (p1 in) (assoc m :k1 (f1 in)) m)
+               m (if (p2 in) (assoc m :k2 (f2 in)) m)]
+           m))")))
+
+  (testing "starts from pre-populated map"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [m {:base true}
+               m (if (p1 in) (assoc m :k1 (f1 in)) m)
+               m (if (p2 in) (assoc m :k2 (f2 in)) m)]
+           m))")))
+
+  (testing "starts from function returning map"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 2,
+        :col 15,
+        :level :info,
+        :message "Prefer cond-> to build a map with successive conditional assocs."})
+     (lint!
+      "(defn foo [in]
+         (let [m (f0 in)
+               m (if (p1 in) (assoc m :k1 (f1 in)) m)
+               m (if (p2 in) (assoc m :k2 (f2 in)) m)]
+           m))")))
+
   (testing "warning with :error level"
     (assert-submaps2
       [{:file "<stdin>"
@@ -46,10 +160,10 @@
                    m (if (pos? in) (assoc m :k1 1) m)
                    m (if (even? in) (assoc m :k2 2) m)]
                m)"
-             {:linters {:conditional-build-up {:level :error}}}))))
+             {:linters {:conditional-build-up {:level :error}}})))
 
 
-(deftest no-warning-test
+(deftest conditional-build-up-negative-test
   (testing "only one conditional assoc (below threshold)"
     (is (empty? (lint! "(let [m {:k0 0}
                               m (if (pos? in) (assoc m :k1 1) m)]


### PR DESCRIPTION
Fixes #2807 

## Description

This PR introduces the `:conditional-build-up` linter, which warns when a local map is repeatedly rebound using successive `(if pred (assoc m ...) m)` patterns inside a `let` binding.

In these cases, the code can often be expressed more concisely with `cond->`.

### Key Implementation Details
- **Threshold:** The linter only triggers when it detects **2 or more consecutive** conditional `assoc` steps. A single conditional `assoc` is not flagged.
- **Chain detection:** The linter only counts a chain after finding a valid base binding for the same local symbol. The following conditional rebindings must be consecutive and must keep the same shape: `(if pred (assoc m ...) m)`.
- **Safety / false positives:** The linter ignores steps where the `if` predicate references the target map symbol itself. 

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
