### PR TITLE
Fix duplicate :refer-clojure

### DIFF
--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -1,6 +1,6 @@
 (ns clj-kondo.impl.hooks
   {:no-doc true}
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys macroexpand])
   (:require
    [clj-kondo.hooks-api :as api]
    [clj-kondo.impl.config :as config]
@@ -11,8 +11,7 @@
    [clojure.pprint]
    [clojure.string :as str]
    [sci.core :as sci]
-   [sci.ctx-store :as store])
-  (:refer-clojure :exclude [macroexpand]))
+   [sci.ctx-store :as store]))
 
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
A bug introduced by one of my previous PRs. Duplicate :refer-clojure certainly doesn't work as intended and also produces warnings.