### PR TITLE
Add new linter for blocking inside go

### DIFF
--- a/doc/linters.md
+++ b/doc/linters.md
@@ -220,6 +220,7 @@ configuration. For general configurations options, go [here](config.md).
 (def my-chan (a/chan))
 (a/go
   (println "Blocked thread consuming:" (a/<!! my-chan)))
+```
 
 Example message: blocking operation inside go block
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -10,6 +10,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Aliased namespace symbol](#aliased-namespace-symbol)
     - [Aliased namespace var usage](#aliased-namespace-var-usage)
     - [Aliased referred var](#aliased-referred-var)
+    - [Blocking inside go](#blocking-inside-go)
     - [Case](#case)
     - [Case duplicate test](#case-duplicate-test)
         - [Case quoted test](#case-quoted-test)
@@ -202,6 +203,25 @@ configuration. For general configurations options, go [here](config.md).
 ```
 
 *Example message:* `Var union is referred but used via alias: set`
+
+### Blocking inside go
+
+*Keyword:* `:blocking-inside-go`.
+
+*Description:* Warns when a blocking operation (`<!!`, `>!!`, `alts!!`) is called inside a `go` block. `go` blocks are designed for non-blocking, cooperative concurrency and execute on a small, fixed-size thread pool. Blocking inside a `go` block defeats this purpose, risking thread starvation, deadlocks, and system-wide performance degradation.
+
+*Default level:* `:warning`
+
+*Example trigger:*
+
+```clojure
+(ns my-app.async-fail
+  (:require [clojure.core.async :as a]))
+(def my-chan (a/chan))
+(a/go
+  (println "Blocked thread consuming:" (a/<!! my-chan)))
+
+Example message: blocking operation inside go block
 
 ### Case
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -208,18 +208,16 @@ configuration. For general configurations options, go [here](config.md).
 
 *Keyword:* `:blocking-inside-go`.
 
-*Description:* Warns when a blocking operation (`<!!`, `>!!`, `alts!!`) is called inside a `go` block. `go` blocks are designed for non-blocking, cooperative concurrency and execute on a small, fixed-size thread pool. Blocking inside a `go` block defeats this purpose, risking thread starvation, deadlocks, and system-wide performance degradation.
+*Description:* Warns when a blocking core.async operation, e.g., `<!!`, `>!!`, or `alts!!`, is used inside a `go` or `go-loop` block. Since these blocks run on a finite thread pool, blocking inside them may prevent further progress and cause starvation or performance issues.
 
 *Default level:* `:warning`
 
 *Example trigger:*
 
 ```clojure
