### PR TITLE
[perf] Implement and use efficient get-in

### DIFF
--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -1,9 +1,9 @@
 (ns clj-kondo.impl.config
   {:no-doc true}
-  (:refer-clojure :exclude [unquote])
+  (:refer-clojure :exclude [unquote get-in])
   (:require
    [clj-kondo.impl.findings :as findings]
-   [clj-kondo.impl.utils :as utils :refer [deep-merge map-vals]]
+   [clj-kondo.impl.utils :as utils :refer [deep-merge map-vals get-in]]
    [clojure.set :as set]
    [clojure.walk :as walk]))
 
@@ -290,9 +290,9 @@
    fq-syms))
 
 (defn skip-args
-  ([config linter]
-   (some-> (get-in config [:linters linter :skip-args])
-           (only-fq-syms-eduction))))
+  [config linter]
+  (some-> (get-in config [:linters linter :skip-args])
+          (only-fq-syms-eduction)))
 
 (defn skip?
   "Used by invalid-arity linter. We optimize for the case that disable-within returns an empty sequence"

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -290,9 +290,9 @@
    fq-syms))
 
 (defn skip-args
-  [config linter]
-  (some-> (get-in config [:linters linter :skip-args])
-          (only-fq-syms-eduction)))
+  ([config linter]
+   (some-> (get-in config [:linters linter :skip-args])
+           (only-fq-syms-eduction))))
 
 (defn skip?
   "Used by invalid-arity linter. We optimize for the case that disable-within returns an empty sequence"

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -1,5 +1,6 @@
 (ns clj-kondo.impl.linters
   {:no-doc true}
+  (:refer-clojure :exclude [get-in])
   (:require
    [clj-kondo.impl.analysis :as analysis]
    [clj-kondo.impl.config :as config]
@@ -8,7 +9,7 @@
    [clj-kondo.impl.types :as types]
    [clj-kondo.impl.types.utils :as tu]
    [clj-kondo.impl.utils :as utils :refer [constant? export-ns-sym node->line
-                                           tag]]
+                                           tag get-in]]
    [clj-kondo.impl.var-info :as var-info]
    [clojure.set :as set]
    [clojure.string :as str]))

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -1,13 +1,13 @@
 (ns clj-kondo.impl.namespace
   {:no-doc true}
-  (:refer-clojure :exclude [ns-name])
+  (:refer-clojure :exclude [ns-name get-in])
   (:require
    [clj-kondo.impl.analysis :as analysis]
    [clj-kondo.impl.analysis.java :as java]
    [clj-kondo.impl.config :as config]
    [clj-kondo.impl.findings :as findings]
    [clj-kondo.impl.utils :as utils
-    :refer [deep-merge export-ns-sym linter-disabled? node->line one-of]]
+    :refer [deep-merge export-ns-sym linter-disabled? node->line one-of get-in]]
    [clj-kondo.impl.var-info :as var-info]
    [clojure.string :as str])
   (:import

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -557,10 +557,12 @@
           arity (:arity call)]
       (when-let [args-spec
                  (or
-                  (when-let [a (:arities (config/type-mismatch-config config called-ns called-name))]
-                    (args-spec-from-arities a arity))
-                  (when-let [a (get-in built-in-specs [called-ns called-name :arities])]
-                    (args-spec-from-arities a arity))
+                  (when-let [s (config/type-mismatch-config config called-ns called-name)]
+                    (when-let [a (:arities s)]
+                      (args-spec-from-arities a arity)))
+                  (when-let [s (get-in built-in-specs [called-ns called-name])]
+                    (when-let [a (:arities s)]
+                      (args-spec-from-arities a arity)))
                   (args-spec-from-arities arities arity))]
         (when (vector? args-spec)
           (loop [check-ctx {}

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -1,6 +1,6 @@
 (ns clj-kondo.impl.types
   {:no-doc true}
-  (:refer-clojure :exclude [keyword select-keys])
+  (:refer-clojure :exclude [keyword select-keys get-in])
   (:require
    [clj-kondo.impl.config :as config]
    [clj-kondo.impl.findings :as findings]
@@ -10,7 +10,7 @@
    [clj-kondo.impl.types.clojure.test :refer [clojure-test]]
    [clj-kondo.impl.types.utils :as type-utils]
    [clj-kondo.impl.utils :as utils :refer
-    [tag sexpr select-keys]]
+    [tag sexpr select-keys get-in]]
    [clojure.string :as str]))
 
 (set! *warn-on-reflection* true)
@@ -557,12 +557,10 @@
           arity (:arity call)]
       (when-let [args-spec
                  (or
-                  (when-let [s (config/type-mismatch-config config called-ns called-name)]
-                    (when-let [a (:arities s)]
-                      (args-spec-from-arities a arity)))
-                  (when-let [s (get-in built-in-specs [called-ns called-name])]
-                    (when-let [a (:arities s)]
-                      (args-spec-from-arities a arity)))
+                  (when-let [a (:arities (config/type-mismatch-config config called-ns called-name))]
+                    (args-spec-from-arities a arity))
+                  (when-let [a (get-in built-in-specs [called-ns called-name :arities])]
+                    (args-spec-from-arities a arity))
                   (args-spec-from-arities arities arity))]
         (when (vector? args-spec)
           (loop [check-ctx {}

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -1,6 +1,6 @@
 (ns clj-kondo.impl.utils
   {:no-doc true}
-  (:refer-clojure :exclude [update-vals eduction select-keys])
+  (:refer-clojure :exclude [update-vals eduction select-keys get-in])
   (:require
    [babashka.fs :as fs]
    [clj-kondo.impl.analyzer.common :as common]
@@ -121,6 +121,16 @@
   (cond-> (attach-branch* node lang)
     splice? (update :children (fn [children]
                                 (map #(attach-branch* % lang) children)))))
+(defmacro get-in
+  "Similar to `clojure.core/get-in'`, but is a macro and when it encounters a
+  literal vector of keys, then it unrolls the keys into a series of `get` calls
+  which is more efficient than constructing the vector path and then iterating
+  over it. Otherwise, if `ks` is not a literal vector, expand to a regular
+  `clojure.core/get-in` invocation."
+  [m ks]
+  (if (vector? ks)
+    `(-> ~m ~@(map #(if (keyword? %) % `(get ~%)) ks))
+    `(clojure.core/get-in ~m ~ks)))
 
 (defn linter-disabled? [ctx linter]
   (= :off (get-in ctx [:config :linters linter :level])))


### PR DESCRIPTION
_This is a part of clojure-lsp optimization effort (https://github.com/clj-kondo/clj-kondo/issues/2778)._

`clojure.core/get-in` is bad for two reasons:
- Forces you to construct a tuple for the sequence of keys. Necessary when the sequence is known at runtime, redundant if you provide the sequence explicitly inline.
- Uses loop and sequences API to iterate the keyseq – inefficient.

This PR provides a new macro `get-in'`. The macro expands the expression into `(-> m :k1 :k2 (get non-keyword-key) ...)`, so no iteration in runtime and no unnecessary allocations.

Across the project, get-in is used a lot, and some of the usages appear on the hot paths. I didn't replace get-in with get-in' everywhere, just in those hottest callsites. All in all, it yields 5% allocations and time, give or take.

```
Before:
[ 99%] Project analyzed            "Elapsed time: 116374.493667 msecs"
Total allocated: 44.3GB

After:
[ 99%] Project analyzed            "Elapsed time: 113115.861458 msecs"
Total allocated: 42.9GB
```

Diffgraph: https://flamebin.dev/yQ89KN
