### PR TITLE
New linter: :cyclomatic-complexity to warn on overly complex forms (#2809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2809](https://github.com/clj-kondo/clj-kondo/issues/2809): NEW linter: `:cyclomatic-complexity` which warns when a top-level form's cyclomatic complexity exceeds a configurable threshold (default level: `:off`, default threshold: 10)
 - Docs: update `doc/config.md` optional-linters section to include linters that are `:off` by default ([@jramosg](https://github.com/jramosg))
 - [#2811](https://github.com/clj-kondo/clj-kondo/issues/2811): report correct location for `:missing-map-value` when the malformed map is nested in a set or in map-key position, and no longer suppress subsequent lint errors in the file
 - [#2813](https://github.com/clj-kondo/clj-kondo/issues/2813): fix false positive `:unused-excluded-var` when a core var is excluded to make room for a `:refer` with `:rename` ([@jramosg](https://github.com/jramosg))

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -2631,3 +2631,24 @@ Clojure namespaces.
 *Example trigger:* `(ns special_files)`
 
 *Example message:* `Avoid underscore in namespace name: special_files`
+
+### Cyclomatic complexity
+
+*Keyword:* `:cyclomatic-complexity`.
+
+*Description:* warns when a top-level form's cyclomatic complexity exceeds the configured threshold. Each branching construct (`if`, `cond`, `case`, `and`, `or`, `catch`, etc.) adds to a base complexity of 1.
+
+*Default level:* `:off`.
+
+*Example trigger:* a `defn` containing more than 10 branching constructs.
+
+*Example message:* `Cyclomatic complexity is 12, exceeds threshold of 10. Consider breaking this into smaller functions.`
+
+*Config:*
+
+``` clojure
+:cyclomatic-complexity {:level :off
+                        :threshold 10}
+```
+
+Each function form (`defn`, `defn-`, `defmacro`, `defmethod`, `fn`, `reify`/`defrecord`/`extend-protocol` method bodies) gets its own scope and is scored independently. Branches outside any function form (e.g. inside a top-level `let` or `def` initializer) are scored on the top-level form.

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -697,13 +697,15 @@
         _ (when fn-name
             (namespace/reg-var!
              ctx ns-name fn-name expr {:temp true}))
-        parsed-bodies (map #(analyze-fn-body
-                             (-> ctx
-                                 (assoc :docstring docstring
-                                        :in-def fn-name
-                                        :macro? macro?))
-                             %)
-                           bodies)
+        body-ctx (linters/enter-fn-scope ctx expr)
+        parsed-bodies (doall (map #(analyze-fn-body
+                                    (-> body-ctx
+                                        (assoc :docstring docstring
+                                               :in-def fn-name
+                                               :macro? macro?))
+                                    %)
+                                  bodies))
+        _ (linters/report-fn-scope! body-ctx ctx)
         ;; poor naming, this is for type information
         arities (extract-arity-info ctx parsed-bodies)
         fixed-arities (into #{} (filter number?) (keys arities))
@@ -1106,20 +1108,22 @@
         arity (fn-arity ctx bodies)
         bodies (:bodies arity)
         filename (:filename ctx)
+        body-ctx (linters/enter-fn-scope ctx expr)
         parsed-bodies
-        (let [ctx (-> ctx
-                      (assoc :fn-body-count (count bodies))
-                      (assoc :fn-parent-loc (meta expr)))
-              ctx (if ?fn-name
-                    (-> ctx
-                        (update :bindings conj [?fn-name
-                                                (assoc (meta ?name-expr)
-                                                       :name ?fn-name
-                                                       :filename filename)])
-                        (update :arities assoc ?fn-name
-                                arity))
-                    ctx)]
-          (map #(analyze-fn-body ctx %) bodies))
+        (let [bctx (-> body-ctx
+                       (assoc :fn-body-count (count bodies))
+                       (assoc :fn-parent-loc (meta expr)))
+              bctx (if ?fn-name
+                     (-> bctx
+                         (update :bindings conj [?fn-name
+                                                 (assoc (meta ?name-expr)
+                                                        :name ?fn-name
+                                                        :filename filename)])
+                         (update :arities assoc ?fn-name
+                                 arity))
+                     bctx)]
+          (doall (map #(analyze-fn-body bctx %) bodies)))
+        _ (linters/report-fn-scope! body-ctx ctx)
         arities
         (when-not (some-> ctx :def-meta :macro)
           (extract-arity-info ctx parsed-bodies))
@@ -1583,6 +1587,7 @@
                                  :defined-by->lint-as defined-by->lint-as)))))
 
 (defn analyze-catch [ctx expr]
+  (linters/bump-complexity! ctx 1)
   (let [ctx (update ctx :callstack conj [nil 'catch])
         [class-expr binding-expr & exprs] (next (:children expr))
         _ (analyze-expression** ctx class-expr) ;; analyze usage for unused import linter
@@ -2729,6 +2734,9 @@
                                                 (when (and resolved-as-name resolved-as-namespace)
                                                   (symbol (name resolved-as-namespace)
                                                           (name resolved-as-name))))
+                        _ (when resolved-as-clojure-var-name
+                            (linters/bump-complexity-for-core-call!
+                             ctx resolved-as-clojure-var-name expr))
                         analyzed
                         (case resolved-as-clojure-var-name
                           (assoc assoc! sorted-map-by struct-map) (analyze-assoc ctx expr)
@@ -3521,12 +3529,13 @@
 (defn analyze-expression*
   "NOTE: :used-namespaces is used in the cache to load namespaces that were actually used."
   [ctx expression]
-  (loop [ctx (assoc ctx
-                    :bindings {}
-                    :top-level? true)
-         ns (:ns ctx)
-         [first-parsed & rest-parsed :as all]
-         (analyze-expression** ctx expression)]
+  (let [ctx (-> ctx
+                (assoc :bindings {} :top-level? true)
+                (linters/install-complexity-tracking expression))]
+    (loop [ctx ctx
+           ns (:ns ctx)
+           [first-parsed & rest-parsed :as all]
+           (analyze-expression** ctx expression)]
     (if (seq all)
       (case (:type first-parsed)
         nil (recur ctx ns rest-parsed)
@@ -3564,7 +3573,9 @@
            (assoc ctx :config config)
            ns
            rest-parsed)))
-      (assoc ctx :ns ns))))
+      (let [ctx (assoc ctx :ns ns)]
+        (linters/report-complexity! ctx)
+        ctx)))))
 
 (defn analyze-expressions
   "Analyzes expressions and collects defs and calls into a map. To

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -195,7 +195,9 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
-              :unquote-not-syntax-quoted {:level :warning}}
+              :unquote-not-syntax-quoted {:level :warning}
+              :cyclomatic-complexity {:level :off
+                                      :threshold 10}}
     ;; :hooks {:macroexpand ... :analyze-call ...}
     :lint-as {cats.core/->= clojure.core/->
               cats.core/->>= clojure.core/->>

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -1156,6 +1156,95 @@
                                    (format "Protocol method %s arities %s are not implemented"
                                            method-name (str/join ", " missing)))))))))))))
 
