### PR TITLE
[perf] Optimize analysis/reg-usage!

### DIFF
--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -12,46 +12,48 @@
       (:context ctx)
       (select-keys (:context ctx) selector))))
 
-(defn- merge-select-keys [m1 m2 m2-keys]
-  (persistent! (reduce (fn [acc k]
-                         (let [v (get m2 k)]
-                           (cond-> acc
-                             (some? v) (assoc! k v))))
-                       (transient m1) m2-keys)))
+(defn- assoc-some! [tm k v]
+  (cond-> tm
+    (some? v) (assoc! k v)))
 
-(defn reg-usage! [ctx filename row col from-ns to-ns var-name arity lang in-def metadata]
-  (let [analysis (:analysis ctx)]
-    (when analysis
-      (let [to-ns (export-ns-sym to-ns)]
-        (swap! analysis update :var-usages conj
-               (-> (merge-select-keys
-                    {:filename filename
-                     :row row
-                     :col col
-                     :from from-ns
-                     :to to-ns
-                     :name var-name}
-                    metadata
-                    [:private :macro
-                     :fixed-arities
-                     :varargs-min-arity
-                     :deprecated
-                     :refer
-                     :alias
-                     :defmethod
-                     :dispatch-val-str
-                     :name-row
-                     :name-col
-                     :name-end-row
-                     :name-end-col
-                     :end-row
-                     :end-col
-                     :derived-location
-                     :derived-name-location])
-                   (assoc-some :arity arity)
-                   (assoc-some :lang lang)
-                   (assoc-some :from-var in-def)
-                   (assoc-some :context (select-context (:analysis-context ctx) ctx))))))))
+(defn reg-usage! [ctx call to-ns base-lang called-fn]
+  (when-let [analysis (:analysis ctx)]
+    (let [to-ns (export-ns-sym to-ns)
+          call-name (:name call)
+          name-meta (meta call-name)
+          result (-> (transient {})
+                     ;; Taken from `call`
+                     (assoc-some! :filename (:filename call))
+                     (assoc-some! :row (:row call))
+                     (assoc-some! :col (:col call))
+                     (assoc-some! :from (:ns call))
+                     (assoc-some! :name call-name)
+                     (assoc-some! :refer (:refer call))
+                     (assoc-some! :alias (:alias call))
+                     (assoc-some! :defmethod (:defmethod call))
+                     (assoc-some! :end-row (:end-row call))
+                     (assoc-some! :end-col (:end-col call))
+                     (assoc-some! :derived-location (:derived-location call))
+                     (assoc-some! :arity (:arity call))
+                     (assoc-some! :lang (when (= :cljc base-lang)
+                                          (:lang call)))
+                     (assoc-some! :from-var (:in-def call))
+                     (assoc-some! :dispatch-val-str (:dispatch-val-str call))
+                     (assoc-some! :name-row (:row name-meta))
+                     (assoc-some! :name-col (:col name-meta))
+                     (assoc-some! :name-end-row (:col name-meta))
+                     (assoc-some! :derived-name-location (:derived-location name-meta))
+                     ;; Taken from `called-fn`.
+                     (assoc-some! :private (:private called-fn))
+                     (assoc-some! :macro (:macro called-fn))
+                     (assoc-some! :fixed-arities (:fixed-arities called-fn))
+                     (assoc-some! :varargs-min-arity (:varargs-min-arity called-fn))
+                     (assoc-some! :deprecated (:deprecated called-fn))
+                     ;; Misc
+                     (assoc-some! :to to-ns)
+                     (assoc-some! :context (select-context (:analysis-context ctx) ctx)))]
+      ;; Use explicit lambda to avoid swap! going through less efficient varargs arity.
+      (swap! analysis #(update % :var-usages conj (persistent! result))))))
 
 (defn reg-symbol! [ctx filename from-ns symbol lang metadata]
   (when (:analyze-symbols? ctx)

--- a/src/clj_kondo/impl/analysis.clj
+++ b/src/clj_kondo/impl/analysis.clj
@@ -6,11 +6,11 @@
    [clj-kondo.impl.overrides :as overrides]
    [clj-kondo.impl.utils :as utils :refer [assoc-some export-ns-sym select-some]]))
 
-(defn select-context [selector ctx]
+(defn select-context [selector context]
   (when selector
     (if (true? selector)
-      (:context ctx)
-      (select-keys (:context ctx) selector))))
+      context
+      (select-keys context selector))))
 
 (defn- assoc-some! [tm k v]
   (cond-> tm
@@ -39,9 +39,11 @@
                                           (:lang call)))
                      (assoc-some! :from-var (:in-def call))
                      (assoc-some! :dispatch-val-str (:dispatch-val-str call))
+                     ;; Taken from `name-meta`
                      (assoc-some! :name-row (:row name-meta))
                      (assoc-some! :name-col (:col name-meta))
-                     (assoc-some! :name-end-row (:col name-meta))
+                     (assoc-some! :name-end-row (:end-row name-meta))
+                     (assoc-some! :name-end-col (:end-col name-meta))
                      (assoc-some! :derived-name-location (:derived-location name-meta))
                      ;; Taken from `called-fn`.
                      (assoc-some! :private (:private called-fn))
@@ -51,7 +53,7 @@
                      (assoc-some! :deprecated (:deprecated called-fn))
                      ;; Misc
                      (assoc-some! :to to-ns)
-                     (assoc-some! :context (select-context (:analysis-context ctx) ctx)))]
+                     (assoc-some! :context (select-context (:analysis-context ctx) (:context call))))]
       ;; Use explicit lambda to avoid swap! going through less efficient varargs arity.
       (swap! analysis #(update % :var-usages conj (persistent! result))))))
 
@@ -80,7 +82,7 @@
                 :symbol symbol}
                extra-meta)
               :lang lang
