### PR TITLE
[perf] Port rewrite-clj optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - [#2849](https://github.com/clj-kondo/clj-kondo/issues/2849): `:conflicting-alias` now catches conflicts with the current namespace name, not just other aliases ([@tomdl89](https://github.com/tomdl89))
 - [#2848](https://github.com/clj-kondo/clj-kondo/pull/2848): allow calling sets and vectors with 2 arguments in ClojureScript, where the second argument is the not-found value ([@p-himik](https://github.com/p-himik))
 - [#2854](https://github.com/clj-kondo/clj-kondo/issues/2854): fix false positive `:invalid-arity` when an inner binding or fn param shadows a local function name ([@yuhan0](https://github.com/yuhan0))
+- Performance optimizations: [#2853](https://github.com/clj-kondo/clj-kondo/issues/2853), [#2857](https://github.com/clj-kondo/clj-kondo/issues/2857), [#2858](https://github.com/clj-kondo/clj-kondo/issues/2858), [#2859](https://github.com/clj-kondo/clj-kondo/issues/2859), [#2866](https://github.com/clj-kondo/clj-kondo/issues/2866) ([@alexander-yakushev](https://github.com/alexander-yakushev))
 
 ## 2026.05.25
 

--- a/parser/clj_kondo/impl/rewrite_clj/node/token.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/node/token.clj
@@ -16,9 +16,10 @@
   (tag [_] :token)
   (printable-only? [_] false)
   (sexpr [this] (if (instance? clojure.lang.IObj value)
-                  (with-meta value (reduce merge (meta this)
-                                           (map (comp ->meta node/sexpr)
-                                                (:meta this))))
+                  (if-some [mta (meta this)]
+                    (with-meta value
+                               (reduce #(conj %1 (->meta (node/sexpr %2))) mta (:meta this)))
+                    value)
                   value))
   (length [_] (count string-value))
   (string [_] string-value)
@@ -33,7 +34,7 @@
 
 (defn token-node
   "Create node for an unspecified EDN token."
-  [value & [string-value]]
-  (->TokenNode
-    value
-    (or string-value (pr-str value))))
+  ([value]
+   (token-node value nil))
+  ([value string-value]
+   (->TokenNode value (or string-value (pr-str value)))))

--- a/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/core.clj
@@ -45,7 +45,8 @@
 
 (defn- parse-delim
   [reader open-delimiter close-delimiter]
-  (let [{:keys [row col]} (reader/position reader :row :col)]
+  (let [row (r/get-line-number reader)
+        col (r/get-column-number reader)]
     (reader/ignore reader)
     (reader/read-repeatedly reader parse-next
                             (->ReaderContext open-delimiter close-delimiter

--- a/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/parser/token.clj
@@ -2,37 +2,54 @@
   (:require [clj-kondo.impl.rewrite-clj
              [node :as node]
              [reader :as r]]
+            [clj-kondo.impl.rewrite-clj.parser.utils :as u]
             [clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.reader-types :as rt]))
 
 (set! *warn-on-reflection* true)
 
+;; Next two functions are extract to avoid allocating fn objects in refsites.
+
+(defn- not-boundary? [c] (not (r/whitespace-or-boundary? c)))
+
+(defn- not-boundary-allow-extra? [c]
+  (or (#{\' \:} c)
+      (not (r/whitespace-or-boundary? c))))
+
 (defn- read-to-boundary
-  ([reader] (read-to-boundary reader #{}))
-  ([reader allowed?]
-   (r/read-until
-    reader
-    #(and (not (allowed? %))
-          (r/whitespace-or-boundary? %)))))
+  [reader buf f]
+  (r/read-into-buffer-while reader buf f true))
 
 (defn- read-to-char-boundary
-  [reader]
-  (let [c (r/next reader)]
-    (str c
-         (if (not= c \\)
-           (read-to-boundary reader)
-           ""))))
+  [reader ^StringBuilder buf]
+  (if-let [c (r/next reader)]
+    (do (.append buf (char c))
+        (when-not (= c \\)
+          (read-to-boundary reader buf not-boundary?)))
+    ;; At least one char must be present after \
+    (u/throw-reader reader "Unexpected EOF")))
 
 (defn- symbol-node
   "Symbols allow for certain boundary characters that have
    to be handled explicitly."
-  [reader value value-string]
-  (let [suffix (read-to-boundary reader #{\' \:})]
-    (if (empty? suffix)
+  [reader value value-string ^StringBuilder buf]
+  (let [length-before (.length buf)
+        _ (read-to-boundary reader buf not-boundary-allow-extra?)
+        length-after (.length buf)]
+    (if (= length-before length-after)
       (node/token-node value value-string)
-      (let [s (str value-string suffix)]
-        (node/token-node
-         (r/string->edn s)
-          s)))))
+      (let [s (str buf)]
+        (node/token-node (r/read-symbol s) s)))))
+
+(defn- number-literal?
+  "Checks whether the reader is at the start of a number literal
+
+  Cribbed and adapted from clojure.tools.reader.impl.commons"
+  [^String s]
+  (let [c1 (.charAt s 0)]
+    (or (Character/isDigit c1)
+        (and (> (.length s) 1)
+             (or (identical? \+ c1) (identical? \- c1))
+             (Character/isDigit (.charAt s 1))))))
 
 (defn parse-token
   "Parse a single token."
@@ -40,14 +57,20 @@
   (let [token-row (rt/get-line-number reader)
         token-col (rt/get-column-number reader)]
     (try
-      (let [first-char (r/next reader)
-            s (->> (if (= \\ first-char)
-                     (read-to-char-boundary reader)
-                     (read-to-boundary reader))
-                   (str first-char))
-            v (r/string->edn s)]
+      (let [buf (StringBuilder.)
+            first-char (r/next reader)
+            _ (.append buf (char first-char))
+            _ (if (= \\ first-char)
+                (read-to-char-boundary reader buf)
+                (read-to-boundary reader buf not-boundary?))
+            s (str buf)
+            v (if (or (= first-char \\) ;; character like \n or \newline
+                      (= first-char \#) ;; something like ##Inf, ##Nan
+                      (number-literal? s))
+                (r/string->edn s)
+                (r/read-symbol s))]
         (if (symbol? v)
-          (symbol-node reader v s)
+          (symbol-node reader v s buf)
           (node/token-node v s)))
       (catch Exception e
         (if (and r/*reader-exceptions*

--- a/parser/clj_kondo/impl/rewrite_clj/reader.clj
+++ b/parser/clj_kondo/impl/rewrite_clj/reader.clj
@@ -3,9 +3,12 @@
   (:require [clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader
              [edn :as edn]
              [reader-types :as r]]
+            [clj-kondo.impl.toolsreader.v1v2v2.clojure.tools.reader.impl.errors
+             :as err]
             [clj-kondo.impl.rewrite-clj.parser
-              [utils :as u]]
-            [clojure.java.io :as io])
+             [utils :as u]]
+            [clojure.java.io :as io]
+            [clojure.string :as str])
   (:import [java.io PushbackReader]))
 
 (def ^:dynamic *reader-exceptions* nil)
@@ -47,12 +50,11 @@
 
 ;; ## Helpers
 
-(defn read-while
+(defn read-into-buffer-while
   "Read while the chars fulfill the given condition. Ignores
    the unmatching char."
-  [reader p? & [eof?]]
-  (let [buf (StringBuilder.)
-        eof? (if (nil? eof?)
+  [reader ^StringBuilder buf p? eof?]
+  (let [eof? (if (nil? eof?)
                (not (p? nil))
                eof?)]
     (loop []
@@ -61,12 +63,18 @@
           (do
             (.append buf (char c))
             (recur))
-          (do
-            (r/unread reader c)
-            (str buf)))
-        (if eof?
-          (str buf)
+          (r/unread reader c))
+        (when-not eof?
           (u/throw-reader reader "Unexpected EOF."))))))
+
+(defn read-while
+  "Read while the chars fulfill the given condition. Ignores the unmatching char."
+  ([reader p?]
+   (read-while reader p? nil))
+  ([reader p? eof?]
+   (let [buf (StringBuilder.)]
+     (read-into-buffer-while reader buf p? eof?)
+     (.toString buf))))
 
 (defn read-until
   "Read until a char fulfills the given condition. Ignores the
@@ -164,6 +172,48 @@
           n
           (if (= 1 n) "" "s")))
       vs)))
+
+(defn- parse-symbol
+  "Parses a string into a Symbol object, either unqualified or namespaced.
+
+  Cribbed from clojure/cljs.tools.reader.impl.commons/parse-symbol merging clj and cljs fns into single implementation
+  Added in equivalent of TRDR-73 patch to allow array class symbols (e.g. foobar/3)."
+  [^String token]
+  (when-not (or (= token "")
+                (str/ends-with? token ":")
+                (str/starts-with? token "::"))
+    (if-let [ns-idx (str/index-of token "/")]
+      (let [ns (subs token 0 ns-idx)
+            ns-idx (inc ns-idx)]
+        (when-not (== ns-idx (count token))
+          (let [sym (subs token ns-idx)]
+            (when (or (contains? #{"1" "2" "3" "4" "5" "6" "7" "8" "9"} sym)
+                      (and (not (Character/isDigit (char (nth sym 0))))
+                           (not (= "" sym))
+                           (not (str/ends-with? ns ":"))
+                           (or (= sym "/")
+                               (nil? (str/index-of sym "/")))))
+              (symbol ns sym)))))
+      (symbol token))))
+
+(defn read-symbol
+  "Return symbol parsed from `token`.
+
+  Cribbed from clojure/cljs.tools.reader.edn/read-symbol and - adapted to work on string"
+  [^String token]
+  (case token
+    ;; special symbols
+    "nil" nil
+    "true" true
+    "false" false
+    "/" '/
+
+    (or (parse-symbol token)
+        ;; Throw in same way that tools.reader would when reading a string
+        ;; for exeption compatibility. Some users, like clojure-lsp, currently rely
+        ;; on parsing exception strings. A user having to resort
+        ;; to parsing exception messages is not great, but a separate issue.
+        (err/throw-invalid nil :symbol token))))
 
 ;; ## Reader Types
 

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -29236,16 +29236,16 @@
   :langs (),
   :message "Unresolved var: node/Node",
   :row 15}
- {:end-row 20,
+ {:end-row 21,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/node/token.clj",
-  :col 62,
-  :end-col 72,
+  :col 59,
+  :end-col 69,
   :langs (),
   :message "Unresolved var: node/sexpr",
-  :row 20}
- {:end-row 28,
+  :row 21}
+ {:end-row 29,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/node/token.clj",
@@ -29253,7 +29253,7 @@
   :end-col 17,
   :langs (),
   :message "Unresolved var: node/string",
-  :row 28}
+  :row 29}
  {:end-row 7,
   :type :unresolved-var,
   :level :warning,
@@ -29317,7 +29317,7 @@
   :langs (),
   :message "Unresolved var: node/forms-node",
   :row 20}
- {:end-row 63,
+ {:end-row 64,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29325,8 +29325,8 @@
   :end-col 36,
   :langs (),
   :message "Unresolved var: node/printable-only?",
-  :row 63}
- {:end-row 173,
+  :row 64}
+ {:end-row 174,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29334,8 +29334,8 @@
   :end-col 46,
   :langs (),
   :message "Unresolved var: node/tag",
-  :row 173}
- {:end-row 220,
+  :row 174}
+ {:end-row 221,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29343,8 +29343,8 @@
   :end-col 22,
   :langs (),
   :message "Unresolved var: node/set-node",
-  :row 220}
- {:end-row 221,
+  :row 221}
+ {:end-row 222,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29352,8 +29352,8 @@
   :end-col 21,
   :langs (),
   :message "Unresolved var: node/fn-node",
-  :row 221}
- {:end-row 222,
+  :row 222}
+ {:end-row 223,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29361,8 +29361,8 @@
   :end-col 24,
   :langs (),
   :message "Unresolved var: node/regex-node",
-  :row 222}
- {:end-row 224,
+  :row 223}
+ {:end-row 225,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29370,8 +29370,8 @@
   :end-col 22,
   :langs (),
   :message "Unresolved var: node/var-node",
-  :row 224}
- {:end-row 225,
+  :row 225}
+ {:end-row 226,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29379,8 +29379,8 @@
   :end-col 23,
   :langs (),
   :message "Unresolved var: node/eval-node",
-  :row 225}
- {:end-row 234,
+  :row 226}
+ {:end-row 235,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29388,8 +29388,8 @@
   :end-col 33,
   :langs (),
   :message "Unresolved var: node/reader-macro-node",
-  :row 234}
- {:end-row 238,
+  :row 235}
+ {:end-row 239,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29397,8 +29397,8 @@
   :end-col 40,
   :langs (),
   :message "Unresolved var: node/token-node",
-  :row 238}
- {:end-row 252,
+  :row 239}
+ {:end-row 253,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29406,8 +29406,8 @@
   :end-col 19,
   :langs (),
   :message "Unresolved var: node/deref-node",
-  :row 252}
- {:end-row 258,
+  :row 253}
+ {:end-row 259,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29415,8 +29415,8 @@
   :end-col 19,
   :langs (),
   :message "Unresolved var: node/quote-node",
-  :row 258}
- {:end-row 262,
+  :row 259}
+ {:end-row 263,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29424,8 +29424,8 @@
   :end-col 26,
   :langs (),
   :message "Unresolved var: node/syntax-quote-node",
-  :row 262}
- {:end-row 269,
+  :row 263}
+ {:end-row 270,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29433,8 +29433,8 @@
   :end-col 34,
   :langs (),
   :message "Unresolved var: node/unquote-splicing-node",
-  :row 269}
- {:end-row 271,
+  :row 270}
+ {:end-row 272,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29442,8 +29442,8 @@
   :end-col 25,
   :langs (),
   :message "Unresolved var: node/unquote-node",
-  :row 271}
- {:end-row 278,
+  :row 272}
+ {:end-row 279,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29451,8 +29451,8 @@
   :end-col 18,
   :langs (),
   :message "Unresolved var: node/list-node",
-  :row 278}
- {:end-row 282,
+  :row 279}
+ {:end-row 283,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29460,8 +29460,8 @@
   :end-col 20,
   :langs (),
   :message "Unresolved var: node/vector-node",
-  :row 282}
- {:end-row 286,
+  :row 283}
+ {:end-row 287,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/core.clj",
@@ -29469,7 +29469,7 @@
   :end-col 17,
   :langs (),
   :message "Unresolved var: node/map-node",
-  :row 286}
+  :row 287}
  {:end-row 43,
   :type :unresolved-var,
   :level :warning,
@@ -29498,7 +29498,7 @@
   :langs (),
   :message "Unresolved var: node/string-node",
   :row 10}
- {:end-row 31,
+ {:end-row 39,
   :type :unresolved-var,
   :level :warning,
   :filename "parser/clj_kondo/impl/rewrite_clj/parser/token.clj",
@@ -29506,7 +29506,7 @@
   :end-col 23,
   :langs (),
   :message "Unresolved var: node/token-node",
-  :row 31}
+  :row 39}
  {:end-row 12,
   :type :unresolved-var,
   :level :warning,


### PR DESCRIPTION
In this PR, I port the optimizations that were already merged to rewrite-clj in https://github.com/clj-commons/rewrite-clj/pull/459. Also, I replace a bunch of vararg arities with fixed multi-arity to prevent arglist rollups.

In the end, this reduces allocations in Metabase+LSP benchmark by ~3%. Not earth-shattering, but since the changes are already in rewrite-clj upstream, I think it won't hurt.

Diffgraph: https://flamebin.dev/pxfxFA

---

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