+(def ^:private branch-bump
+  '{if 1, if-not 1, when 1, when-not 1, while 1
+    when-let 1, when-some 1, when-first 1, if-let 1, if-some 1})
+
+(defn- count-cond-pairs [forms]
+  (let [n (count forms)
+        pairs (quot n 2)
+        last-test (when (>= n 2) (nth forms (- n 2)))
+        last-test-val (or (:k last-test) (:value last-test))]
+    (if (contains? '#{:else :default} last-test-val)
+      (dec pairs)
+      pairs)))
+
+(defn- complexity-for-core-call [op children]
+  (or (get branch-bump op)
+      (case op
+        cond (count-cond-pairs (next children))
+        case (let [forms (drop 2 children)
+                   n (count forms)]
+               (if (odd? n) (quot (dec n) 2) (quot n 2)))
+        condp (let [forms (drop 3 children)
+                    n (count forms)]
+                (if (odd? n) (quot (dec n) 2) (quot n 2)))
+        (and or) (max 0 (dec (count (next children))))
+        (some-> some->>) (max 0 (- (count children) 2))
+        ;; cond->/cond->> macroexpand into real `if` nodes; those ifs will
+        ;; bump complexity themselves, so don't double-count here.
+        (cond-> cond->>) 0
+        0)))
+
+(defn- open-scope [ctx expr]
+  (assoc ctx :complexity-volatile (volatile! 1) :complexity-node expr))
+
+(defn install-complexity-tracking
+  "Open the outer complexity scope on ctx when the linter is enabled.
+  No-op otherwise, so disabled linters add zero overhead."
+  [ctx expr]
+  (cond-> ctx
+    (not (utils/linter-disabled? ctx :cyclomatic-complexity))
+    (open-scope expr)))
+
+(defn enter-fn-scope
+  "Open a fresh scope for a function-form body (defn/fn/method).
+  No-op when tracking is off or analyzer is inside `(comment ...)`."
+  [ctx expr]
+  (cond-> ctx
+    (and (:complexity-volatile ctx) (not (:in-comment ctx)))
+    (open-scope expr)))
+
+(defn report-complexity!
+  "Emit a finding if the tracked complexity exceeds the configured threshold."
+  [ctx]
+  (when-let [v (:complexity-volatile ctx)]
+    (let [threshold (or (get-in ctx [:config :linters :cyclomatic-complexity :threshold]) 10)
+          complexity @v]
+      (when (> complexity threshold)
+        (findings/reg-finding!
+         ctx
+         (node->line (:filename ctx)
+                     (:complexity-node ctx)
+                     :cyclomatic-complexity
+                     (str "Cyclomatic complexity is " complexity
+                          ", exceeds threshold of " threshold
+                          ". Consider breaking this into smaller functions.")))))))
+
+(defn report-fn-scope!
+  "Emit a finding for the inner function scope, if one was opened."
+  [inner-ctx outer-ctx]
+  (when-not (identical? (:complexity-volatile inner-ctx)
+                        (:complexity-volatile outer-ctx))
+    (report-complexity! inner-ctx)))
+
+(defn bump-complexity!
+  "Add n to the current scope's complexity counter.
+  No-op when linter disabled or analyzer is inside `(comment ...)`."
+  [ctx n]
+  (when-let [v (:complexity-volatile ctx)]
+    (when-not (:in-comment ctx)
+      (vswap! v + n))))
+
+(defn bump-complexity-for-core-call!
+  "Bump current scope's complexity for a clojure.core/cljs.core branching op.
+  resolved-as-name is the post-:lint-as core symbol from analyze-call."
+  [ctx resolved-as-name expr]
+  (when-let [v (:complexity-volatile ctx)]
+    (when-not (:in-comment ctx)
+      (let [n (complexity-for-core-call resolved-as-name (:children expr))]
+        (when (pos? n) (vswap! v + n))))))
+
 ;;;; scratch
 
 (comment)

--- a/test/clj_kondo/cyclomatic_complexity_test.clj
+++ b/test/clj_kondo/cyclomatic_complexity_test.clj
@@ -1,0 +1,306 @@
+(ns clj-kondo.cyclomatic-complexity-test
+  (:require
+   [clj-kondo.test-utils :refer [lint! assert-submaps2]]
+   [clojure.test :refer [deftest is testing]]))
+
+(def ^:private config {:linters {:cyclomatic-complexity {:level :warning
+                                                         :threshold 2}}})
+
+(deftest basic-conditionals-test
+  (testing "single if has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (if x 1 2))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "no warning when under threshold"
+    (is (empty? (lint! "(defn foo [x] (if x 1 2))" config)))))
+
+(deftest nested-conditionals-test
+  (testing "nested if has complexity 3"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x y] (if x (if y 1 2) 3))" config)))
+
+  (testing "when has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (when x 1))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}}))))
+
+(deftest when-variants-test
+  (testing "when-not has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (when-not x 1))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "if-not has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (if-not x 1 2))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "when-let has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (when-let [y x] y))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "if-let has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (if-let [y x] y nil))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "when-some has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (when-some [y x] y))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "if-some has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (if-some [y x] y nil))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}}))))
+
+(deftest cond-test
+  (testing "cond with 3 conditions has complexity 4"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 4, exceeds threshold of 3. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (cond (< x 0) -1 (= x 0) 0 (> x 0) 1))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 3}}})))
+
+  (testing "cond with :else doesn't add extra complexity"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (cond (< x 0) -1 (> x 0) 1 :else 0))" config))))
+
+(deftest case-test
+  (testing "case with 4 clauses has complexity 5"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 5, exceeds threshold of 4. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (case x 1 :one 2 :two 3 :three 4 :four :other))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 4}}})))
+
+  (testing "case counts non-default clauses only"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (case x 1 :one 2 :two :other))" config))))
+
+(deftest condp-test
+  (testing "condp with 3 tests has complexity 4"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 4, exceeds threshold of 3. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (condp = x 1 :one 2 :two 3 :three :other))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 3}}}))))
+
+(deftest logical-operators-test
+  (testing "and with 3 operands has complexity 3"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x y z] (and x y z))" config)))
+
+  (testing "or with 2 operands has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x y] (or x y))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "nested and/or combines complexity"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 4, exceeds threshold of 3. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [a b c d] (and (or a b) (or c d)))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 3}}}))))
+
+(deftest exception-handling-test
+  (testing "try with 2 catch clauses has complexity 3"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (try (/ x 0) (catch Exception e 1) (catch Throwable t 2)))" config)))
+
+  (testing "try with 1 catch has complexity 2"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (try (/ x 0) (catch Exception e 1)))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "try with finally but no catch has complexity 1"
+    (is (empty? (lint! "(defn foo [x] (try (/ x 0) (finally (println x))))" config)))))
+
+(deftest threading-macros-test
+  (testing "some-> with 3 forms has complexity 4"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 4, exceeds threshold of 3. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (some-> x inc dec str))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 3}}})))
+
+  (testing "some->> with 2 forms has complexity 3"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (some->> x inc dec))" config)))
+
+  (testing "cond-> with 2 conditions has complexity 3"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (cond-> x true inc false dec))" config)))
+
+  (testing "cond->> with 2 conditions has complexity 3"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (cond->> x true inc false dec))" config))))
+
+(deftest recur-test
+  (testing "recur does not add complexity (loop branching is counted via if/when)"
+    (is (empty?
+         (lint! "(defn foo [x] (if (< x 10) (recur (inc x)) x))"
+                {:linters {:cyclomatic-complexity {:level :warning
+                                                   :threshold 2}}})))))
+
+(deftest complex-function-test
+  (testing "realistic complex function exceeds threshold"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 7, exceeds threshold of 5. Consider breaking this into smaller functions."})
+     (lint! "(defn process [x]
+               (cond
+                 (nil? x) nil
+                 (neg? x) (if (even? x) :neg-even :neg-odd)
+                 (zero? x) :zero
+                 (pos? x) (if (even? x) :pos-even :pos-odd)
+                 :else :unknown))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 5}}})))
+
+  (testing "function just under threshold passes"
+    (is (empty? (lint! "(defn foo [x] (if (< x 0) -1 (if (> x 0) 1 0)))"
+                       {:linters {:cyclomatic-complexity {:level :warning
+                                                          :threshold 3}}})))))
+
+(deftest configuration-test
+  (testing "linter disabled by default"
+    (is (empty? (lint! "(defn foo [x] (if (< x 0) (if (> x 10) 1 2) 3))"))))
+
+  (testing "linter respects level off"
+    (is (empty? (lint! "(defn foo [x] (if (< x 0) (if (> x 10) 1 2) 3))"
+                       {:linters {:cyclomatic-complexity {:level :off}}}))))
+
+  (testing "linter respects custom threshold"
+    (is (empty? (lint! "(defn foo [x] (if x 1 2))"
+                       {:linters {:cyclomatic-complexity {:level :warning
+                                                          :threshold 10}}}))))
+
+  (testing "ignore metadata suppresses warning"
+    (is (empty? (lint! "#_{:clj-kondo/ignore [:cyclomatic-complexity]}
+                        (defn foo [x] (if (< x 0) (if (> x 10) 1 2) 3))"
+                       config))))
+
+  (testing "linter-specific ignore works"
+    (is (empty? (lint! "^{:clj-kondo/ignore [:cyclomatic-complexity]}
+                        (defn foo [x] (if (< x 0) (if (> x 10) 1 2) 3))"
+                       config)))))
+
+(deftest scope-test
+  (testing "defn is measured"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1})
+     (lint! "(defn foo [x] (if (< x 0) (if (> x 10) 1 2) 3))" config)))
+
+  (testing "def with non-function is measured"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1})
+     (lint! "(def foo (if true 1 2))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "top-level let is measured"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1})
+     (lint! "(let [x 1] (if x 2 3))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}})))
+
+  (testing "ns declaration has low complexity"
+    (is (empty? (lint! "(ns foo.bar)" config)))))
+
+(deftest clojurescript-test
+  (testing "works with cljs.core forms"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 3, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x y] (if x (if y 1 2) 3))" config "--lang" "cljs"))))
+
+(deftest nested-fn-test
+  (testing "inner fn warns independently when outer is simple"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 14, :level :warning,
+        :message "Cyclomatic complexity is 4, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [] (fn [x] (if x (if x 1 2) (if x 3 4))))" config)))
+
+  (testing "outer defn warns independently when inner fn is simple"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 4, exceeds threshold of 2. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [a b c] (and a b c (fn [x] (if x 1 2))))" config))))
+
+(deftest comment-body-test
+  (testing "branches inside (comment ...) do not count"
+    (is (empty?
+         (lint! "(defn foo [x] (comment (if x (if x 1 2) (if x 3 4))))" config)))))
+
+(deftest while-test
+  (testing "while contributes complexity"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [x] (while x (println x)))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}}))))
+
+(deftest when-first-test
+  (testing "when-first contributes complexity"
+    (assert-submaps2
+     '({:file "<stdin>", :row 1, :col 1, :level :warning,
+        :message "Cyclomatic complexity is 2, exceeds threshold of 1. Consider breaking this into smaller functions."})
+     (lint! "(defn foo [xs] (when-first [x xs] x))"
+            {:linters {:cyclomatic-complexity {:level :warning
+                                               :threshold 1}}}))))


### PR DESCRIPTION
Adds a new optional linter :cyclomatic-complexity that warns when a top-level form (or function body within it) exceeds a configurable McCabe cyclomatic complexity threshold. Off by default, threshold defaults to 10.

Disclosure: Claude Code (Anthropic) was used to help enumerate and track representativeness of the test cases in cyclomatic_complexity_test.clj — covering each branching construct, scope-isolation scenarios, `:lint-as` interactions, and edge cases like `(comment ...)`. All test assertions were reviewed and verified against the implementation manually.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
