### PR TITLE
[bench] Simplify allocation tracking in benchmarks

### DIFF
--- a/benchmarks/metabase+clojure-lsp.clj
+++ b/benchmarks/metabase+clojure-lsp.clj
@@ -1,51 +1,22 @@
 ;; invoke with clj -M:profiler:bench benchmarks/metabase+clojure-lsp.clj
+;; Allocation measurements require JDK21+. If you need to run on earlier JDK,
+;; comment allocation-related parts.
 (require '[clojure-lsp.api :as api]
          '[clojure.java.io :as io])
 
 (import
- '[com.sun.management GarbageCollectionNotificationInfo GcInfo]
- '[javax.management NotificationEmitter]
- '[java.lang.management ManagementFactory MemoryUsage]
- '[javax.management NotificationListener]
- '[javax.management.openmbean CompositeData])
+ '[com.sun.management ThreadMXBean]
+ '[java.lang.management ManagementFactory])
 
-(def gc-events (atom []))
+(def ^ThreadMXBean thread-bean (ManagementFactory/getThreadMXBean))
 
-(defn calc-freed [^GcInfo gc-info]
-  (let [before (.getMemoryUsageBeforeGc gc-info)
-        after  (.getMemoryUsageAfterGc gc-info)]
-    (reduce (fn [total pool]
-              (let [used-before (.getUsed ^MemoryUsage (get before pool))
-                    used-after  (.getUsed ^MemoryUsage (get after pool))]
-                (if (> used-before used-after)
-                  (+ total (- used-before used-after))
-                  total)))
-            0
-            (keys before))))
-
-(defn install-gc-listener! []
-  (doseq [gc-bean (ManagementFactory/getGarbageCollectorMXBeans)]
-    (.addNotificationListener
-     ^NotificationEmitter gc-bean
-     (reify NotificationListener
-       (handleNotification [_ notification _]
-         (when (= (.getType notification)
-                  GarbageCollectionNotificationInfo/GARBAGE_COLLECTION_NOTIFICATION)
-           (let [info (GarbageCollectionNotificationInfo/from
-                       ^CompositeData (.getUserData notification))
-                 gc-info (.getGcInfo info)
-                 freed   (calc-freed gc-info)]
-             (swap! gc-events conj [freed (.getDuration gc-info)])))))
-     nil nil)))
-
-(install-gc-listener!)
+(def bytes-before (.getTotalThreadAllocatedBytes thread-bean))
 
 (time (clojure-lsp.api/analyze-project-only! {:project-root (clojure.java.io/file "/Users/borkdude/dev/metabase")}))
 
-(println (format "GC stats: %s collections, collected %.1fGB, spent %.1f seconds on GC"
-                 (count @gc-events)
-                 (double (/ (reduce + (map first @gc-events)) 1e9))
-                 (double (/ (reduce + (map second @gc-events)) 1e3))))
+(let [bytes-after (.getTotalThreadAllocatedBytes thread-bean)
+      total-allocated (- bytes-after bytes-before)]
+  (println (format "Total allocated: %.1fGB" (double (/ total-allocated 1e9)))))
 
 (prn :done)
 (shutdown-agents)

--- a/benchmarks/metabase-lint.clj
+++ b/benchmarks/metabase-lint.clj
@@ -1,56 +1,26 @@
 ;; invoke with:
 ;; cd /path/to/metabase && clj -Sdeps '{:deps {clj-kondo/clj-kondo {:local/root "/Users/borkdude/dev/clj-kondo"}}}' benchmarks/metabase-lint.clj
+;; Allocation measurements require JDK21+. If you need to run on earlier JDK,
 (require '[clj-kondo.core :as kondo]
          '[clojure.java.io :as io])
 
 (import
- '[com.sun.management GarbageCollectionNotificationInfo GcInfo]
- '[javax.management NotificationEmitter]
- '[java.lang.management ManagementFactory MemoryUsage]
- '[javax.management NotificationListener]
- '[javax.management.openmbean CompositeData])
+ '[com.sun.management ThreadMXBean]
+ '[java.lang.management ManagementFactory])
 
-(def gc-events (atom []))
+(def ^ThreadMXBean thread-bean (ManagementFactory/getThreadMXBean))
 
-(defn calc-freed [^GcInfo gc-info]
-  (let [before (.getMemoryUsageBeforeGc gc-info)
-        after  (.getMemoryUsageAfterGc gc-info)]
-    (reduce (fn [total pool]
-              (let [used-before (.getUsed ^MemoryUsage (get before pool))
-                    used-after  (.getUsed ^MemoryUsage (get after pool))]
-                (if (> used-before used-after)
-                  (+ total (- used-before used-after))
-                  total)))
-            0
-            (keys before))))
-
-(defn install-gc-listener! []
-  (doseq [gc-bean (ManagementFactory/getGarbageCollectorMXBeans)]
-    (.addNotificationListener
-     ^NotificationEmitter gc-bean
-     (reify NotificationListener
-       (handleNotification [_ notification _]
-         (when (= (.getType notification)
-                  GarbageCollectionNotificationInfo/GARBAGE_COLLECTION_NOTIFICATION)
-           (let [info (GarbageCollectionNotificationInfo/from
-                       ^CompositeData (.getUserData notification))
-                 gc-info (.getGcInfo info)
-                 freed   (calc-freed gc-info)]
-             (swap! gc-events conj [freed (.getDuration gc-info)])))))
-     nil nil)))
-
-(install-gc-listener!)
+(def bytes-before (.getTotalThreadAllocatedBytes thread-bean))
 
 (let [start (System/currentTimeMillis)
       result (kondo/run! {:lint ["src"]})
-      elapsed (- (System/currentTimeMillis) start)]
+      elapsed (- (System/currentTimeMillis) start)
+      bytes-after (.getTotalThreadAllocatedBytes thread-bean)
+      total-allocated (- bytes-after bytes-before)]
   (println (format "Linting took %dms, errors: %d, warnings: %d"
                    elapsed
                    (count (filter #(= :error (:level %)) (:findings result)))
                    (count (filter #(= :warning (:level %)) (:findings result)))))
-  (println (format "GC stats: %d collections, collected %.1fGB, spent %.1f seconds on GC"
-                   (count @gc-events)
-                   (double (/ (reduce + (map first @gc-events)) 1e9))
-                   (double (/ (reduce + (map second @gc-events)) 1e3)))))
+  (println (format "Total allocated: %.1fGB" (double (/ total-allocated 1e9)))))
 
 (shutdown-agents)


### PR DESCRIPTION
A simpler method of measuring total allocations done by all threads was demonstrated to me recently. This PR introduces it to replace the GC tracking hook. Nothing major here, just less code in the benchmark files.