-(ns my-app.async-fail
-  (:require [clojure.core.async :as a]))
-(def my-chan (a/chan))
 (a/go
-  (println "Blocked thread consuming:" (a/<!! my-chan)))
+  (a/alts!! [started-chan (a/timeout 1000)])
+  (a/close! result-chan))
 ```
 
 Example message: blocking operation inside go block

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2981,7 +2981,24 @@
                                              (-> (assoc-in [:recur-arity :fixed-arity] 0)
                                                  (assoc :seen-recur? (volatile! nil))
                                                  (dissoc :protocol-fn)))]
-                              (analyze-children next-ctx children false))))]
+                        
+                              (cond
+                                (and (= resolved-namespace 'clojure.core.async)
+                                     (= resolved-name 'go))
+                                (do
+                                  (analyze-children (assoc next-ctx :inside-go? true) children))
+                                (and (= resolved-namespace 'clojure.core.async)
+                                     (contains? '#{<!! >!!} resolved-name))
+                                (do
+                                  (when (:inside-go? ctx)
+                                    (findings/reg-finding!
+                                      ctx
+                                      (node->line (:filename ctx) expr :blocking-inside-go 
+                                                    "blocking operation inside go block")))
+                                  (analyze-children next-ctx children false))
+                                  
+                                  :else
+                                  (analyze-children next-ctx children false)))))]
                     (if (= 'ns resolved-as-clojure-var-name)
                       analyzed
                       (let [in-def (:in-def ctx)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2801,7 +2801,13 @@
                           case
                           (analyze-case ctx expr)
                           loop
-                          (analyze-loop ctx expr)
+                          (analyze-loop (cond-> ctx
+                                          (contains? '#{clojure.core.async/go-loop
+                                                        cljs.core.async/go-loop
+                                                        cljs.core.async.macros/go-loop}
+                                                     resolved-var-sym)
+                                          (assoc :inside-go? true))
+                                        expr)
                           recur
                           (analyze-recur ctx expr)
                           quote nil
@@ -2987,7 +2993,7 @@
                                      (= resolved-name 'go))
                                 (analyze-children (assoc next-ctx :inside-go? true) children)
                                 (and (= resolved-namespace 'clojure.core.async)
-                                     (contains? '#{<!! >!!} resolved-name))
+                                     (contains? '#{<!! >!! alts!!} resolved-name))
                                 (do
                                   (when (:inside-go? ctx)
                                     (findings/reg-finding!

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1210,7 +1210,7 @@
      [clojure.core.async thread]
      [clojure.core.async thread-call]
      [cljs.core fn]
-     [cljs.core.fn*]
+     [cljs.core fn*]
      [cljs.core.async thread]
      [cljs.core.async thread-call]})
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1192,6 +1192,42 @@
         cse
         (recur (rest callstack))))))
 
+(def ^:private go-vars
+  '#{[clojure.core.async go]
+     [clojure.core.async go-loop]
+     [cljs.core.async go]
+     [cljs.core.async go-loop]
+     [cljs.core.async.macros go]
+     [cljs.core.async.macros go-loop]})
+
+(def ^:private execution-boundary-vars
+  '#{[clojure.core future]
+     [clojure.core delay]
+     [clojure.core lazy-seq]
+     [clojure.core lazy-cat]
+     [clojure.core fn]
+     [clojure.core fn*]
+     [clojure.core.async thread]
+     [clojure.core.async thread-call]
+     [cljs.core fn]
+     [cljs.core.fn*]
+     [cljs.core.async thread]
+     [cljs.core.async thread-call]})
+
+(defn in-go-on-current-thread? [callstack]
+  (boolean
+   (reduce (fn [_ frame]
+             (cond
+               (contains? go-vars frame)
+               (reduced true)
+
+               (contains? execution-boundary-vars frame)
+               (reduced false)
+
+               :else nil))
+           nil
+           callstack)))
+
 (defn mark-non-tail-recur
   "Marks ctx as a non-tail position for recur (e.g. inside a collection
   literal). An empty map is used as the sentinel so that downstream
@@ -2801,13 +2837,7 @@
                           case
                           (analyze-case ctx expr)
                           loop
-                          (analyze-loop (cond-> ctx
-                                          (contains? '#{clojure.core.async/go-loop
-                                                        cljs.core.async/go-loop
-                                                        cljs.core.async.macros/go-loop}
-                                                     resolved-var-sym)
-                                          (assoc :inside-go? true))
-                                        expr)
+                          (analyze-loop ctx expr)
                           recur
                           (analyze-recur ctx expr)
                           quote nil
@@ -2986,17 +3016,11 @@
                                                       [clojure.core lazy-cat]])
                                              (-> (assoc-in [:recur-arity :fixed-arity] 0)
                                                  (assoc :seen-recur? (volatile! nil))
-                                                 (dissoc :protocol-fn)))
-
-                                    next-ctx
-                                    (if (and (= resolved-namespace 'clojure.core.async)
-                                            (contains? '#{go go-loop} resolved-name))
-                                      (assoc next-ctx :inside-go? true)
-                                      next-ctx)]
+                                                 (dissoc :protocol-fn)))]
 
                                 (when (and (= resolved-namespace 'clojure.core.async)
-                                          (contains? '#{<!! >!! alts!!} resolved-name)
-                                          (:inside-go? ctx))
+                                           (contains? '#{<!! >!! alts!!} resolved-name)
+                                           (in-go-on-current-thread? (:callstack ctx)))
                                   (findings/reg-finding!
                                     ctx
                                     (node->line (:filename ctx)

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2985,8 +2985,7 @@
                               (cond
                                 (and (= resolved-namespace 'clojure.core.async)
                                      (= resolved-name 'go))
-                                (do
-                                  (analyze-children (assoc next-ctx :inside-go? true) children))
+                                (analyze-children (assoc next-ctx :inside-go? true) children)
                                 (and (= resolved-namespace 'clojure.core.async)
                                      (contains? '#{<!! >!!} resolved-name))
                                 (do

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2986,24 +2986,25 @@
                                                       [clojure.core lazy-cat]])
                                              (-> (assoc-in [:recur-arity :fixed-arity] 0)
                                                  (assoc :seen-recur? (volatile! nil))
-                                                 (dissoc :protocol-fn)))]
-                        
-                              (cond
-                                (and (= resolved-namespace 'clojure.core.async)
-                                     (= resolved-name 'go))
-                                (analyze-children (assoc next-ctx :inside-go? true) children)
-                                (and (= resolved-namespace 'clojure.core.async)
-                                     (contains? '#{<!! >!! alts!!} resolved-name))
-                                (do
-                                  (when (:inside-go? ctx)
-                                    (findings/reg-finding!
-                                      ctx
-                                      (node->line (:filename ctx) expr :blocking-inside-go 
-                                                    "blocking operation inside go block")))
-                                  (analyze-children next-ctx children false))
-                                  
-                                  :else
-                                  (analyze-children next-ctx children false)))))]
+                                                 (dissoc :protocol-fn)))
+
+                                    next-ctx
+                                    (if (and (= resolved-namespace 'clojure.core.async)
+                                            (contains? '#{go go-loop} resolved-name))
+                                      (assoc next-ctx :inside-go? true)
+                                      next-ctx)]
+
+                                (when (and (= resolved-namespace 'clojure.core.async)
+                                          (contains? '#{<!! >!! alts!!} resolved-name)
+                                          (:inside-go? ctx))
+                                  (findings/reg-finding!
+                                    ctx
+                                    (node->line (:filename ctx)
+                                                expr
+                                                :blocking-inside-go
+                                                "blocking operation inside go block")))
+
+                                (analyze-children next-ctx children false))))]
                     (if (= 'ns resolved-as-clojure-var-name)
                       analyzed
                       (let [in-def (:in-def ctx)

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -195,7 +195,8 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
-              :unquote-not-syntax-quoted {:level :warning}}
+              :unquote-not-syntax-quoted {:level :warning}
+              :blocking-inside-go {:level :warning}}
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -1855,6 +1855,16 @@
   :langs (),
   :message "Unresolved symbol: re=",
   :row 22}
+ {:end-row 34,
+  :type :blocking-inside-go,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/server/statistics_handler_test.clj",
+  :col 11,
+  :end-col 37,
+  :langs (),
+  :message "blocking operation inside go block",
+  :row 34}
  {:end-row 121,
   :type :unresolved-symbol,
   :level :error,
@@ -1938,6 +1948,16 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 1018}
+ {:end-row 41,
+  :type :blocking-inside-go,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/util/async_test.clj",
+  :col 11,
+  :end-col 53,
+  :langs (),
+  :message "blocking operation inside go block",
+  :row 41}
  {:end-row 54,
   :type :unresolved-symbol,
   :level :error,

--- a/test/clj_kondo/blocking_inside_go_test.clj
+++ b/test/clj_kondo/blocking_inside_go_test.clj
@@ -138,3 +138,68 @@
     (is (empty?
           (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))"
                  {:linters {:blocking-inside-go {:level :off}}})))))
+
+(deftest no-blocking-inside-go-via-fn-test
+  (testing "<!! inside fn inside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/go (fn [] (a/<!! (a/chan))))"))))
+  (testing ">!! inside fn inside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/go (fn [] (a/>!! (a/chan) 1)))"))))
+  (testing "alts!! inside fn inside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/go (fn [] (a/alts!! [(a/chan)])))"))))
+  (testing "<!! inside fn with args inside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/go (fn [x] (a/<!! x)))"
+                 {:linters {:unresolved-symbol {:level :off}}}))))
+  (testing "<!! inside #() inside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/go #(a/<!! (a/chan)))"))))
+  (testing "<!! with refer inside fn inside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :refer [go <!! chan]]) (go (fn [] (<!! (chan))))")))))
+(deftest blocking-inside-go-direct-still-warns-test
+  (testing "<!! directly inside go still emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 45, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))"))))
+(deftest blocking-inside-go-let-fn-test
+  (testing "<!! directly in let inside go still warns"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 56, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (let [x 1] (a/<!! (a/chan))))"))))
+
+(deftest no-blocking-inside-go-false-positives-guard-test
+  (testing "fn returning blocking form is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a])
+                  (a/go (fn [] (identity (a/<!! (a/chan)))))"))))
+
+  (testing "higher-order function returning fn is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a])
+                  (a/go ((fn [] (fn [] (a/<!! (a/chan))))) )"))))
+
+  (testing "blocking inside map function is OK if not executed in go body"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a])
+                  (a/go (map (fn [_] (a/<!! (a/chan))) [1 2 3]))")))))
+
+(deftest no-blocking-inside-go-false-positives-guard-test
+  (testing "fn returning blocking form is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a])
+                  (a/go (fn [] (identity (a/<!! (a/chan)))))"))))
+
+  (testing "higher-order function returning fn is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a])
+                  (a/go ((fn [] (fn [] (a/<!! (a/chan))))) )"))))
+
+  (testing "blocking inside map function is OK if not executed in go body"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a])
+                  (a/go (map (fn [_] (a/<!! (a/chan))) [1 2 3]))")))))

--- a/test/clj_kondo/blocking_inside_go_test.clj
+++ b/test/clj_kondo/blocking_inside_go_test.clj
@@ -187,19 +187,3 @@
     (is (empty?
           (lint! "(require '[clojure.core.async :as a])
                   (a/go (map (fn [_] (a/<!! (a/chan))) [1 2 3]))")))))
-
-(deftest no-blocking-inside-go-false-positives-guard-test
-  (testing "fn returning blocking form is OK"
-    (is (empty?
-          (lint! "(require '[clojure.core.async :as a])
-                  (a/go (fn [] (identity (a/<!! (a/chan)))))"))))
-
-  (testing "higher-order function returning fn is OK"
-    (is (empty?
-          (lint! "(require '[clojure.core.async :as a])
-                  (a/go ((fn [] (fn [] (a/<!! (a/chan))))) )"))))
-
-  (testing "blocking inside map function is OK if not executed in go body"
-    (is (empty?
-          (lint! "(require '[clojure.core.async :as a])
-                  (a/go (map (fn [_] (a/<!! (a/chan))) [1 2 3]))")))))

--- a/test/clj_kondo/blocking_inside_go_test.clj
+++ b/test/clj_kondo/blocking_inside_go_test.clj
@@ -1,0 +1,86 @@
+(ns clj-kondo.blocking-inside-go-test
+  (:require [clj-kondo.test-utils :refer [lint! assert-submaps2]]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest blocking-inside-go-test
+  (testing "<!! inside go emits warning"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 1,
+        :col 45,
+        :level :warning,
+        :message "blocking operation inside go block"})
+     (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))")))
+
+  (testing ">!! inside go emits warning"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 1,
+        :col 45,
+        :level :warning,
+        :message "blocking operation inside go block"})
+     (lint! "(require '[clojure.core.async :as a]) (a/go (a/>!! (a/chan) 1))")))
+
+  (testing "<!! with refer inside go emits warning"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 1,
+        :col 53,
+        :level :warning,
+        :message "blocking operation inside go block"})
+     (lint! "(require '[clojure.core.async :refer [go <!!]]) (go (<!! (chan)))")))
+
+  (testing ">!! with refer inside go emits warning"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 1,
+        :col 53,
+        :level :warning,
+        :message "blocking operation inside go block"})
+     (lint! "(require '[clojure.core.async :refer [go >!!]]) (go (>!! (chan) 1))")))
+
+  (testing "multiple blocking calls inside go emits multiple warnings"
+    (assert-submaps2
+     '({:file "<stdin>",
+        :row 1,
+        :col 45,
+        :level :warning,
+        :message "blocking operation inside go block"}
+       {:file "<stdin>",
+        :row 1,
+        :col 56,
+        :level :warning,
+        :message "blocking operation inside go block"})
+     (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! ch) (a/>!! ch 1))"
+            {:linters {:unused-binding {:level :off}
+                       :unresolved-symbol {:level :off}}}))))
+
+(deftest no-blocking-inside-go-test
+  (testing "<! (parking, not blocking) inside go is OK"
+    (is (empty?
+         (lint! "(require '[clojure.core.async :as a]) (a/go (a/<! (a/chan)))"))))
+
+  (testing ">! (parking, not blocking) inside go is OK"
+    (is (empty?
+         (lint! "(require '[clojure.core.async :as a]) (a/go (a/>! (a/chan) 1))"))))
+
+  (testing "<!! outside go is OK"
+    (is (empty?
+         (lint! "(require '[clojure.core.async :as a]) (a/<!! (a/chan))"))))
+
+  (testing ">!! outside go is OK"
+    (is (empty?
+         (lint! "(require '[clojure.core.async :as a]) (a/>!! (a/chan) 1)"))))
+
+  (testing "<!! inside thread (not go) is OK"
+    (is (empty?
+         (lint! "(require '[clojure.core.async :as a]) (a/thread (a/<!! (a/chan)))"))))
+
+  (testing ">!! inside thread (not go) is OK"
+    (is (empty?
+         (lint! "(require '[clojure.core.async :as a]) (a/thread (a/>!! (a/chan) 1))"))))
+
+  (testing "linter can be disabled via config"
+    (is (empty?
+         (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))"
+                {:linters {:blocking-inside-go {:level :off}}})))))

--- a/test/clj_kondo/blocking_inside_go_test.clj
+++ b/test/clj_kondo/blocking_inside_go_test.clj
@@ -5,82 +5,136 @@
 (deftest blocking-inside-go-test
   (testing "<!! inside go emits warning"
     (assert-submaps2
-     '({:file "<stdin>",
-        :row 1,
-        :col 45,
-        :level :warning,
-        :message "blocking operation inside go block"})
-     (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))")))
+      '({:file "<stdin>", :row 1, :col 45, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))")))
 
   (testing ">!! inside go emits warning"
     (assert-submaps2
-     '({:file "<stdin>",
-        :row 1,
-        :col 45,
-        :level :warning,
-        :message "blocking operation inside go block"})
-     (lint! "(require '[clojure.core.async :as a]) (a/go (a/>!! (a/chan) 1))")))
+      '({:file "<stdin>", :row 1, :col 45, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (a/>!! (a/chan) 1))")))
+
+  (testing "alts!! inside go emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 45, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (a/alts!! [(a/chan)]))")))
 
   (testing "<!! with refer inside go emits warning"
     (assert-submaps2
-     '({:file "<stdin>",
-        :row 1,
-        :col 53,
-        :level :warning,
-        :message "blocking operation inside go block"})
-     (lint! "(require '[clojure.core.async :refer [go <!!]]) (go (<!! (chan)))")))
+      '({:file "<stdin>", :row 1, :col 58, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :refer [go <!! chan]]) (go (<!! (chan)))")))
 
   (testing ">!! with refer inside go emits warning"
     (assert-submaps2
-     '({:file "<stdin>",
-        :row 1,
-        :col 53,
-        :level :warning,
-        :message "blocking operation inside go block"})
-     (lint! "(require '[clojure.core.async :refer [go >!!]]) (go (>!! (chan) 1))")))
+      '({:file "<stdin>", :row 1, :col 58, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :refer [go >!! chan]]) (go (>!! (chan) 1))")))
+
+  (testing "nested expression inside go emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 54, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (println (a/<!! (a/chan))))")))
+
+  (testing "deeper nesting inside go emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 67, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (let [x 1] (when true (a/<!! (a/chan)))))")))
 
   (testing "multiple blocking calls inside go emits multiple warnings"
     (assert-submaps2
-     '({:file "<stdin>",
-        :row 1,
-        :col 45,
-        :level :warning,
-        :message "blocking operation inside go block"}
-       {:file "<stdin>",
-        :row 1,
-        :col 56,
-        :level :warning,
-        :message "blocking operation inside go block"})
-     (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! ch) (a/>!! ch 1))"
-            {:linters {:unused-binding {:level :off}
-                       :unresolved-symbol {:level :off}}}))))
+      '({:file "<stdin>", :row 1, :col 45, :level :warning,
+         :message "blocking operation inside go block"}
+        {:file "<stdin>", :row 1, :col 56, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! ch) (a/>!! ch 1))"
+             {:linters {:unused-binding {:level :off}
+                        :unresolved-symbol {:level :off}}})))
+
+  (testing "<!! inside go-loop emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 53, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go-loop [] (a/<!! (a/chan)) (recur))")))
+
+  (testing ">!! inside go-loop emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 53, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go-loop [] (a/>!! (a/chan) 1) (recur))")))
+
+  (testing "alts!! inside go-loop emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 53, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go-loop [] (a/alts!! [(a/chan)]) (recur))")))
+
+  (testing "nested blocking inside go-loop emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 62, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go-loop [] (println (a/<!! (a/chan))) (recur))")))
+
+  (testing "deeper nesting inside go-loop emits warning"
+    (assert-submaps2
+      '({:file "<stdin>", :row 1, :col 75, :level :warning,
+         :message "blocking operation inside go block"})
+      (lint! "(require '[clojure.core.async :as a]) (a/go-loop [] (let [x 1] (when true (a/<!! (a/chan)))) (recur))"))))
 
 (deftest no-blocking-inside-go-test
   (testing "<! (parking, not blocking) inside go is OK"
     (is (empty?
-         (lint! "(require '[clojure.core.async :as a]) (a/go (a/<! (a/chan)))"))))
+          (lint! "(require '[clojure.core.async :as a]) (a/go (a/<! (a/chan)))"))))
 
   (testing ">! (parking, not blocking) inside go is OK"
     (is (empty?
-         (lint! "(require '[clojure.core.async :as a]) (a/go (a/>! (a/chan) 1))"))))
+          (lint! "(require '[clojure.core.async :as a]) (a/go (a/>! (a/chan) 1))"))))
+
+  (testing "alts! (parking) inside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/go (a/alts! [(a/chan)]))"))))
 
   (testing "<!! outside go is OK"
     (is (empty?
-         (lint! "(require '[clojure.core.async :as a]) (a/<!! (a/chan))"))))
+          (lint! "(require '[clojure.core.async :as a]) (a/<!! (a/chan))"))))
 
   (testing ">!! outside go is OK"
     (is (empty?
-         (lint! "(require '[clojure.core.async :as a]) (a/>!! (a/chan) 1)"))))
+          (lint! "(require '[clojure.core.async :as a]) (a/>!! (a/chan) 1)"))))
+
+  (testing "alts!! outside go is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/alts!! [(a/chan)])"))))
 
   (testing "<!! inside thread (not go) is OK"
     (is (empty?
-         (lint! "(require '[clojure.core.async :as a]) (a/thread (a/<!! (a/chan)))"))))
+          (lint! "(require '[clojure.core.async :as a]) (a/thread (a/<!! (a/chan)))"))))
 
   (testing ">!! inside thread (not go) is OK"
     (is (empty?
-         (lint! "(require '[clojure.core.async :as a]) (a/thread (a/>!! (a/chan) 1))"))))
+          (lint! "(require '[clojure.core.async :as a]) (a/thread (a/>!! (a/chan) 1))"))))
+
+  (testing "alts!! inside thread (not go) is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/thread (a/alts!! [(a/chan)]))"))))
+
+  (testing "<!! inside future is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (future (a/<!! (a/chan)))"))))
+
+  (testing "go without blocking is OK"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (a/go (println \"safe\"))"))))
+
+  (testing "shadowed <!! should NOT trigger"
+    (is (empty?
+          (lint! "(require '[clojure.core.async :as a]) (let [<!! (fn [_] :fake)] (a/go (<!! (a/chan))))"))))
 
   (testing "linter can be disabled via config"
     (is (empty?
-         (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))"
-                {:linters {:blocking-inside-go {:level :off}}})))))
+          (lint! "(require '[clojure.core.async :as a]) (a/go (a/<!! (a/chan)))"
+                 {:linters {:blocking-inside-go {:level :off}}})))))


### PR DESCRIPTION
Fixes #2802

Description

This PR introduces the :blocking-inside-go linter, which warns when blocking core.async operations are used inside go/go-loop blocks.

Blocking operations such as <!!, >!!, and alts!! should not be used inside go blocks, since go is designed for parking operations and using blocking calls may exhaust thread resources or lead to unexpected behavior.

Key Implementation Details

    Detection scope: The linter tracks whether the current analysis context is inside a clojure.core.async/go or go-loop block.
    Blocking operations: The linter currently warns for <!!, >!!, and alts!! when used inside a go/go-loop context.
    Context propagation: The analyzer propagates an :inside-go? flag through child analysis contexts so nested forms are also checked.
    Safety / false positives: The linter only triggers for fully resolved clojure.core.async symbols, avoiding false positives from local bindings or similarly named functions.




Here are the new test regression findings:
- [Metabase statistics handler test](https://github.com/metabase/metabase/blob/aa0cdb546d7c9e4ef5c52ad23c656272b7599e23/test/metabase/server/statistics_handler_test.clj#L34)

- [Metabase async test](https://github.com/metabase/metabase/blob/aa0cdb546d7c9e4ef5c52ad23c656272b7599e23/test/metabase/util/async_test.clj#L41)

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
