### PR TITLE
[perf] Add fastpaths to rewrite-clj.node.string/sexpr

### DIFF
--- a/parser/clj_kondo/impl/rewrite_clj/node/string.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/node/string.clj
@@ -7,11 +7,17 @@
 
 (defn- wrap-string
   [s]
-  (format "\"%s\"" s))
+  (str "\"" s "\""))
 
 (defn- join-lines
   [lines]
   (string/join "\n" lines))
+
+(defn- maybe-unescape
+  [s]
+  (if (string/includes? s "\\")
+    (edn/read-string (wrap-string s))
+    s))
 
 (defrecord StringNode [lines]
   node/Node
@@ -22,10 +28,9 @@
   (printable-only? [_]
     false)
   (sexpr [_]
-    (join-lines
-     (map
-      (comp edn/read-string wrap-string)
-      lines)))
+    (if (= (count lines) 1)
+      (maybe-unescape (nth lines 0))
+      (join-lines (map maybe-unescape lines))))
   (length [_]
     (+ 2 (reduce + (map count lines))))
   (string [_]

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -29209,7 +29209,7 @@
   :langs (),
   :message "unused binding this",
   :row 71}
- {:end-row 17,
+ {:end-row 23,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/node/string.clj",
@@ -29217,8 +29217,8 @@
   :end-col 12,
   :langs (),
   :message "Unresolved var: node/Node",
-  :row 17}
- {:end-row 36,
+  :row 23}
+ {:end-row 41,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/node/string.clj",
@@ -29226,7 +29226,7 @@
   :end-col 17,
   :langs (),
   :message "Unresolved var: node/string",
-  :row 36}
+  :row 41}
  {:end-row 15,
   :type :unresolved-var,
   :level :warning,


### PR DESCRIPTION
_This is a part of clojure-lsp optimization effort (https://github.com/clj-kondo/clj-kondo/issues/2778)._

Kondo calls `clj-kondo.impl.utils/sexpr` quite a bit, which in turn invokes differet rewrite-clj Node implementations of `sexpr`. StringNode in particular is expensive because it performs indiscriminate roundtrip through `edn/read-string` where in most strings it is not needed.

The proposed added fastpath removes ~3% allocations and comparatively reduces the execution time.

Before:

```
"Elapsed time: 71396.939417 msecs"
GC stats: 151 collections, allocated 54.5GB, spent 22.2 seconds on GC
```

After:

```
"Elapsed time: 69779.297458 msecs"
GC stats: 142 collections, allocated 53.1GB, spent 22.8 seconds on GC
```

Diffgraph: https://flamebin.dev/HferEf