### PR TITLE
Don't attach empty :children to nodes

### DIFF
--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -152,7 +152,7 @@
   [inner outer form]
   (cond
     (instance? clj_kondo.impl.rewrite_clj.node.protocols.Node form)
-    (outer (update form :children #(mapv inner %)))
+    (outer (utils/update-some form :children #(mapv inner %)))
     :else (outer form)))
 
 (defn prewalk

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -32,6 +32,16 @@
                    (assoc! acc k v))))
              (transient {}) keyseq))))
 
+(let [not-found (Object.)]
+  (defn update-some
+    "Like `clojure.core/update` but only performs the update on a key if the map
+  contains a value for that key."
+    [m k f]
+    (let [v (get m k not-found)]
+      (if (identical? v not-found)
+        m
+        (assoc m k (f v))))))
+
 ;;; export rewrite-clj functions
 
 (defn tag [expr]
@@ -119,8 +129,8 @@
 
 (defn attach-branch [node lang splice?]
   (cond-> (attach-branch* node lang)
-    splice? (update :children (fn [children]
-                                (map #(attach-branch* % lang) children)))))
+    splice? (update-some :children (fn [children]
+                                     (map #(attach-branch* % lang) children)))))
 (defmacro get-in
   "Similar to `clojure.core/get-in'`, but is a macro and when it encounters a
   literal vector of keys, then it unrolls the keys into a series of `get` calls

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -32554,7 +32554,7 @@
   :langs (),
   :message "namespace clj-kondo.impl.utils is required but never used",
   :row 4}
- {:end-row 38,
+ {:end-row 48,
   :type :unresolved-var,
   :level :warning,
   :filename "src/clj_kondo/impl/utils.clj",
@@ -32562,8 +32562,8 @@
   :end-col 23,
   :langs (),
   :message "Unresolved var: node/tag",
-  :row 38}
- {:end-row 51,
+  :row 48}
+ {:end-row 61,
   :type :unresolved-var,
   :level :warning,
   :filename "src/clj_kondo/impl/utils.clj",
@@ -32571,4 +32571,4 @@
   :end-col 16,
   :langs (),
   :message "Unresolved var: node/sexpr",
-  :row 51})
+  :row 61})


### PR DESCRIPTION
_This is a part of clojure-lsp optimization effort (https://github.com/clj-kondo/clj-kondo/issues/2778)._

I've finally started investigating the big memory footprint to Kondo/LSP maintains while the analysis is running (and which is cleared afterwards). This small, innocuous change reduces the footprint by 17% in my tests. The secret is the following: attaching an empty `:children` key to every parsed rewrite-clj node causes an extmap spillover for types that don't have `children` field (e.g. TokenNode), and that significantly inflates the nodes, and thus `:expr`s, and thus the whole context.

I don't have a formal benchmark for this yet, but what I do is I put `(def -ctx ctx)` inside `reg-usage!` function (could be any other, I suppose). Then I run `clojure-lsp.api/analyze-project-only!` as usual. The added `def` captures the context in some state (I presume, it's an almost final one) and doesn't let GC claim it. Then I run clj-memory-meter on the `-ctx`.

Results:
```
Before patch: 4.1 GB
After patch: 3.4 GB
```