### PR TITLE
Add multi-require line style linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2834](https://github.com/clj-kondo/clj-kondo/pull/2834): NEW linter: `:multi-require-each-on-own-line` which warns when multiple entries in a `:require` or `:require-macros` form are not each on their own line (default level: `:off`) ([@dotemacs](https://github.com/dotemacs))
 - Docs: update `doc/config.md` optional-linters section to include linters that are `:off` by default ([@jramosg](https://github.com/jramosg))
 - [#2811](https://github.com/clj-kondo/clj-kondo/issues/2811): report correct location for `:missing-map-value` when the malformed map is nested in a set or in map-key position, and no longer suppress subsequent lint errors in the file
 - [#2813](https://github.com/clj-kondo/clj-kondo/issues/2813): fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename` ([@jramosg](https://github.com/jramosg))
@@ -56,7 +57,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - `unused-excluded-var`: Add location metadata to excluded vars in `ns-unmap`. This fixes some findings with not location. ([@jramosg](https://github.com/jramosg))
 - [#2747](https://github.com/clj-kondo/clj-kondo/issues/2747): Fix: Gensym bindings in nested syntax quotes are now correctly recognized ([@jramosg](https://github.com/jramosg))when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2746](https://github.com/clj-kondo/clj-kondo/issues/2746): Fix regression: primitive array class syntax (e.g., `byte/1`, `int/2`) now correctly recognized as class literals in type checking ([@jramosg](https://github.com/jramosg))
-- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg)) 
+- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2749](https://github.com/clj-kondo/clj-kondo/issues/2749): Fix false positive for throw in CLJS when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2732](https://github.com/clj-kondo/clj-kondo/issues/2732): `unreachable-code`: warn when `:default` does not come last in reader conditionals ([@jramosg](https://github.com/jramosg))

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -72,6 +72,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Missing docstring](#missing-docstring)
     - [Missing else branch](#missing-else-branch)
     - [Missing map value](#missing-map-value)
+    - [Multi require each on own line](#multi-require-each-on-own-line)
     - [Unresolved protocol method](#unresolved-protocol-method)
     - [Missing protocol method](#missing-protocol-method)
     - [Protocol method arity mismatch](#protocol-method-arity-mismatch)
@@ -1324,6 +1325,18 @@ misses a value.
 *Example trigger:* `{:a 1 :b}`
 
 *Example message:* `missing value for key :b`.
+
+### Multi require each on own line
+
+*Keyword:* `:multi-require-each-on-own-line`.
+
+*Description:* when requiring multiple namespaces from one `:require` or `:require-macros` form, warn when entries are not each on their own line. A single require entry may be on the same line as `:require`.
+
+*Default level:* `:off`.
+
+*Example trigger:* `(ns foo (:require [foo.bar] [bar.baz]))`.
+
+*Example message:* `When requiring multiple namespaces, each :require entry must be on its own line`.
 
 ### Unresolved protocol method
 

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -390,14 +390,12 @@
     (when (and (one-of (:k require-kw-node) [:require :require-macros])
                (> (count libspecs) 1))
       (let [require-row (:row (meta require-kw-node))
-            by-line (group-by #(-> % meta :row) libspecs)
-            crowded-rows (->> by-line
-                              (filter #(> (count (val %)) 1))
-                              (map key)
-                              set)
-            invalid-entry? #(or (= require-row (-> % meta :row))
-                                (contains? crowded-rows (-> % meta :row)))]
-        (doseq [libspec-expr (filter invalid-entry? libspecs)]
+            by-row (partition-by #(-> % meta :row) libspecs)
+            invalid-row? (fn [[first-libspec & more-libspecs]]
+                           (or (= require-row (-> first-libspec meta :row))
+                               (seq more-libspecs)))]
+        (doseq [invalid-row (filter invalid-row? by-row)
+                libspec-expr invalid-row]
           (findings/reg-finding!
            ctx
            (node->line (:filename ctx)

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -385,11 +385,32 @@
                {}))
     nil))
 
+(defn- lint-multi-require-each-on-own-line! [ctx require-kw-node libspecs]
+  (when-not (linter-disabled? ctx :multi-require-each-on-own-line)
+    (when (and (one-of (:k require-kw-node) [:require :require-macros])
+               (> (count libspecs) 1))
+      (let [require-row (:row (meta require-kw-node))
+            by-line (group-by #(-> % meta :row) libspecs)
+            crowded-rows (->> by-line
+                              (filter #(> (count (val %)) 1))
+                              (map key)
+                              set)
+            invalid-entry? #(or (= require-row (-> % meta :row))
+                                (contains? crowded-rows (-> % meta :row)))]
+        (doseq [libspec-expr (filter invalid-entry? libspecs)]
+          (findings/reg-finding!
+           ctx
+           (node->line (:filename ctx)
+                       libspec-expr
+                       :multi-require-each-on-own-line
+                       "When requiring multiple namespaces, each :require entry must be on its own line")))))))
+
 (defn analyze-require-clauses [ctx ns-name kw+libspecs]
   (let [lang (:lang ctx)
         unused-namespace-disabled? (identical? :off (-> ctx :config :linters :unused-namespace :level))
         analyzed
         (map (fn [[require-kw libspecs]]
+               (lint-multi-require-each-on-own-line! ctx require-kw libspecs)
                (when-not libspecs
                  (findings/reg-finding!
                   ctx (node->line (:filename ctx) require-kw :syntax

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -39,6 +39,7 @@
               :duplicate-field {:level :error}
               :duplicate-key-args {:level :warning}
               :missing-map-value {:level :error}
+              :multi-require-each-on-own-line {:level :off}
               :redefined-var {:level :warning}
               :redundant-declare {:level :warning}
               :var-same-name-except-case {:level :warning}

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3369,6 +3369,46 @@ app.api/my-var"
                                                                  :sort :case-sensitive}}}
                        "--lang" "cljs")))))
 
+(deftest multi-require-each-on-own-line-test
+  (testing "single require on same line is ok"
+    (is (empty? (lint! "(ns foo (:require [foo.bar]))"
+                       {:linters {:multi-require-each-on-own-line {:level :warning}}}))))
+  (testing "multiple requires on same line as :require"
+    (assert-submaps
+     [{:file "<stdin>"
+       :row 1
+       :col 19
+       :level :warning
+       :message "When requiring multiple namespaces, each :require entry must be on its own line"}
+      {:file "<stdin>"
+       :row 1
+       :col 29
+       :level :warning
+       :message "When requiring multiple namespaces, each :require entry must be on its own line"}]
+     (lint! "(ns foo (:require [foo.bar] [bar.baz]))"
+            {:linters {:multi-require-each-on-own-line {:level :warning}}})))
+  (testing "multiple requires on one line after :require"
+    (assert-submaps
+     [{:file "<stdin>"
+       :row 3
+       :col 4
+       :level :warning
+       :message "When requiring multiple namespaces, each :require entry must be on its own line"}
+      {:file "<stdin>"
+       :row 3
+       :col 14
+       :level :warning
+       :message "When requiring multiple namespaces, each :require entry must be on its own line"}]
+     (lint! "(ns foo\n  (:require\n   [foo.bar] [bar.baz]))"
+            {:linters {:multi-require-each-on-own-line {:level :warning}}})))
+  (testing "multiple requires on separate lines are ok"
+    (is (empty? (lint! "(ns foo\n  (:require\n   [foo.bar]\n   [bar.baz]))"
+                       {:linters {:multi-require-each-on-own-line {:level :warning}}}))))
+  (testing "use clauses are ignored"
+    (is (empty? (lint! "(ns foo (:use [foo.bar] [bar.baz]))"
+                       {:linters {:multi-require-each-on-own-line {:level :warning}
+                                  :use {:level :off}}})))))
+
 (deftest unsorted-imports-test
   (assert-submaps2
    [{:file "<stdin>"


### PR DESCRIPTION
Add an opt-in linter that warns when a :require or :require-macros form contains multiple entries that are not each on their own line.

This supports projects that allow a single inline require but want multi-require clauses formatted consistently for readability.

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

~- [] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).~

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
