### PR TITLE
[perf] Implement and use efficient select-keys

### DIFF
--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -1,11 +1,12 @@
 (ns clj-kondo.impl.hooks
   {:no-doc true}
+  (:refer-clojure :exclude [select-keys])
   (:require
    [clj-kondo.hooks-api :as api]
    [clj-kondo.impl.config :as config]
    [clj-kondo.impl.findings :as findings]
    [clj-kondo.impl.metadata :as meta]
-   [clj-kondo.impl.utils :as utils]
+   [clj-kondo.impl.utils :as utils :refer [select-keys]]
    [clojure.java.io :as io]
    [clojure.pprint]
    [clojure.string :as str]

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -1,6 +1,6 @@
 (ns clj-kondo.impl.types
   {:no-doc true}
-  (:refer-clojure :exclude [keyword])
+  (:refer-clojure :exclude [keyword select-keys])
   (:require
    [clj-kondo.impl.config :as config]
    [clj-kondo.impl.findings :as findings]
@@ -10,7 +10,7 @@
    [clj-kondo.impl.types.clojure.test :refer [clojure-test]]
    [clj-kondo.impl.types.utils :as type-utils]
    [clj-kondo.impl.utils :as utils :refer
-    [tag sexpr]]
+    [tag sexpr select-keys]]
    [clojure.string :as str]))
 
 (set! *warn-on-reflection* true)

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -1,6 +1,6 @@
 (ns clj-kondo.impl.utils
   {:no-doc true}
-  (:refer-clojure :exclude [update-vals eduction])
+  (:refer-clojure :exclude [update-vals eduction select-keys])
   (:require
    [babashka.fs :as fs]
    [clj-kondo.impl.analyzer.common :as common]
@@ -18,6 +18,19 @@
    [clojure.string :as str]))
 
 (set! *warn-on-reflection* true)
+
+(let [not-found (Object.)]
+  (defn select-keys
+    "Like `clojure.core/select-keys`, but uses `reduce` to traverse the list of keys
+  for efficiency, and also doesn't use `find` to avoid redundant allocations."
+    [m keyseq]
+    (persistent!
+     (reduce (fn [acc k]
+               (let [v (get m k not-found)]
+                 (if (identical? v not-found)
+                   acc
+                   (assoc! acc k v))))
+             (transient {}) keyseq))))
 
 ;;; export rewrite-clj functions
 

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -32554,7 +32554,7 @@
   :langs (),
   :message "namespace clj-kondo.impl.utils is required but never used",
   :row 4}
- {:end-row 25,
+ {:end-row 38,
   :type :unresolved-var,
   :level :warning,
   :filename "src/clj_kondo/impl/utils.clj",
@@ -32562,8 +32562,8 @@
   :end-col 23,
   :langs (),
   :message "Unresolved var: node/tag",
-  :row 25}
- {:end-row 38,
+  :row 38}
+ {:end-row 51,
   :type :unresolved-var,
   :level :warning,
   :filename "src/clj_kondo/impl/utils.clj",
@@ -32571,4 +32571,4 @@
   :end-col 16,
   :langs (),
   :message "Unresolved var: node/sexpr",
-  :row 38})
+  :row 51})


### PR DESCRIPTION
_This is a part of clojure-lsp optimization effort (https://github.com/clj-kondo/clj-kondo/issues/2778)._

`clojure.core/select-keys` uses inefficient iteration and doesn't employ transients to construct the resulting map. An alternative, more efficient implementation, when used in a few strategic places, saves us ~3% on allocations and time.

```
Before:
[ 99%] Project analyzed            "Elapsed time: 116374.493667 msecs"
Total allocated: 44.3GB

After:
[ 99%] Project analyzed            "Elapsed time: 113276.594375 msecs"
Total allocated: 43.6GB
```

Diffgraph: https://flamebin.dev/NybCmz