### PR TITLE
Use qualified symbol for var resolution in `if-kondo` trick

### DIFF
--- a/corpus/macro-from-source-if-kondo/src/myapp.clj
+++ b/corpus/macro-from-source-if-kondo/src/myapp.clj
@@ -4,10 +4,10 @@
 
 (defmacro if-kondo
   "Picks `kondo-form` at expand time when running inside clj-kondo's SCI
-  (where `-not-in-kondo` is unresolved), and `runtime-form` otherwise."
+  (where `myapp/-not-in-kondo` is unresolved), and `runtime-form` otherwise."
   {:clj-kondo/macroexpand-hook true}
   [kondo-form runtime-form]
-  (if-not (resolve '-not-in-kondo)
+  (if-not (resolve 'myapp/-not-in-kondo)
     kondo-form
     runtime-form))
 

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -436,11 +436,11 @@ namespace but is unknown to SCI, then `resolve` it at expand time.
 
 (defmacro if-kondo
   "Picks `kondo-form` at expand time when the surrounding context is
-  clj-kondo's SCI runtime (which won't have `-not-in-kondo` interned),
+  clj-kondo's SCI runtime (which won't have `my.app/-not-in-kondo` interned),
   and `runtime-form` otherwise."
   {:clj-kondo/macroexpand-hook true}
   [kondo-form runtime-form]
-  (if-not (resolve '-not-in-kondo)
+  (if-not (resolve 'my.app/-not-in-kondo)
     kondo-form
     runtime-form))
 


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x ] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x ] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Note that testing this requires running the code, as the bug is that the var isn't resolved across namespaces if the symbol is unqualified..