### PR TITLE
[perf] Various optimizations

### DIFF
--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -42,7 +42,7 @@
    [clj-kondo.impl.utils :as utils :refer
     [assoc-some ctx-with-bindings linter-disabled? node->line
      one-of parse-string select-lang sexpr string-from-token symbol-call
-     tag]]
+     tag assoc-new some']]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -67,15 +67,15 @@
      (when-not (and (:in-comment ctx)
                     (:skip-comments config))
        (let [len (count children)
-             ctx (assoc ctx
-                        :top-level? top-level?
-                        :arg-types (if add-new-arg-types?
-                                     (let [[k v] (first callstack)]
-                                       (when (and (symbol? k)
-                                                  (symbol? v))
-                                         (atom [])))
-                                     (:arg-types ctx))
-                        :len len)]
+             ctx (-> ctx
+                     (assoc-new :top-level? top-level?)
+                     (assoc-new :arg-types (if add-new-arg-types?
+                                             (let [[k v] (first callstack)]
+                                               (when (and (symbol? k)
+                                                          (symbol? v))
+                                                 (atom [])))
+                                             (:arg-types ctx)))
+                     (assoc-new :len len))]
          (into []
                (comp (map-indexed (fn [i e]
                                     (analyze-expression** (assoc ctx :idx i) e)))
@@ -174,9 +174,12 @@
 (defn analyze-binding-vector [ctx children]
   (let [as-kw? (fn [n] (and (= :as (:k n))
                             (not (:namespaced? n))))
-        rest-param+ (into [] (drop-while #(not= '&  (:value %))) children)
-        varargs     (into [] (take-while (complement as-kw?)) rest-param+)
-        as-args     (into [] (drop-while (complement as-kw?)) children)]
+        rest-param+ (when (some' #(= (:value %) '&) children)
+                      (into [] (drop-while #(not= '& (:value %))) children))
+        varargs     (when rest-param+
+                      (into [] (take-while (complement as-kw?)) rest-param+))
+        as-args     (when (some' as-kw? children)
+                      (into [] (drop-while (complement as-kw?)) children))]
     (cond (and (< 1 (count varargs))
                (= '& (:value (second varargs))))
           (findings/reg-finding!
@@ -4349,11 +4352,7 @@
                         :global-config config)]
     (swap! (:used-namespaces ctx)
            update base-lang into (:used-namespaces init-ns))
-    (loop [ctx init-ctx
-           [expression & rest-expressions] expressions]
-      (when expression
-        (let [ctx (analyze-expression* ctx expression)]
-          (recur ctx rest-expressions))))))
+    (reduce analyze-expression* init-ctx expressions)))
 
 ;;;; processing of string input
 

--- a/src/clj_kondo/impl/analyzer/usages.clj
+++ b/src/clj_kondo/impl/analyzer/usages.clj
@@ -9,7 +9,7 @@
    [clj-kondo.impl.namespace :as namespace]
    [clj-kondo.impl.types :as types]
    [clj-kondo.impl.utils :as utils :refer [tag one-of symbol-from-token kw->sym assoc-some
-                                           symbol-token?]]
+                                           symbol-token? assoc-new]]
    [clojure.string :as str])
   (:import [clj_kondo.impl.rewrite_clj.node.seq NamespacedMapNode]))
 
@@ -126,7 +126,7 @@
         (f ctx m)))))
 
 (defn analyze-usages2
-  ([ctx expr] (analyze-usages2 ctx expr {}))
+  ([ctx expr] (analyze-usages2 ctx expr {:quote? false, :syntax-quote? false}))
   ([ctx expr {:keys [quote? syntax-quote?] :as opts}]
    (let [ns (:ns ctx)
          dependencies (:dependencies ctx)
@@ -141,23 +141,21 @@
          new-syntax-quote-level (if syntax-quote-tag? (inc syntax-quote-level)
                                     syntax-quote-level)
          syntax-quote? (or syntax-quote? syntax-quote-tag?)
-         ctx (assoc ctx :syntax-quote-level new-syntax-quote-level)
+         ctx (assoc-new ctx :syntax-quote-level new-syntax-quote-level)
          ctx (if syntax-quote-tag?
                (update ctx :callstack #(cons [:syntax-quote] %))
                ctx)
-         new-syntax-quote-level-pos? (pos? new-syntax-quote-level)]
+         new-syntax-quote-level-pos? (pos? new-syntax-quote-level)
+         opts' (-> opts
+                   (assoc-new :quote? quote?)
+                   (assoc-new :syntax-quote? syntax-quote?))]
      (if (and new-syntax-quote-level-pos? unquote-tag?)
        (common/analyze-expression** ctx expr)
        (if quote?
          (do
            (when (:k expr)
              (analyze-keyword ctx expr opts))
-           (doall (mapcat
-                   #(analyze-usages2 ctx %
-                                     (assoc opts
-                                            :quote? quote?
-                                            :syntax-quote? syntax-quote?))
-                   (:children expr))))
+           (into [] (mapcat #(analyze-usages2 ctx % opts')) (:children expr)))
          (do
            (meta/lift-meta-content2 ctx expr true)
            (case t
@@ -339,13 +337,6 @@
                  (when (:k expr)
                    (analyze-keyword ctx expr opts))))
              :reader-macro
-             (doall (mapcat
-                     #(analyze-usages2 ctx %
-                                       (assoc opts :quote? quote? :syntax-quote? syntax-quote?))
-                     (rest (:children expr))))
+             (into [] (mapcat #(analyze-usages2 ctx % opts')) (rest (:children expr)))
              ;; catch-call
-             (doall (mapcat
-                     #(analyze-usages2 ctx %
-                                       (assoc opts :quote? quote? :syntax-quote? syntax-quote?))
-                     (:children expr))))))))))
-
+             (into [] (mapcat #(analyze-usages2 ctx % opts')) (:children expr)))))))))

--- a/src/clj_kondo/impl/hooks.clj
+++ b/src/clj_kondo/impl/hooks.clj
@@ -6,7 +6,7 @@
    [clj-kondo.impl.config :as config]
    [clj-kondo.impl.findings :as findings]
    [clj-kondo.impl.metadata :as meta]
-   [clj-kondo.impl.utils :as utils :refer [select-keys]]
+   [clj-kondo.impl.utils :as utils :refer [select-keys some']]
    [clojure.java.io :as io]
    [clojure.pprint]
    [clojure.string :as str]
@@ -230,10 +230,10 @@
         filename (:filename ctx)]
     (when hook-cfg
       (if-let [x (or (get-in hook-cfg [:analyze-call sym])
-                      (some (fn [group-sym]
-                              (get-in hook-cfg [:analyze-call (symbol (str group-sym)
-                                                                      (str var-sym))]))
-                            (config/ns-groups-eduction ctx config ns-sym filename)))]
+                      (some' (fn [group-sym]
+                               (get-in hook-cfg [:analyze-call (symbol (str group-sym)
+                                                                       (str var-sym))]))
+                             (config/ns-groups-eduction ctx config ns-sym filename)))]
         (sci/binding [sci/out *out*
                       sci/err *err*]
           (binding [utils/*ctx* ctx]
@@ -251,10 +251,10 @@
                                    x)))]
               (sci/eval-string* (store/get-ctx) code))))
         (when-let [x (or (get-in hook-cfg [:macroexpand sym])
-                          (some (fn [group-sym]
-                                  (get-in hook-cfg [:macroexpand (symbol (str group-sym)
-                                                                         (str var-sym))]))
-                                (config/ns-groups-eduction ctx config ns-sym filename)))]
+                          (some' (fn [group-sym]
+                                   (get-in hook-cfg [:macroexpand (symbol (str group-sym)
+                                                                          (str var-sym))]))
+                                 (config/ns-groups-eduction ctx config ns-sym filename)))]
           (sci/binding [sci/out *out*
                         sci/err *err*]
             (binding [utils/*ctx* ctx]

--- a/src/clj_kondo/impl/types.clj
+++ b/src/clj_kondo/impl/types.clj
@@ -348,33 +348,30 @@
 
 (defn map->tag [ctx expr]
   (let [children (:children expr)
-        kexprs (take-nth 2 children)
-        mvals (take-nth 2 (rest children))
-        ;; each key resolves to [mk] when statically known, else nil. The
-        ;; wrap distinguishes a nil or false key from an unknown one. A
-        ;; quoted collection is static but map-key cannot extract it, so it
-        ;; opens the map, like a dynamic key
-        keys* (map (fn [k]
-                     (when (static-map-key? ctx k)
-                       (let [mk (map-key ctx k)]
-                         (when (known-map-key? mk) [mk]))))
-                   kexprs)
-        all-known? (every? some? keys*)
-        entries (map (fn [kw e]
-                       (when kw
-                         (let [t (expr->tag ctx e)
-                               m (meta e)]
-                           ;; NOTE: be careful to not include any
-                           ;; non-serializable data here, see issue #2165
-                           [(first kw) (cond-> (select-keys m [:row :end-row :col :end-col])
-                                         t (assoc :tag t))])))
-                     keys* mvals)]
+        all-known? (volatile! true)
+        val (reduce (fn [acc [k e]]
+                      ;; A quoted collection is static but map-key cannot
+                      ;; extract it, so it opens the map, like a dynamic key
+                      (if (static-map-key? ctx k)
+                        (let [mk (map-key ctx k)]
+                          (if (known-map-key? mk)
+                            (let [t (expr->tag ctx e)
+                                  m (meta e)]
+                              ;; NOTE: be careful to not include any
+                              ;; non-serializable data here, see issue #2165
+                              (assoc acc mk (cond-> (select-keys m [:row :end-row :col :end-col])
+                                              t (assoc :tag t))))
+                            (do (vreset! all-known? false)
+                                acc)))
+                        (do (vreset! all-known? false)
+                            acc)))
+                    {} (partition 2 children))]
     (cond-> {:type :map
-             :val (into {} (remove nil?) entries)}
+             :val val}
       ;; a generated literal, e.g. a hook's placeholder map, is no evidence
       ;; of absence, and a dynamic or inextractable key could be any key:
       ;; only a map whose every key is statically known is closed
-      (or (not all-known?)
+      (or (not @all-known?)
           (let [m (meta expr)]
             (or (:clj-kondo.impl/generated expr)
                 (:clj-kondo.impl/generated m)

--- a/src/clj_kondo/impl/utils.clj
+++ b/src/clj_kondo/impl/utils.clj
@@ -442,6 +442,15 @@
            (assoc-some m k v)
            (partition 2 kvs))))
 
+(defn assoc-new
+  "Associates a key with a value in a map if the previous value is missing or
+  different from new value. Treats missing value and `nil` as same."
+  [m k v]
+  (let [old-value (get m k nil)]
+    (if (= old-value v)
+      m
+      (assoc m k v))))
+
 (defn select-some
   "Like select-keys, but only selects when value is not nil."
   ([m ks]


### PR DESCRIPTION
Small optimizations which that don't make sense to split into separate PRs. In total, this saves ~100-200 MB of allocations on `metabase-lint.clj` benchmark (from 7.1GB to 6.9-7.0GB).

Diffgraph: https://flamebin.dev/HTqJKk