-              :context (select-context (:analysis-context ctx) ctx))))))
+              :context (select-context (:analysis-context ctx) (:context ctx)))))))
 
 (defn reg-var! [{:keys [analysis-var-meta analysis base-lang lang
                         analyze-callstack-in-defs?] :as ctx}
@@ -185,7 +187,7 @@
                          :lang (when (= :cljc (:base-lang ctx)) (:lang ctx))
                          :from-var (:in-def ctx)
                          :from (get-in ctx [:ns :name])
-                         :context (select-context (:analysis-context ctx) usage))))))
+                         :context (select-context (:analysis-context ctx) (:context usage)))))))
 
 (defn reg-protocol-impl!
   [ctx filename impl-ns protocol-ns protocol-name method-node method-name-node defined-by defined-by->lint-as]

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -407,7 +407,6 @@
                   #_#__ (prn (keys (:defs (:clj idacs))))
                   called-fn (utils/resolve-call idacs call call-lang
                                                 resolved-ns call-fn-name unresolved? refer-alls)
-
                   #_#__ (when (not call?)
                           (clojure.pprint/pprint (dissoc call :config)))
                   name-meta (meta call-fn-name)
@@ -478,11 +477,6 @@
                                 :end-row (or name-end-row end-row)
                                 :end-col (or name-end-col end-col))
                          call)))
-                  ;; row (:row call)
-                  ;; col (:col call)
-                  ;; end-row (:end-row call)
-                  ;; end-col (:end-col call)
-                  ;; filename (:filename call)
                   fn-ns (:ns called-fn)
                   resolved-ns (or fn-ns resolved-ns)
                   arity (:arity call)
@@ -490,32 +484,9 @@
                   recursive? (and
                               (= fn-ns caller-ns-sym)
                               (= call-fn-name in-def))
-                  _ (when (:analysis ctx)
-                      (when-not (:interop? call)
-                        (let [mexpr (meta (:expr call))]
-                          (when-not (:skip-analysis mexpr)
-                            (analysis/reg-usage! (assoc ctx :context (:context call))
-                                                 filename
-                                                 row
-                                                 col
-                                                 caller-ns-sym
-                                                 resolved-ns call-fn-name arity
-                                                 (when (= :cljc base-lang)
-                                                   call-lang)
-                                                 in-def
-                                                 (assoc called-fn
-                                                        :alias (:alias call)
-                                                        :refer (:refer call)
-                                                        :defmethod (:defmethod call)
-                                                        :dispatch-val-str (:dispatch-val-str call)
-                                                        :name-row name-row
-                                                        :name-col name-col
-                                                        :name-end-row name-end-row
-                                                        :name-end-col name-end-col
-                                                        :end-row end-row
-                                                        :end-col end-col
-                                                        :derived-location (:derived-location call)
-                                                        :derived-name-location (:derived-location name-meta)))))))
+                  _ (when (and (:analysis ctx) (not (:interop? call))
+                               (not (:skip-analysis (meta (:expr call)))))
+                      (analysis/reg-usage! ctx call resolved-ns base-lang called-fn))
                   call-config (:config call)
                   fn-sym (symbol (str resolved-ns)
                                  (str call-fn-name))]


### PR DESCRIPTION
_This is a part of clojure-lsp optimization effort (https://github.com/clj-kondo/clj-kondo/issues/2778)._

This is a substantial update to both `linters/lint-var-usage` and `analysis/reg-usage!` functions. The idea is to perform much fewer persistent assocs and avoid reshuffling and recombining pieces of data willy-nilly. Instead, ship source data objects to `reg-usage!` as is, and allow it to construct the desired object using a transient.

With the patch, I reliably observe 10% allocation improvement on metabase+lsp bench.

```
Before:
[ 99%] Project analyzed            "Elapsed time: 116374.493667 msecs"
Total allocated: 44.3GB

After:
[ 99%] Project analyzed            "Elapsed time: 97698.185042 msecs"
Total allocated: 40.8GB
```

Diffgraph: https://flamebin.dev/ExJDLV

---

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
