### PR TITLE
Add `:redefined-spec` linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ### New
 
-- [#2878](https://github.com/clj-kondo/clj-kondo/issues/2878): new `:redefined-spec` linter that reports duplicate `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` and `s/fdef` registrations. Registrations are compared by their fully resolved identity, so `::foo` in two namespaces are distinct while an alias and the equivalent fully-qualified keyword are the same. Detection is project-wide, both within a run and across runs via a global spec index in the cache that mirrors spec's own global registry.
+- [#2878](https://github.com/clj-kondo/clj-kondo/issues/2878): new `:redefined-spec` linter that reports duplicate `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` and `s/fdef` registrations.
 
 ## 2026.07.24
 
@@ -176,7 +176,7 @@ Performance: linting is faster and allocates less. Var usages and bindings are n
 - `unused-excluded-var`: Add location metadata to excluded vars in `ns-unmap`. This fixes some findings with not location. ([@jramosg](https://github.com/jramosg))
 - [#2747](https://github.com/clj-kondo/clj-kondo/issues/2747): Fix: Gensym bindings in nested syntax quotes are now correctly recognized ([@jramosg](https://github.com/jramosg))when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2746](https://github.com/clj-kondo/clj-kondo/issues/2746): Fix regression: primitive array class syntax (e.g., `byte/1`, `int/2`) now correctly recognized as class literals in type checking ([@jramosg](https://github.com/jramosg))
-- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg)) 
+- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2749](https://github.com/clj-kondo/clj-kondo/issues/2749): Fix false positive for throw in CLJS when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2732](https://github.com/clj-kondo/clj-kondo/issues/2732): `unreachable-code`: warn when `:default` does not come last in reader conditionals ([@jramosg](https://github.com/jramosg))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] github release (publish the draft manually) -->
 <!-- - [ ] bb script/release-everything.clj -> homebrew, clj-kondo pod, clj-kondo-bb, lein-clj-kondo, post-release bump -->
 
+## Unreleased
+
+### New
+
+- [#2878](https://github.com/clj-kondo/clj-kondo/issues/2878): new `:redefined-spec` linter that reports duplicate `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` and `s/fdef` registrations. Registrations are compared by their fully resolved identity, so `::foo` in two namespaces are distinct while an alias and the equivalent fully-qualified keyword are the same. Detection is project-wide, both within a run and across runs via a global spec index in the cache that mirrors spec's own global registry.
+
 ## 2026.07.24
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+### New
+
+- [#2878](https://github.com/clj-kondo/clj-kondo/issues/2878): new `:redefined-spec` linter that reports duplicate `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` and `s/fdef` registrations. Registrations are compared by their fully resolved identity, so `::foo` in two namespaces are distinct while an alias and the equivalent fully-qualified keyword are the same. Detection is project-wide, both within a run and across runs via a global spec index in the cache that mirrors spec's own global registry.
+
+### Fixed
+
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 
 ## 2026.08.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ### New
 
-- [#2878](https://github.com/clj-kondo/clj-kondo/issues/2878): new `:redefined-spec` linter that reports duplicate `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` and `s/fdef` registrations. Registrations are compared by their fully resolved identity, so `::foo` in two namespaces are distinct while an alias and the equivalent fully-qualified keyword are the same. Detection is project-wide, both within a run and across runs via a global spec index in the cache that mirrors spec's own global registry.
+- [#2878](https://github.com/clj-kondo/clj-kondo/issues/2878): new `:redefined-spec` linter that reports duplicate `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` and `s/fdef` registrations.
 
 ### Fixed
 
@@ -195,7 +195,7 @@ Performance: linting is faster and allocates less. Var usages and bindings are n
 - `unused-excluded-var`: Add location metadata to excluded vars in `ns-unmap`. This fixes some findings with not location. ([@jramosg](https://github.com/jramosg))
 - [#2747](https://github.com/clj-kondo/clj-kondo/issues/2747): Fix: Gensym bindings in nested syntax quotes are now correctly recognized ([@jramosg](https://github.com/jramosg))when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2746](https://github.com/clj-kondo/clj-kondo/issues/2746): Fix regression: primitive array class syntax (e.g., `byte/1`, `int/2`) now correctly recognized as class literals in type checking ([@jramosg](https://github.com/jramosg))
-- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg)) 
+- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2749](https://github.com/clj-kondo/clj-kondo/issues/2749): Fix false positive for throw in CLJS when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2732](https://github.com/clj-kondo/clj-kondo/issues/2732): `unreachable-code`: warn when `:default` does not come last in reader conditionals ([@jramosg](https://github.com/jramosg))

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1673,21 +1673,6 @@ message is: `inc already refers to #'clojure.core/inc`
 
 *Description:* warn when a `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` or
 `s/fdef` redefines a spec that was already registered elsewhere in the project.
-Registrations are compared by their fully resolved identity, so `::foo` in two
-different namespaces are distinct, while `:some-alias/foo` and the equivalent
-fully qualified keyword refer to the same spec. `s/def` and `s/fdef` share one
-identity space: an `s/fdef` and an `s/def` that resolve to the same name are
-considered redefinitions of each other. Because a spec's identity is
-runtime-specific, a spec registered in a `.clj` file and one in a `.cljs` file
-with the same name do not clash, while a `.cljc` registration is checked against
-both.
-
-Detection is project-wide, both when linting the whole project in a single run
-and across separate runs (e.g. editor integration linting a single file). Across
-runs it uses a global spec index stored in the cache that mirrors spec's own
-global registry: every registration from every previously linted file is
-considered, independent of the require graph. Re-linting a file refreshes its
-entries, so removing an `s/def` also removes it from the index.
 
 *Default level:* `:warning`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -89,6 +89,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Private call](#private-call)
     - [Protocol method varargs](#protocol-method-varargs)
     - [Redefined var](#redefined-var)
+    - [Redefined spec](#redefined-spec)
     - [Var same name except case](#var-same-name-except-case)
     - [Alias same as ns name](#alias-same-ns-name)
     - [Redundant do](#redundant-do)
@@ -1665,6 +1666,34 @@ To suppress the above message, refer to `foo/f` using the var `#'foo/f` or write
 
 When redefining a var from another namespace that was referred, e.g. `inc`, the
 message is: `inc already refers to #'clojure.core/inc`
+
+### Redefined spec
+
+*Keyword:* `:redefined-spec`.
+
+*Description:* warn when a `clojure.spec.alpha`/`cljs.spec.alpha` `s/def` or
+`s/fdef` redefines a spec that was already registered elsewhere in the project.
+Registrations are compared by their fully resolved identity, so `::foo` in two
+different namespaces are distinct, while `:some-alias/foo` and the equivalent
+fully qualified keyword refer to the same spec. `s/def` and `s/fdef` share one
+identity space: an `s/fdef` and an `s/def` that resolve to the same name are
+considered redefinitions of each other. Because a spec's identity is
+runtime-specific, a spec registered in a `.clj` file and one in a `.cljs` file
+with the same name do not clash, while a `.cljc` registration is checked against
+both.
+
+Detection is project-wide, both when linting the whole project in a single run
+and across separate runs (e.g. editor integration linting a single file). Across
+runs it uses a global spec index stored in the cache that mirrors spec's own
+global registry: every registration from every previously linted file is
+considered, independent of the require graph. Re-linting a file refreshes its
+entries, so removing an `s/def` also removes it from the index.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(s/def ::foo string?) (s/def ::foo int?)`
+
+*Example message:* `redefined spec :user/foo, first defined at src/user.clj:1:8`.
 
 ### Var same name except case
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1678,7 +1678,7 @@ message is: `inc already refers to #'clojure.core/inc`
 
 *Example trigger:* `(s/def ::foo string?) (s/def ::foo int?)`
 
-*Example message:* `redefined spec :user/foo, first defined at src/user.clj:1:8`.
+*Example message:* `spec :user/foo also defined at src/user.clj:1:8`.
 
 Detection is project-wide and spans runs: registrations from previously linted
 files are remembered in the cache (mirroring spec's own global registry), so a

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1680,6 +1680,13 @@ message is: `inc already refers to #'clojure.core/inc`
 
 *Example message:* `redefined spec :user/foo, first defined at src/user.clj:1:8`.
 
+Detection is project-wide and spans runs: registrations from previously linted
+files are remembered in the cache (mirroring spec's own global registry), so a
+finding can point at a file that is not part of the current lint set, and
+linting a single file can report a redefinition of a spec registered elsewhere.
+Since this depends on cache state, stale results can be reset by deleting the
+cache directory (`.clj-kondo/.cache`) or by linting with `--cache false`.
+
 ### Var same name except case
 
 *Keyword:* `:var-same-name-except-case`.

--- a/src/clj_kondo/core.clj
+++ b/src/clj_kondo/core.clj
@@ -253,6 +253,7 @@
                     (l/lint-var-usage ctx idacs)
                     (l/lint-deferred-conditions! ctx idacs)
                     (l/lint-unused-namespaces! ctx idacs)
+                    (l/lint-redefined-specs! ctx)
                     (l/lint-unused-private-vars! ctx)
                     (l/lint-bindings! ctx)
                     (l/lint-unresolved-symbols! ctx)

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -16,15 +16,17 @@
   (not (identical? :off (get-in ctx [:global-config :linters :redefined-spec :level]))))
 
 (defn reg-spec-def!
-  "Records a spec registration for the :redefined-spec linter. `tp` is :def or
-  :fdef, `name-node` is the registered name node and `resolved-ns`/`resolved-name`
-  its fully-resolved identity."
-  [ctx tp name-node resolved-ns resolved-name]
+  "Records a spec registration for the :redefined-spec linter. `kind` is
+  :keyword (a keyword-keyed `s/def`) or :symbol (a symbol-keyed `s/def` or an
+  `s/fdef`), matching the two disjoint key spaces of spec's registry.
+  `name-node` is the registered name node and `resolved-ns`/`resolved-name` its
+  fully-resolved identity."
+  [ctx kind name-node resolved-ns resolved-name]
   (when (and resolved-ns resolved-name (redefined-spec-enabled? ctx))
     (namespace/reg-spec-def! ctx (-> ctx :ns :name)
                              (assoc (utils/location (meta name-node))
                                     :filename (:filename ctx)
-                                    :type tp
+                                    :kind kind
                                     :ns resolved-ns
                                     :name resolved-name))))
 
@@ -48,8 +50,8 @@
             ;; regardless of whether its var has been analyzed yet, so key it
             ;; there for consistent cross-file detection
             (if (and unresolved? (not (namespace sym)))
-              (reg-spec-def! ctx :fdef sym-expr ns-nm resolved-name)
-              (reg-spec-def! ctx :fdef sym-expr resolved-ns resolved-name))
+              (reg-spec-def! ctx :symbol sym-expr ns-nm resolved-name)
+              (reg-spec-def! ctx :symbol sym-expr resolved-ns resolved-name))
             ;; revisit this when needed
             #_(findings/reg-finding! ctx
                                      (utils/node->line (:filename ctx)
@@ -65,7 +67,7 @@
                   name-expr)]
     (when (and (:k name-expr) (redefined-spec-enabled? ctx))
       (let [{:keys [ns name]} (usages/resolve-keyword ctx name-expr (-> ctx :ns :name))]
-        (reg-spec-def! ctx :def name-expr ns name)))
+        (reg-spec-def! ctx :keyword name-expr ns name)))
     (common/analyze-expression** (utils/ctx-with-linter-disabled ctx :unresolved-symbol) reg-val)
     (common/analyze-children ctx body)))
 

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -2,10 +2,31 @@
   {:no-doc true}
   (:require
    [clj-kondo.impl.analyzer.common :as common]
+   [clj-kondo.impl.analyzer.usages :as usages]
    [clj-kondo.impl.findings :as findings]
    [clj-kondo.impl.linters.keys :as keys]
    [clj-kondo.impl.namespace :as namespace]
    [clj-kondo.impl.utils :as utils]))
+
+(defn- redefined-spec-enabled?
+  "The :redefined-spec linter reports duplicates project-wide from a
+  post-analysis pass, so we record registrations whenever the linter isn't
+  globally off, regardless of namespace-local config."
+  [ctx]
+  (not (identical? :off (get-in ctx [:global-config :linters :redefined-spec :level]))))
+
+(defn reg-spec-def!
+  "Records a spec registration for the :redefined-spec linter. `tp` is :def or
+  :fdef, `name-node` is the registered name node and `resolved-ns`/`resolved-name`
+  its fully-resolved identity."
+  [ctx tp name-node resolved-ns resolved-name]
+  (when (and resolved-ns resolved-name (redefined-spec-enabled? ctx))
+    (namespace/reg-spec-def! ctx (-> ctx :ns :name)
+                             (assoc (utils/location (meta name-node))
+                                    :filename (:filename ctx)
+                                    :type tp
+                                    :ns resolved-ns
+                                    :name resolved-name))))
 
 (defn analyze-fdef [{:keys [analyze-children ns] :as ctx} expr]
   (let [[sym-expr & body] (next (:children expr))
@@ -18,11 +39,17 @@
                                                  sym-expr
                                                  :syntax
                                                  "expected symbol"))
-        (let [{resolved-ns :ns}
+        (let [{resolved-ns :ns resolved-name :name unresolved? :unresolved?}
               (namespace/resolve-name ctx true ns-nm
                                       sym nil)]
           (when resolved-ns
             (namespace/reg-used-namespace! ctx ns-nm resolved-ns)
+            ;; an unqualified fdef target registers under the current namespace,
+            ;; regardless of whether its var has been analyzed yet, so key it
+            ;; there for consistent cross-file detection
+            (if (and unresolved? (not (namespace sym)))
+              (reg-spec-def! ctx :fdef sym-expr ns-nm resolved-name)
+              (reg-spec-def! ctx :fdef sym-expr resolved-ns resolved-name))
             ;; revisit this when needed
             #_(findings/reg-finding! ctx
                                      (utils/node->line (:filename ctx)
@@ -36,6 +63,9 @@
         reg-val (if (:k name-expr)
                   (assoc name-expr :reg fq-def)
                   name-expr)]
+    (when (and (:k name-expr) (redefined-spec-enabled? ctx))
+      (let [{:keys [ns name]} (usages/resolve-keyword ctx name-expr (-> ctx :ns :name))]
+        (reg-spec-def! ctx :def name-expr ns name)))
     (common/analyze-expression** (utils/ctx-with-linter-disabled ctx :unresolved-symbol) reg-val)
     (common/analyze-children ctx body)))
 

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -67,9 +67,21 @@
         reg-val (if (:k name-expr)
                   (assoc name-expr :reg fq-def)
                   name-expr)]
-    (when (and (:k name-expr) (redefined-spec-enabled? ctx))
-      (let [{:keys [ns name]} (usages/resolve-keyword ctx name-expr (-> ctx :ns :name))]
-        (reg-spec-def! ctx :keyword name-expr ns name)))
+    (when (redefined-spec-enabled? ctx)
+      (cond
+        (:k name-expr)
+        (let [{:keys [ns name]} (usages/resolve-keyword ctx name-expr (-> ctx :ns :name))]
+          (reg-spec-def! ctx :keyword name-expr ns name))
+        ;; a symbol-keyed s/def registers in the same key space as s/fdef
+        (symbol? (:value name-expr))
+        (let [sym (:value name-expr)
+              ns-nm (-> ctx :ns :name)
+              {resolved-ns :ns resolved-name :name unresolved? :unresolved?}
+              (namespace/resolve-name ctx true ns-nm sym nil)]
+          (when resolved-ns
+            (if (and unresolved? (not (namespace sym)))
+              (reg-spec-def! ctx :symbol name-expr ns-nm resolved-name)
+              (reg-spec-def! ctx :symbol name-expr resolved-ns resolved-name))))))
     (common/analyze-expression** (utils/ctx-with-linter-disabled ctx :unresolved-symbol) reg-val)
     (common/analyze-children ctx body)))
 

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -22,7 +22,9 @@
   `name-node` is the registered name node and `resolved-ns`/`resolved-name` its
   fully-resolved identity."
   [ctx kind name-node resolved-ns resolved-name]
-  (when (and resolved-ns resolved-name (redefined-spec-enabled? ctx))
+  (when (and resolved-ns resolved-name
+             (not (:in-comment ctx))
+             (redefined-spec-enabled? ctx))
     (namespace/reg-spec-def! ctx (-> ctx :ns :name)
                              (assoc (utils/location (meta name-node))
                                     :filename (:filename ctx)

--- a/src/clj_kondo/impl/analyzer/spec.clj
+++ b/src/clj_kondo/impl/analyzer/spec.clj
@@ -72,7 +72,6 @@
         (:k name-expr)
         (let [{:keys [ns name]} (usages/resolve-keyword ctx name-expr (-> ctx :ns :name))]
           (reg-spec-def! ctx :keyword name-expr ns name))
-        ;; a symbol-keyed s/def registers in the same key space as s/fdef
         (symbol? (:value name-expr))
         (let [sym (:value name-expr)
               ns-nm (-> ctx :ns :name)

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -214,6 +214,58 @@
         (sync-cache* idacs config-dir cache-dir)))
     (sync-cache* idacs config-dir cache-dir)))
 
+;;;; Global spec index
+;;
+;; A single project-wide index of spec registrations (`s/def`/`s/fdef`),
+;; mirroring spec's own global registry. It maps each source file to the
+;; registrations it contributes, so re-linting a file replaces exactly its
+;; entries. Used by the :redefined-spec linter to detect redefinitions across
+;; separate runs, independent of the require graph.
+
+(defn spec-index-file ^java.io.File [cache-dir]
+  (io/file cache-dir "spec-index.transit.json"))
+
+(defn read-spec-index [cache-dir]
+  (let [f (spec-index-file cache-dir)]
+    (when (.exists f)
+      (try (with-open [is (io/input-stream f)]
+             (transit/read (transit/reader is :json)))
+           (catch Exception _ nil)))))
+
+(defn write-spec-index! [cache-dir index]
+  (let [f (spec-index-file cache-dir)]
+    (io/make-parents f)
+    (with-open [os (no-flush-output-stream (io/output-stream f))]
+      (let [writer (transit/writer os :json)]
+        (transit/write writer index)))))
+
+(defn sync-spec-index!
+  "Refreshes the global spec index for the files linted in this run and returns
+  the registrations contributed by *other* files (as `first defined at`
+  originals for cross-run detection).
+
+  `current-contributions` is a map of filename -> vector of registration maps.
+  `current-filenames` is the set of files linted this run; their entries are
+  cleared first, so removing an `s/def` also removes it from the index. Runs
+  under the cache lock so concurrent clj-kondo processes don't clobber it."
+  [cache-dir current-contributions current-filenames]
+  (when cache-dir
+    (with-thread-lock
+      (with-cache cache-dir 6
+        (let [index (or (read-spec-index cache-dir) {})
+              index (apply dissoc index current-filenames)
+              index (reduce-kv (fn [m f entries]
+                                 (if (seq entries)
+                                   (assoc m f entries)
+                                   m))
+                               index
+                               current-contributions)]
+          (write-spec-index! cache-dir index)
+          (vec (for [[f entries] index
+                     :when (not (contains? current-filenames f))
+                     e entries]
+                 (assoc e :filename f :reportable? false))))))))
+
 ;;;; Scratch
 
 (comment

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -299,7 +299,7 @@
   identity is the key itself."
   [current-contributions canonical-by-filename]
   (reduce-kv (fn [m filename occs]
-               (let [canonical (get canonical-by-filename filename)]
+               (let [canonical (canonical-by-filename filename)]
                  (reduce (fn [m occ]
                            (update-in m [(spec-key occ) canonical] (fnil conj [])
                                       {:filename filename
@@ -310,6 +310,17 @@
              {}
              current-contributions))
 
+(defn- registered-keys-by-file
+  "Inverts the registrations into canonical file -> the spec identities it
+  registers now, which is what each file's manifest records."
+  [registrations]
+  (reduce-kv (fn [m k by-file]
+               (reduce-kv (fn [m f _entries] (update m f (fnil conj []) k))
+                          m
+                          by-file))
+             {}
+             registrations))
+
 (defn- previous-spec-keys
   "Reads the manifests of the files linted this run: canonical file -> the spec
   identities it registered according to the previous run. Their buckets have to
@@ -319,37 +330,57 @@
         (map (juxt identity #(:keys (read-shard (manifest-file cache-dir %)))))
         canonical-paths))
 
+(defn- external-occurrences
+  "Rebuilds full registration maps from a spec identity and its per-file entries,
+  marked as non-reportable so they only serve as `first defined at` originals."
+  [[kind ns name lang] by-file]
+  (map #(assoc % :kind kind :ns ns :name name :lang lang :reportable? false)
+       (mapcat val by-file)))
+
 (defn- update-bucket
   "Applies this run's registrations to one bucket and returns
   `[updated-index external-occurrences]`, where the external occurrences are the
   registrations of the bucket's keys coming from files not linted this run."
-  [index bucket-keys registrations current-canonical-paths file-exists?]
+  [index bucket-keys registrations external-file?]
   (reduce
    (fn [[index externals] k]
-     (let [;; drop what the files of this run registered before (it is
-           ;; superseded by `registrations`) and what files that vanished
-           ;; (deleted or renamed) registered: stale entries must not be
-           ;; reported as the original definition
-           kept (reduce-kv (fn [m f _entries]
-                             (if (or (contains? current-canonical-paths f)
-                                     (not (file-exists? f)))
-                               (dissoc m f)
-                               m))
-                           (get index k {})
-                           (get index k {}))
-           by-file (merge kept (get registrations k))
-           externals (into externals
-                           (comp (mapcat val)
-                                 (map (fn [entry]
-                                        (assoc entry
-                                               :kind (nth k 0) :ns (nth k 1)
-                                               :name (nth k 2) :lang (nth k 3)
-                                               :reportable? false))))
-                           kept)]
+     ;; keep only what files outside this run still register: this run's own
+     ;; entries are superseded by `registrations`, and entries of vanished
+     ;; files must not be reported as the original definition
+     (let [kept (into {} (filter (comp external-file? key)) (get index k))
+           by-file (merge kept (get registrations k))]
        [(if (seq by-file) (assoc index k by-file) (dissoc index k))
-        externals]))
+        (into externals (external-occurrences k kept))]))
    [index []]
    bucket-keys))
+
+(defn- sync-buckets!
+  "Rewrites every bucket affected by this run and returns the external
+  registrations found in them."
+  [cache-dir affected-keys registrations external-file?]
+  (reduce-kv (fn [acc f bucket-keys]
+               (let [index (or (:index (read-shard f)) {})
+                     [index' externals] (update-bucket index bucket-keys
+                                                       registrations external-file?)]
+                 (when-not (= index index')
+                   (if (seq index')
+                     (write-shard! f {:index index'})
+                     (delete-quietly! f)))
+                 (into acc externals)))
+             []
+             (group-by #(bucket-file cache-dir %) affected-keys)))
+
+(defn- write-manifests!
+  "Records what each file contributes now, so a later run can drop it again.
+  Manifests that didn't change are left alone."
+  [cache-dir canonical-paths current-keys previous-keys]
+  (doseq [canonical canonical-paths
+          :let [ks (get current-keys canonical)]
+          :when (not= ks (get previous-keys canonical))
+          :let [f (manifest-file cache-dir canonical)]]
+    (if (seq ks)
+      (write-shard! f {:file canonical :keys ks})
+      (delete-quietly! f))))
 
 (defn sync-spec-index!
   "Refreshes the spec index for the files linted in this run and returns the
@@ -366,45 +397,18 @@
                                       (map (juxt identity (comp str fs/canonicalize)))
                                       (into (set current-filenames)
                                             (keys current-contributions)))
-          current-canonical-paths (set (vals canonical-by-filename))
+          current-paths (set (vals canonical-by-filename))
           registrations (current-registrations current-contributions canonical-by-filename)
-          keys-by-file (reduce-kv (fn [m k by-file]
-                                    (reduce #(update %1 %2 (fnil conj []) k) m (keys by-file)))
-                                  {} registrations)
-          previous-keys (previous-spec-keys cache-dir current-canonical-paths)
-          ;; the same file shows up under many spec identities
-          ^java.util.HashMap existence (java.util.HashMap.)
-          file-exists? (fn [f]
-                         (if-some [cached (.get existence f)]
-                           cached
-                           (let [e (fs/exists? f)]
-                             (.put existence f e)
-                             e)))
+          current-keys (registered-keys-by-file registrations)
+          previous-keys (previous-spec-keys cache-dir current-paths)
+          external-file? (fn [f] (and (not (contains? current-paths f))
+                                      (fs/exists? f)))
           ;; only the buckets of specs registered now or previously by these
           ;; files can be affected by this run
-          buckets (group-by #(bucket-file cache-dir %)
-                            (distinct (concat (keys registrations) (mapcat val previous-keys))))
-          externals
-          (reduce-kv
-           (fn [acc f bucket-keys]
-             (let [index (or (:index (read-shard f)) {})
-                   [index' externals] (update-bucket index bucket-keys registrations
-                                                     current-canonical-paths file-exists?)]
-               (when-not (= index index')
-                 (if (seq index')
-                   (write-shard! f {:index index'})
-                   (delete-quietly! f)))
-               (into acc externals)))
-           []
-           buckets)]
-      ;; record what each file contributes now, so a later run can drop it again
-      (doseq [canonical current-canonical-paths
-              :let [ks (get keys-by-file canonical)
-                    f (manifest-file cache-dir canonical)]]
-        (cond
-          (= ks (get previous-keys canonical)) nil ;; unchanged, leave it alone
-          (seq ks) (write-shard! f {:file canonical :keys ks})
-          :else (when (fs/exists? f) (delete-quietly! f))))
+          affected-keys (distinct (concat (keys registrations)
+                                          (mapcat val previous-keys)))
+          externals (sync-buckets! cache-dir affected-keys registrations external-file?)]
+      (write-manifests! cache-dir current-paths current-keys previous-keys)
       externals)))
 
 ;;;; Scratch

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -1,6 +1,7 @@
 (ns clj-kondo.impl.cache
   {:no-doc true}
   (:require
+   [babashka.fs :as fs]
    [clj-kondo.impl.types :as types]
    [clj-kondo.impl.utils :refer [one-of]]
    [clojure.java.io :as io]
@@ -239,6 +240,17 @@
       (let [writer (transit/writer os :json)]
         (transit/write writer index)))))
 
+(defn- prune-missing-files
+  "Drops index entries whose file no longer exists (deleted or renamed), so stale
+  registrations can't be reported as the original definition."
+  [index]
+  (reduce-kv (fn [m f entries]
+               (if (fs/exists? f)
+                 (assoc m f entries)
+                 (dissoc m f)))
+             index
+             index))
+
 (defn sync-spec-index!
   "Refreshes the global spec index for the files linted in this run and returns
   the registrations contributed by *other* files (as `first defined at`
@@ -252,11 +264,16 @@
   (when cache-dir
     (with-thread-lock
       (with-cache cache-dir 6
-        (let [index (or (read-spec-index cache-dir) {})
+        (let [current-filenames (into #{} (map (comp str fs/canonicalize)) current-filenames)
+              index (-> (or (read-spec-index cache-dir) {})
+                        prune-missing-files)
               index (apply dissoc index current-filenames)
               index (reduce-kv (fn [m f entries]
                                  (if (seq entries)
-                                   (assoc m f entries)
+                                   ;; keep the spelling used in this run for
+                                   ;; display, but key on the canonical path
+                                   (assoc m (str (fs/canonicalize f))
+                                          (mapv #(assoc % :filename f) entries))
                                    m))
                                index
                                current-contributions)]
@@ -264,7 +281,7 @@
           (vec (for [[f entries] index
                      :when (not (contains? current-filenames f))
                      e entries]
-                 (assoc e :filename f :reportable? false))))))))
+                 (assoc e :reportable? false))))))))
 
 ;;;; Scratch
 

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -235,8 +235,8 @@
 ;; Shards are written by atomic rename and every run is the single writer for
 ;; its own files, so no global cache lock is needed.
 
-(defn- spec-index-dir ^java.io.File [cache-dir]
-  (io/file cache-dir "specs"))
+(defn- spec-index-dir [cache-dir]
+  (fs/path cache-dir "specs"))
 
 (defn- digest
   "Stable, filesystem-safe name for a string."
@@ -247,8 +247,8 @@
       (.append sb (format "%02x" (bit-and (int b) 0xff))))
     (str sb)))
 
-(defn- manifest-file ^java.io.File [cache-dir ^String canonical-path]
-  (io/file (spec-index-dir cache-dir) "files"
+(defn- manifest-file [cache-dir canonical-path]
+  (fs/path (spec-index-dir cache-dir) "files"
            (str (digest canonical-path) ".transit.json")))
 
 (defn- spec-key
@@ -257,18 +257,18 @@
   [occ]
   [(:kind occ) (:ns occ) (:name occ) (:lang occ)])
 
-(defn- bucket-file ^java.io.File [cache-dir spec-key]
+(defn- bucket-file [cache-dir spec-key]
   ;; one hex byte of the digest: enough buckets to keep them small, few enough
   ;; that a full-project run doesn't write thousands of tiny files
-  (io/file (spec-index-dir cache-dir) "keys"
+  (fs/path (spec-index-dir cache-dir) "keys"
            (str (subs (digest (pr-str spec-key)) 0 2) ".transit.json")))
 
 (defn- read-shard
   "Reads one shard, or nil if it's absent or unreadable (e.g. concurrently
   replaced or written by an incompatible version)."
-  [^java.io.File f]
-  (when (.exists f)
-    (try (let [data (with-open [is (io/input-stream f)]
+  [f]
+  (when (fs/exists? f)
+    (try (let [data (with-open [is (io/input-stream (fs/file f))]
                       (transit/read (transit/reader is :json)))]
            (when (map? data) data))
          (catch Exception _ nil))))
@@ -276,24 +276,22 @@
 (defn- write-shard!
   "Writes a shard via a temp file + atomic rename, so concurrent readers see
   either the old or the new contents, never a partial write."
-  [^java.io.File f data]
-  (io/make-parents f)
-  (let [tmp (java.io.File/createTempFile "spec-shard" ".transit.json" (.getParentFile f))]
+  [f data]
+  (let [dir (fs/parent f)
+        _ (fs/create-dirs dir)
+        tmp (fs/create-temp-file {:dir dir
+                                  :prefix "spec-shard"
+                                  :suffix ".transit.json"})]
     (try
-      (with-open [os (no-flush-output-stream (io/output-stream tmp))]
+      (with-open [os (no-flush-output-stream (io/output-stream (fs/file tmp)))]
         (transit/write (transit/writer os :json) data))
-      (let [opts [java.nio.file.StandardCopyOption/REPLACE_EXISTING]]
-        (try (java.nio.file.Files/move
-              (.toPath tmp) (.toPath f)
-              (into-array java.nio.file.CopyOption
-                          (conj opts java.nio.file.StandardCopyOption/ATOMIC_MOVE)))
-             (catch java.nio.file.AtomicMoveNotSupportedException _
-               (java.nio.file.Files/move (.toPath tmp) (.toPath f)
-                                         (into-array java.nio.file.CopyOption opts)))))
-      (finally (.delete tmp)))))
+      (try (fs/move tmp f {:replace-existing true :atomic-move true})
+           (catch java.nio.file.AtomicMoveNotSupportedException _
+             (fs/move tmp f {:replace-existing true})))
+      (finally (fs/delete-if-exists tmp)))))
 
-(defn- delete-quietly! [^java.io.File f]
-  (try (.delete f) (catch Exception _ false)))
+(defn- delete-quietly! [f]
+  (try (fs/delete-if-exists f) (catch Exception _ false)))
 
 (defn- current-registrations
   "The registrations of this run, as spec-key -> canonical file -> entries. Only
@@ -406,7 +404,7 @@
         (cond
           (= ks (get previous-keys canonical)) nil ;; unchanged, leave it alone
           (seq ks) (write-shard! f {:file canonical :keys ks})
-          :else (when (.exists f) (delete-quietly! f))))
+          :else (when (fs/exists? f) (delete-quietly! f))))
       externals)))
 
 ;;;; Scratch

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -393,8 +393,15 @@
   removes it."
   [cache-dir current-contributions current-filenames]
   (when cache-dir
-    (let [canonical-by-filename (into {}
-                                      (map (juxt identity (comp str fs/canonicalize)))
+    (let [;; Only filesystem paths belong in the persistent index. In
+          ;; particular, fs/canonicalize throws for <stdin> on Windows, and a
+          ;; stdin entry could never be a useful cross-run definition anyway.
+          indexable-filename? (fn [filename]
+                                (and (not= "<stdin>" filename)
+                                     (not (str/includes? filename ".jar:"))))
+          canonical-by-filename (into {}
+                                      (comp (filter indexable-filename?)
+                                            (map (juxt identity (comp str fs/canonicalize))))
                                       (into (set current-filenames)
                                             (keys current-contributions)))
           current-paths (set (vals canonical-by-filename))

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -332,7 +332,7 @@
 
 (defn- external-occurrences
   "Rebuilds full registration maps from a spec identity and its per-file entries,
-  marked as non-reportable so they only serve as `first defined at` originals."
+  marked as non-reportable so they only serve as `also defined at` locations."
   [[kind ns name lang] by-file]
   (map #(assoc % :kind kind :ns ns :name name :lang lang :reportable? false)
        (mapcat val by-file)))
@@ -385,7 +385,7 @@
 (defn sync-spec-index!
   "Refreshes the spec index for the files linted in this run and returns the
   registrations of the same specs contributed by *other* files (as
-  `first defined at` originals for cross-run detection).
+  `also defined at` locations for cross-run detection).
 
   `current-contributions` is a map of filename -> vector of registration maps.
   `current-filenames` is the set of files linted this run; the registrations

--- a/src/clj_kondo/impl/cache.clj
+++ b/src/clj_kondo/impl/cache.clj
@@ -214,74 +214,200 @@
       (with-cache cache-dir 6
         (sync-cache* idacs config-dir cache-dir)))
     (sync-cache* idacs config-dir cache-dir)))
-
-;;;; Global spec index
+;;;; Spec index
 ;;
-;; A single project-wide index of spec registrations (`s/def`/`s/fdef`),
-;; mirroring spec's own global registry. It maps each source file to the
-;; registrations it contributes, so re-linting a file replaces exactly its
-;; entries. Used by the :redefined-spec linter to detect redefinitions across
-;; separate runs, independent of the require graph.
+;; A project-wide index of spec registrations (`s/def`/`s/fdef`), mirroring
+;; spec's own global registry. Used by the :redefined-spec linter to detect
+;; redefinitions across separate runs, independent of the require graph.
+;;
+;; The index is sharded, next to the per-namespace cache entries, under
+;; `<cache-dir>/specs`:
+;;
+;; - `keys/<bucket>.transit.json` holds, for a bucket of spec identities, the
+;;   registrations of that spec per source file. Buckets are addressed by a
+;;   digest of the spec identity, so a run only touches the buckets for the
+;;   specs it actually registers instead of reading and rewriting a
+;;   project-wide blob.
+;; - `files/<digest-of-path>.transit.json` is a per-file manifest of the spec
+;;   identities that file contributed last time, so re-linting it can drop the
+;;   registrations it no longer has.
+;;
+;; Shards are written by atomic rename and every run is the single writer for
+;; its own files, so no global cache lock is needed.
 
-(defn spec-index-file ^java.io.File [cache-dir]
-  (io/file cache-dir "spec-index.transit.json"))
+(defn- spec-index-dir ^java.io.File [cache-dir]
+  (io/file cache-dir "specs"))
 
-(defn read-spec-index [cache-dir]
-  (let [f (spec-index-file cache-dir)]
-    (when (.exists f)
-      (try (with-open [is (io/input-stream f)]
-             (transit/read (transit/reader is :json)))
-           (catch Exception _ nil)))))
+(defn- digest
+  "Stable, filesystem-safe name for a string."
+  ^String [^String s]
+  (let [md (java.security.MessageDigest/getInstance "SHA-1")
+        sb (StringBuilder.)]
+    (doseq [b (.digest md (.getBytes s "UTF-8"))]
+      (.append sb (format "%02x" (bit-and (int b) 0xff))))
+    (str sb)))
 
-(defn write-spec-index! [cache-dir index]
-  (let [f (spec-index-file cache-dir)]
-    (io/make-parents f)
-    (with-open [os (no-flush-output-stream (io/output-stream f))]
-      (let [writer (transit/writer os :json)]
-        (transit/write writer index)))))
+(defn- manifest-file ^java.io.File [cache-dir ^String canonical-path]
+  (io/file (spec-index-dir cache-dir) "files"
+           (str (digest canonical-path) ".transit.json")))
 
-(defn- prune-missing-files
-  "Drops index entries whose file no longer exists (deleted or renamed), so stale
-  registrations can't be reported as the original definition."
-  [index]
-  (reduce-kv (fn [m f entries]
-               (if (fs/exists? f)
-                 (assoc m f entries)
-                 (dissoc m f)))
-             index
-             index))
+(defn- spec-key
+  "The identity a registration is indexed under, matching the grouping used by
+  the :redefined-spec linter."
+  [occ]
+  [(:kind occ) (:ns occ) (:name occ) (:lang occ)])
+
+(defn- bucket-file ^java.io.File [cache-dir spec-key]
+  ;; one hex byte of the digest: enough buckets to keep them small, few enough
+  ;; that a full-project run doesn't write thousands of tiny files
+  (io/file (spec-index-dir cache-dir) "keys"
+           (str (subs (digest (pr-str spec-key)) 0 2) ".transit.json")))
+
+(defn- read-shard
+  "Reads one shard, or nil if it's absent or unreadable (e.g. concurrently
+  replaced or written by an incompatible version)."
+  [^java.io.File f]
+  (when (.exists f)
+    (try (let [data (with-open [is (io/input-stream f)]
+                      (transit/read (transit/reader is :json)))]
+           (when (map? data) data))
+         (catch Exception _ nil))))
+
+(defn- write-shard!
+  "Writes a shard via a temp file + atomic rename, so concurrent readers see
+  either the old or the new contents, never a partial write."
+  [^java.io.File f data]
+  (io/make-parents f)
+  (let [tmp (java.io.File/createTempFile "spec-shard" ".transit.json" (.getParentFile f))]
+    (try
+      (with-open [os (no-flush-output-stream (io/output-stream tmp))]
+        (transit/write (transit/writer os :json) data))
+      (let [opts [java.nio.file.StandardCopyOption/REPLACE_EXISTING]]
+        (try (java.nio.file.Files/move
+              (.toPath tmp) (.toPath f)
+              (into-array java.nio.file.CopyOption
+                          (conj opts java.nio.file.StandardCopyOption/ATOMIC_MOVE)))
+             (catch java.nio.file.AtomicMoveNotSupportedException _
+               (java.nio.file.Files/move (.toPath tmp) (.toPath f)
+                                         (into-array java.nio.file.CopyOption opts)))))
+      (finally (.delete tmp)))))
+
+(defn- delete-quietly! [^java.io.File f]
+  (try (.delete f) (catch Exception _ false)))
+
+(defn- current-registrations
+  "The registrations of this run, as spec-key -> canonical file -> entries. Only
+  location and the filename spelling used in this run are stored; the rest of the
+  identity is the key itself."
+  [current-contributions canonical-by-filename]
+  (reduce-kv (fn [m filename occs]
+               (let [canonical (get canonical-by-filename filename)]
+                 (reduce (fn [m occ]
+                           (update-in m [(spec-key occ) canonical] (fnil conj [])
+                                      {:filename filename
+                                       :row (:row occ)
+                                       :col (:col occ)}))
+                         m
+                         occs)))
+             {}
+             current-contributions))
+
+(defn- previous-spec-keys
+  "Reads the manifests of the files linted this run: canonical file -> the spec
+  identities it registered according to the previous run. Their buckets have to
+  be visited too, to drop registrations that are gone now."
+  [cache-dir canonical-paths]
+  (into {}
+        (map (juxt identity #(:keys (read-shard (manifest-file cache-dir %)))))
+        canonical-paths))
+
+(defn- update-bucket
+  "Applies this run's registrations to one bucket and returns
+  `[updated-index external-occurrences]`, where the external occurrences are the
+  registrations of the bucket's keys coming from files not linted this run."
+  [index bucket-keys registrations current-canonical-paths file-exists?]
+  (reduce
+   (fn [[index externals] k]
+     (let [;; drop what the files of this run registered before (it is
+           ;; superseded by `registrations`) and what files that vanished
+           ;; (deleted or renamed) registered: stale entries must not be
+           ;; reported as the original definition
+           kept (reduce-kv (fn [m f _entries]
+                             (if (or (contains? current-canonical-paths f)
+                                     (not (file-exists? f)))
+                               (dissoc m f)
+                               m))
+                           (get index k {})
+                           (get index k {}))
+           by-file (merge kept (get registrations k))
+           externals (into externals
+                           (comp (mapcat val)
+                                 (map (fn [entry]
+                                        (assoc entry
+                                               :kind (nth k 0) :ns (nth k 1)
+                                               :name (nth k 2) :lang (nth k 3)
+                                               :reportable? false))))
+                           kept)]
+       [(if (seq by-file) (assoc index k by-file) (dissoc index k))
+        externals]))
+   [index []]
+   bucket-keys))
 
 (defn sync-spec-index!
-  "Refreshes the global spec index for the files linted in this run and returns
-  the registrations contributed by *other* files (as `first defined at`
-  originals for cross-run detection).
+  "Refreshes the spec index for the files linted in this run and returns the
+  registrations of the same specs contributed by *other* files (as
+  `first defined at` originals for cross-run detection).
 
   `current-contributions` is a map of filename -> vector of registration maps.
-  `current-filenames` is the set of files linted this run; their entries are
-  cleared first, so removing an `s/def` also removes it from the index. Runs
-  under the cache lock so concurrent clj-kondo processes don't clobber it."
+  `current-filenames` is the set of files linted this run; the registrations
+  they no longer have are dropped from the index, so removing an `s/def` also
+  removes it."
   [cache-dir current-contributions current-filenames]
   (when cache-dir
-    (with-thread-lock
-      (with-cache cache-dir 6
-        (let [current-filenames (into #{} (map (comp str fs/canonicalize)) current-filenames)
-              index (-> (or (read-spec-index cache-dir) {})
-                        prune-missing-files)
-              index (apply dissoc index current-filenames)
-              index (reduce-kv (fn [m f entries]
-                                 (if (seq entries)
-                                   ;; keep the spelling used in this run for
-                                   ;; display, but key on the canonical path
-                                   (assoc m (str (fs/canonicalize f))
-                                          (mapv #(assoc % :filename f) entries))
-                                   m))
-                               index
-                               current-contributions)]
-          (write-spec-index! cache-dir index)
-          (vec (for [[f entries] index
-                     :when (not (contains? current-filenames f))
-                     e entries]
-                 (assoc e :reportable? false))))))))
+    (let [canonical-by-filename (into {}
+                                      (map (juxt identity (comp str fs/canonicalize)))
+                                      (into (set current-filenames)
+                                            (keys current-contributions)))
+          current-canonical-paths (set (vals canonical-by-filename))
+          registrations (current-registrations current-contributions canonical-by-filename)
+          keys-by-file (reduce-kv (fn [m k by-file]
+                                    (reduce #(update %1 %2 (fnil conj []) k) m (keys by-file)))
+                                  {} registrations)
+          previous-keys (previous-spec-keys cache-dir current-canonical-paths)
+          ;; the same file shows up under many spec identities
+          ^java.util.HashMap existence (java.util.HashMap.)
+          file-exists? (fn [f]
+                         (if-some [cached (.get existence f)]
+                           cached
+                           (let [e (fs/exists? f)]
+                             (.put existence f e)
+                             e)))
+          ;; only the buckets of specs registered now or previously by these
+          ;; files can be affected by this run
+          buckets (group-by #(bucket-file cache-dir %)
+                            (distinct (concat (keys registrations) (mapcat val previous-keys))))
+          externals
+          (reduce-kv
+           (fn [acc f bucket-keys]
+             (let [index (or (:index (read-shard f)) {})
+                   [index' externals] (update-bucket index bucket-keys registrations
+                                                     current-canonical-paths file-exists?)]
+               (when-not (= index index')
+                 (if (seq index')
+                   (write-shard! f {:index index'})
+                   (delete-quietly! f)))
+               (into acc externals)))
+           []
+           buckets)]
+      ;; record what each file contributes now, so a later run can drop it again
+      (doseq [canonical current-canonical-paths
+              :let [ks (get keys-by-file canonical)
+                    f (manifest-file cache-dir canonical)]]
+        (cond
+          (= ks (get previous-keys canonical)) nil ;; unchanged, leave it alone
+          (seq ks) (write-shard! f {:file canonical :keys ks})
+          :else (when (.exists f) (delete-quietly! f))))
+      externals)))
 
 ;;;; Scratch
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -40,6 +40,7 @@
               :duplicate-key-args {:level :warning}
               :missing-map-value {:level :error}
               :redefined-var {:level :warning}
+              :redefined-spec {:level :warning}
               :redundant-declare {:level :warning}
               :var-same-name-except-case {:level :warning}
               :constant-condition {:level :warning}

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -885,9 +885,9 @@
                        :unused-alias (str "Unused alias: " alias)))))
       (lint-aliased-referred-var! ctx ns))))
 
-(defn- spec-def-display [{:keys [type ns name]}]
-  ;; s/def registers under a keyword, s/fdef under a symbol
-  (if (identical? :def type)
+(defn- spec-def-display [{:keys [kind ns name]}]
+  ;; keyword-keyed registrations print as a keyword, symbol-keyed as a symbol
+  (if (identical? :keyword kind)
     (str ":" ns "/" name)
     (str ns "/" name)))
 
@@ -915,7 +915,7 @@
                                 (namespace/list-namespaces ctx))
         contributions (reduce (fn [m occ]
                                 (update m (:filename occ) (fnil conj [])
-                                        (select-keys occ [:ns :name :lang
+                                        (select-keys occ [:kind :ns :name :lang
                                                           :row :col])))
                               {}
                               current-occs)]
@@ -925,8 +925,9 @@
   "Reports `s/def` and `s/fdef` registrations that redefine an already
   registered spec. Registrations are grouped by their fully resolved identity so
   that, e.g., `::foo` in two namespaces are distinct while `:some-alias/foo` and
-  the equivalent fully-qualified keyword are the same. `s/def` and `s/fdef`
-  share one identity space: an fdef and a def resolving to the same name collide.
+  the equivalent fully-qualified keyword are the same. Keyword-keyed `s/def` and
+  symbol-keyed `s/def`/`s/fdef` occupy the two disjoint key spaces of spec's
+  registry, so `::foo` and an `s/fdef foo` do not clash.
 
   Detection is project-wide within a run. Across runs, a global spec index in the
   cache (mirroring spec's own global registry) makes detection complete: every
@@ -942,7 +943,7 @@
           external-occs (cache/sync-spec-index! (:cache-dir ctx)
                                                 contributions
                                                 current-filenames)
-          groups (group-by (juxt :ns :name :lang)
+          groups (group-by (juxt :kind :ns :name :lang)
                            (concat current-occs external-occs))]
       (doseq [[_k occs] groups
               :let [;; collapse physically identical registrations

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -3,6 +3,7 @@
   (:refer-clojure :exclude [get-in])
   (:require
    [clj-kondo.impl.analysis :as analysis]
+   [clj-kondo.impl.cache :as cache]
    [clj-kondo.impl.config :as config]
    [clj-kondo.impl.findings :as findings]
    [clj-kondo.impl.namespace :as namespace]
@@ -883,6 +884,92 @@
            (node->line (:filename (meta alias)) alias
                        :unused-alias (str "Unused alias: " alias)))))
       (lint-aliased-referred-var! ctx ns))))
+
+(defn- spec-def-display [{:keys [type ns name]}]
+  ;; s/def registers under a keyword, s/fdef under a symbol
+  (if (identical? :def type)
+    (str ":" ns "/" name)
+    (str ns "/" name)))
+
+(defn- redefined-spec-current-occurrences
+  "Reportable registrations from the current run, taken from the live namespace
+  state so we have the exact language and namespace-local config for each. A
+  `.cljc` file yields two namespace entries (one per dialect), so its
+  registrations naturally appear once for :clj and once for :cljs."
+  [ctx]
+  (for [ns (namespace/list-namespaces ctx)
+        entry (vals (:spec-defs ns))]
+    (assoc entry
+           :lang (:lang ns)
+           :base-lang (:base-lang ns)
+           :config (:config ns)
+           :reportable? true)))
+
+(defn- redefined-spec-contributions
+  "Turns the current run's occurrences into the minimal per-file entries stored
+  in the global spec index, plus the set of files linted this run (so their old
+  entries are refreshed even when they no longer register any spec)."
+  [ctx current-occs]
+  (let [current-filenames (into #{}
+                                (keep :filename)
+                                (namespace/list-namespaces ctx))
+        contributions (reduce (fn [m occ]
+                                (update m (:filename occ) (fnil conj [])
+                                        (select-keys occ [:ns :name :lang
+                                                          :row :col])))
+                              {}
+                              current-occs)]
+    [contributions current-filenames]))
+
+(defn lint-redefined-specs!
+  "Reports `s/def` and `s/fdef` registrations that redefine an already
+  registered spec. Registrations are grouped by their fully resolved identity so
+  that, e.g., `::foo` in two namespaces are distinct while `:some-alias/foo` and
+  the equivalent fully-qualified keyword are the same. `s/def` and `s/fdef`
+  share one identity space: an fdef and a def resolving to the same name collide.
+
+  Detection is project-wide within a run. Across runs, a global spec index in the
+  cache (mirroring spec's own global registry) makes detection complete: every
+  registration from every previously linted file is considered, independent of
+  the require graph."
+  [ctx]
+  (when-not (utils/linter-disabled? ctx :redefined-spec)
+    (let [current-occs (redefined-spec-current-occurrences ctx)
+          [contributions current-filenames]
+          (redefined-spec-contributions ctx current-occs)
+          ;; refresh the on-disk index and get the registrations from all other
+          ;; files as potential `first defined at` originals
+          external-occs (cache/sync-spec-index! (:cache-dir ctx)
+                                                contributions
+                                                current-filenames)
+          groups (group-by (juxt :ns :name :lang)
+                           (concat current-occs external-occs))]
+      (doseq [[_k occs] groups
+              :let [;; collapse physically identical registrations
+                    occs (vals (into {} (map (juxt (juxt :filename :row :col)
+                                                   identity))
+                                     occs))
+                    occs (sort-by (juxt :filename :row :col) occs)]
+              :when (> (count occs) 1)
+              :let [original (first occs)
+                    orig-loc (str (:filename original) ":"
+                                  (:row original) ":" (:col original))]
+              occ (rest occs)
+              ;; only report registrations from files linted in this run
+              :when (:reportable? occ)]
+        (findings/reg-finding!
+         (assoc ctx
+                :lang (:lang occ)
+                :base-lang (:base-lang occ)
+                :config (or (:config occ) (:config ctx)))
+         {:filename (:filename occ)
+          :row (:row occ)
+          :col (:col occ)
+          :end-row (:end-row occ)
+          :end-col (:end-col occ)
+          :type :redefined-spec
+          :message (str "redefined spec " (spec-def-display occ)
+                        ", first defined at " orig-loc)})))))
 
 (defn lint-unused-excluded-vars! [ctx]
   (when-not (utils/linter-disabled? ctx :unused-excluded-var)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -902,41 +902,10 @@
   (for [ns (namespace/list-namespaces ctx)
         entry (vals (:spec-defs ns))]
     (assoc entry
-           :in-ns (:name ns)
            :lang (:lang ns)
            :base-lang (:base-lang ns)
            :config (:config ns)
            :reportable? true)))
-
-(defn- redefined-spec-load-ranks
-  "Load-order rank per namespace that registered a spec in this run, derived
-  from the require graph: a namespace ranks after every spec-registering
-  namespace it (transitively) requires, since those are loaded first at
-  runtime. Cycles and namespaces of unknown load order rank 0, leaving the
-  filename as the ordering criterion for them."
-  [ctx]
-  (let [requires (into {}
-                       (keep (fn [ns]
-                               (when (seq (:spec-defs ns))
-                                 [(:name ns) (:required ns)])))
-                       (namespace/list-namespaces ctx))
-        ranks (volatile! {})
-        rank (fn rank [ns-sym visiting]
-               (or (get @ranks ns-sym)
-                   (if (contains? visiting ns-sym)
-                     0
-                     (let [visiting (conj visiting ns-sym)
-                           r (reduce (fn [r dep]
-                                       (if (contains? requires dep)
-                                         (max r (inc (rank dep visiting)))
-                                         r))
-                                     0
-                                     (get requires ns-sym))]
-                       (vswap! ranks assoc ns-sym r)
-                       r))))]
-    (doseq [ns-sym (keys requires)]
-      (rank ns-sym #{}))
-    @ranks))
 
 (defn- redefined-spec-contributions
   "Turns the current run's occurrences into the minimal per-file entries stored
@@ -965,15 +934,17 @@
   Detection is project-wide within a run. Across runs, a global spec index in the
   cache (mirroring spec's own global registry) makes detection complete: every
   registration from every previously linted file is considered, independent of
-  the require graph."
+  the require graph.
+
+  Which registration is reported as the original is decided by source order
+  (filename, row, col), not by runtime load order."
   [ctx]
   (when-not (utils/linter-disabled? ctx :redefined-spec)
     (let [current-occs (redefined-spec-current-occurrences ctx)
-          load-ranks (redefined-spec-load-ranks ctx)
           [contributions current-filenames]
           (redefined-spec-contributions ctx current-occs)
           ;; refresh the on-disk index and get the registrations from all other
-          ;; files as potential `first defined at` originals
+          ;; files as potential `also defined at` locations
           external-occs (cache/sync-spec-index! (:cache-dir ctx)
                                                 contributions
                                                 current-filenames)
@@ -984,12 +955,11 @@
                     occs (vals (into {} (map (juxt (juxt :filename :row :col)
                                                    identity))
                                      occs))
-                    ;; the namespace loaded first wins, so that the reported
-                    ;; original matches what spec's registry sees at runtime;
-                    ;; the filename only breaks ties
-                    occs (sort-by (juxt #(get load-ranks (:in-ns %) 0)
-                                        :filename :row :col)
-                                  occs)]
+                    ;; source order decides which registration is reported as
+                    ;; the original: a deterministic choice, independent of
+                    ;; which files happen to be linted in this run. It does not
+                    ;; attempt to model runtime load order.
+                    occs (sort-by (juxt :filename :row :col) occs)]
               :when (> (count occs) 1)
               :let [original (first occs)
                     orig-loc (str (:filename original) ":"
@@ -1008,8 +978,8 @@
           :end-row (:end-row occ)
           :end-col (:end-col occ)
           :type :redefined-spec
-          :message (str "redefined spec " (spec-def-display occ)
-                        ", first defined at " orig-loc)})))))
+          :message (str "spec " (spec-def-display occ)
+                        " also defined at " orig-loc)})))))
 
 (defn lint-unused-excluded-vars! [ctx]
   (when-not (utils/linter-disabled? ctx :unused-excluded-var)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -902,10 +902,41 @@
   (for [ns (namespace/list-namespaces ctx)
         entry (vals (:spec-defs ns))]
     (assoc entry
+           :in-ns (:name ns)
            :lang (:lang ns)
            :base-lang (:base-lang ns)
            :config (:config ns)
            :reportable? true)))
+
+(defn- redefined-spec-load-ranks
+  "Load-order rank per namespace that registered a spec in this run, derived
+  from the require graph: a namespace ranks after every spec-registering
+  namespace it (transitively) requires, since those are loaded first at
+  runtime. Cycles and namespaces of unknown load order rank 0, leaving the
+  filename as the ordering criterion for them."
+  [ctx]
+  (let [requires (into {}
+                       (keep (fn [ns]
+                               (when (seq (:spec-defs ns))
+                                 [(:name ns) (:required ns)])))
+                       (namespace/list-namespaces ctx))
+        ranks (volatile! {})
+        rank (fn rank [ns-sym visiting]
+               (or (get @ranks ns-sym)
+                   (if (contains? visiting ns-sym)
+                     0
+                     (let [visiting (conj visiting ns-sym)
+                           r (reduce (fn [r dep]
+                                       (if (contains? requires dep)
+                                         (max r (inc (rank dep visiting)))
+                                         r))
+                                     0
+                                     (get requires ns-sym))]
+                       (vswap! ranks assoc ns-sym r)
+                       r))))]
+    (doseq [ns-sym (keys requires)]
+      (rank ns-sym #{}))
+    @ranks))
 
 (defn- redefined-spec-contributions
   "Turns the current run's occurrences into the minimal per-file entries stored
@@ -938,6 +969,7 @@
   [ctx]
   (when-not (utils/linter-disabled? ctx :redefined-spec)
     (let [current-occs (redefined-spec-current-occurrences ctx)
+          load-ranks (redefined-spec-load-ranks ctx)
           [contributions current-filenames]
           (redefined-spec-contributions ctx current-occs)
           ;; refresh the on-disk index and get the registrations from all other
@@ -952,7 +984,12 @@
                     occs (vals (into {} (map (juxt (juxt :filename :row :col)
                                                    identity))
                                      occs))
-                    occs (sort-by (juxt :filename :row :col) occs)]
+                    ;; the namespace loaded first wins, so that the reported
+                    ;; original matches what spec's registry sees at runtime;
+                    ;; the filename only breaks ties
+                    occs (sort-by (juxt #(get load-ranks (:in-ns %) 0)
+                                        :filename :row :col)
+                                  occs)]
               :when (> (count occs) 1)
               :let [original (first occs)
                     orig-loc (str (:filename original) ":"

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -3,6 +3,7 @@
   (:refer-clojure :exclude [get-in])
   (:require
    [clj-kondo.impl.analysis :as analysis]
+   [clj-kondo.impl.cache :as cache]
    [clj-kondo.impl.config :as config]
    [clj-kondo.impl.findings :as findings]
    [clj-kondo.impl.namespace :as namespace]
@@ -885,6 +886,92 @@
            (node->line (:filename (meta alias)) alias
                        :unused-alias (str "Unused alias: " alias)))))
       (lint-aliased-referred-var! ctx ns))))
+
+(defn- spec-def-display [{:keys [type ns name]}]
+  ;; s/def registers under a keyword, s/fdef under a symbol
+  (if (identical? :def type)
+    (str ":" ns "/" name)
+    (str ns "/" name)))
+
+(defn- redefined-spec-current-occurrences
+  "Reportable registrations from the current run, taken from the live namespace
+  state so we have the exact language and namespace-local config for each. A
+  `.cljc` file yields two namespace entries (one per dialect), so its
+  registrations naturally appear once for :clj and once for :cljs."
+  [ctx]
+  (for [ns (namespace/list-namespaces ctx)
+        entry (vals (:spec-defs ns))]
+    (assoc entry
+           :lang (:lang ns)
+           :base-lang (:base-lang ns)
+           :config (:config ns)
+           :reportable? true)))
+
+(defn- redefined-spec-contributions
+  "Turns the current run's occurrences into the minimal per-file entries stored
+  in the global spec index, plus the set of files linted this run (so their old
+  entries are refreshed even when they no longer register any spec)."
+  [ctx current-occs]
+  (let [current-filenames (into #{}
+                                (keep :filename)
+                                (namespace/list-namespaces ctx))
+        contributions (reduce (fn [m occ]
+                                (update m (:filename occ) (fnil conj [])
+                                        (select-keys occ [:ns :name :lang
+                                                          :row :col])))
+                              {}
+                              current-occs)]
+    [contributions current-filenames]))
+
+(defn lint-redefined-specs!
+  "Reports `s/def` and `s/fdef` registrations that redefine an already
+  registered spec. Registrations are grouped by their fully resolved identity so
+  that, e.g., `::foo` in two namespaces are distinct while `:some-alias/foo` and
+  the equivalent fully-qualified keyword are the same. `s/def` and `s/fdef`
+  share one identity space: an fdef and a def resolving to the same name collide.
+
+  Detection is project-wide within a run. Across runs, a global spec index in the
+  cache (mirroring spec's own global registry) makes detection complete: every
+  registration from every previously linted file is considered, independent of
+  the require graph."
+  [ctx]
+  (when-not (utils/linter-disabled? ctx :redefined-spec)
+    (let [current-occs (redefined-spec-current-occurrences ctx)
+          [contributions current-filenames]
+          (redefined-spec-contributions ctx current-occs)
+          ;; refresh the on-disk index and get the registrations from all other
+          ;; files as potential `first defined at` originals
+          external-occs (cache/sync-spec-index! (:cache-dir ctx)
+                                                contributions
+                                                current-filenames)
+          groups (group-by (juxt :ns :name :lang)
+                           (concat current-occs external-occs))]
+      (doseq [[_k occs] groups
+              :let [;; collapse physically identical registrations
+                    occs (vals (into {} (map (juxt (juxt :filename :row :col)
+                                                   identity))
+                                     occs))
+                    occs (sort-by (juxt :filename :row :col) occs)]
+              :when (> (count occs) 1)
+              :let [original (first occs)
+                    orig-loc (str (:filename original) ":"
+                                  (:row original) ":" (:col original))]
+              occ (rest occs)
+              ;; only report registrations from files linted in this run
+              :when (:reportable? occ)]
+        (findings/reg-finding!
+         (assoc ctx
+                :lang (:lang occ)
+                :base-lang (:base-lang occ)
+                :config (or (:config occ) (:config ctx)))
+         {:filename (:filename occ)
+          :row (:row occ)
+          :col (:col occ)
+          :end-row (:end-row occ)
+          :end-col (:end-col occ)
+          :type :redefined-spec
+          :message (str "redefined spec " (spec-def-display occ)
+                        ", first defined at " orig-loc)})))))
 
 (defn lint-unused-excluded-vars! [ctx]
   (when-not (utils/linter-disabled? ctx :unused-excluded-var)

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -887,9 +887,9 @@
                        :unused-alias (str "Unused alias: " alias)))))
       (lint-aliased-referred-var! ctx ns))))
 
-(defn- spec-def-display [{:keys [type ns name]}]
-  ;; s/def registers under a keyword, s/fdef under a symbol
-  (if (identical? :def type)
+(defn- spec-def-display [{:keys [kind ns name]}]
+  ;; keyword-keyed registrations print as a keyword, symbol-keyed as a symbol
+  (if (identical? :keyword kind)
     (str ":" ns "/" name)
     (str ns "/" name)))
 
@@ -917,7 +917,7 @@
                                 (namespace/list-namespaces ctx))
         contributions (reduce (fn [m occ]
                                 (update m (:filename occ) (fnil conj [])
-                                        (select-keys occ [:ns :name :lang
+                                        (select-keys occ [:kind :ns :name :lang
                                                           :row :col])))
                               {}
                               current-occs)]
@@ -927,8 +927,9 @@
   "Reports `s/def` and `s/fdef` registrations that redefine an already
   registered spec. Registrations are grouped by their fully resolved identity so
   that, e.g., `::foo` in two namespaces are distinct while `:some-alias/foo` and
-  the equivalent fully-qualified keyword are the same. `s/def` and `s/fdef`
-  share one identity space: an fdef and a def resolving to the same name collide.
+  the equivalent fully-qualified keyword are the same. Keyword-keyed `s/def` and
+  symbol-keyed `s/def`/`s/fdef` occupy the two disjoint key spaces of spec's
+  registry, so `::foo` and an `s/fdef foo` do not clash.
 
   Detection is project-wide within a run. Across runs, a global spec index in the
   cache (mirroring spec's own global registry) makes detection complete: every
@@ -944,7 +945,7 @@
           external-occs (cache/sync-spec-index! (:cache-dir ctx)
                                                 contributions
                                                 current-filenames)
-          groups (group-by (juxt :ns :name :lang)
+          groups (group-by (juxt :kind :ns :name :lang)
                            (concat current-occs external-occs))]
       (doseq [[_k occs] groups
               :let [;; collapse physically identical registrations

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -327,6 +327,21 @@
                                     "Main function without gen-class."))))))))
            nil))))))
 
+(defn reg-spec-def!
+  "Records a spec registration (`s/def` or `s/fdef`) in namespace `ns-sym` for
+  the :redefined-spec linter. `entry` is a map describing the registration,
+  containing at least :type (:def or :fdef), the resolved :ns and :name and the
+  location (:filename :row :col :end-row :end-col) of the registered name.
+
+  Registrations are stored in a map keyed by their location string so that (1)
+  the same physical form analyzed once per dialect of a `.cljc` file collapses
+  to a single entry when the indexed defs of both dialects are merged for the
+  cache, and (2) transit can serialize the keys."
+  [{:keys [base-lang lang namespaces]} ns-sym entry]
+  (let [k (str (:filename entry) ":" (:row entry) ":" (:col entry))]
+    (swap! namespaces update-in [base-lang lang ns-sym :spec-defs]
+           (fnil assoc {}) k entry)))
+
 (defn reg-var-usage!
   [{:keys [base-lang lang namespaces dependencies] :as ctx}
    ns-sym usage]

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -328,6 +328,21 @@
                                     "Main function without gen-class."))))))))
            nil))))))
 
+(defn reg-spec-def!
+  "Records a spec registration (`s/def` or `s/fdef`) in namespace `ns-sym` for
+  the :redefined-spec linter. `entry` is a map describing the registration,
+  containing at least :type (:def or :fdef), the resolved :ns and :name and the
+  location (:filename :row :col :end-row :end-col) of the registered name.
+
+  Registrations are stored in a map keyed by their location string so that (1)
+  the same physical form analyzed once per dialect of a `.cljc` file collapses
+  to a single entry when the indexed defs of both dialects are merged for the
+  cache, and (2) transit can serialize the keys."
+  [{:keys [base-lang lang namespaces]} ns-sym entry]
+  (let [k (str (:filename entry) ":" (:row entry) ":" (:col entry))]
+    (swap! namespaces update-in [base-lang lang ns-sym :spec-defs]
+           (fnil assoc {}) k entry)))
+
 (defn reg-var-usage!
   [{:keys [base-lang lang namespaces dependencies] :as ctx}
    ns-sym usage]

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -330,7 +330,7 @@
 (defn reg-spec-def!
   "Records a spec registration (`s/def` or `s/fdef`) in namespace `ns-sym` for
   the :redefined-spec linter. `entry` is a map describing the registration,
-  containing at least :type (:def or :fdef), the resolved :ns and :name and the
+  containing at least :kind (:keyword or :symbol), the resolved :ns and :name and the
   location (:filename :row :col :end-row :end-col) of the registered name.
 
   Registrations are stored in a map keyed by their location string so that (1)

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -2173,6 +2173,17 @@
   :langs (),
   :message "Format string contains no format specifiers",
   :row 123}
+ {:end-row 138,
+  :type :redefined-spec,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/test/generate.clj",
+  :col 8,
+  :end-col 13,
+  :langs (),
+  :message
+  "redefined spec :metabase.test.generate/col, first defined at test-regression/checkouts/metabase/test/metabase/test/generate.clj:137:8",
+  :row 138}
  {:end-row 497,
   :type :is-message-not-string,
   :level :info,

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -2182,7 +2182,7 @@
   :end-col 13,
   :langs (),
   :message
-  "redefined spec :metabase.test.generate/col, first defined at test-regression/checkouts/metabase/test/metabase/test/generate.clj:137:8",
+  "spec :metabase.test.generate/col also defined at test-regression/checkouts/metabase/test/metabase/test/generate.clj:137:8",
   :row 138}
  {:end-row 497,
   :type :is-message-not-string,

--- a/test/clj_kondo/redefined_spec_test.clj
+++ b/test/clj_kondo/redefined_spec_test.clj
@@ -1,0 +1,156 @@
+(ns clj-kondo.redefined-spec-test
+  (:require
+   [babashka.fs :as fs]
+   [clj-kondo.test-utils :refer [lint! assert-submaps2]]
+   [clojure.test :as t :refer [deftest is testing]]))
+
+(def spec-require "[clojure.spec.alpha :as s]")
+
+(deftest single-namespace-test
+  (testing "s/def registering the same keyword twice"
+    (assert-submaps2
+     '({:row 3 :col 8 :level :warning
+        :message #"redefined spec :foo/x"})
+     (lint! (str "(ns foo (:require " spec-require "))\n"
+                 "(s/def ::x string?)\n"
+                 "(s/def ::x int?)"))))
+  (testing "no warning for a single registration"
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(s/def ::x string?)")))))
+  (testing "s/fdef registering the same symbol twice"
+    (assert-submaps2
+     '({:row 4 :col 9 :level :warning
+        :message #"redefined spec foo/f"})
+     (lint! (str "(ns foo (:require " spec-require "))\n"
+                 "(defn f [x] x)\n"
+                 "(s/fdef f :args (s/cat :x int?))\n"
+                 "(s/fdef f :args (s/cat :y int?))"))))
+  (testing "s/def and s/fdef share one identity space"
+    (assert-submaps2
+     '({:row 4 :col 8 :level :warning
+        :message #"redefined spec :foo/f"})
+     (lint! (str "(ns foo (:require " spec-require "))\n"
+                 "(defn f [x] x)\n"
+                 "(s/fdef f :args (s/cat :x int?))\n"
+                 "(s/def ::f int?)")))))
+
+(deftest edge-cases-test
+  (testing "auto-resolved keywords in different namespaces are distinct"
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(s/def ::x string?)\n"
+                            "(ns bar (:require " spec-require "))\n"
+                            "(s/def ::x string?)")))))
+  (testing "aliased and fully-qualified keyword resolving to the same spec clash"
+    (assert-submaps2
+     '({:row 4 :col 8 :level :warning
+        :message #"redefined spec :shared/x"})
+     (lint! (str "(ns foo (:require " spec-require " [shared :as sh]))\n"
+                 "(s/def ::sh/x string?)\n"
+                 "(ns bar (:require " spec-require "))\n"
+                 "(s/def :shared/x string?)")))))
+
+(deftest whole-project-test
+  (testing "duplicate specs are detected across files in a single run"
+    (fs/with-temp-dir [tmp {}]
+      (spit (fs/file tmp "a.clj")
+            (str "(ns a (:require " spec-require " [shared :as sh]))\n"
+                 "(s/def ::sh/x string?)"))
+      (spit (fs/file tmp "b.clj")
+            (str "(ns b (:require " spec-require "))\n"
+                 "(s/def :shared/x int?)"))
+      (spit (fs/file tmp "shared.clj") "(ns shared)")
+      (assert-submaps2
+       '({:file #"b.clj" :row 2 :col 8 :level :warning
+          :message #"redefined spec :shared/x, first defined at"})
+       (filter #(re-find #"redefined spec" (:message %))
+               (lint! (fs/file tmp)))))))
+
+(deftest cljc-test
+  (testing "a single cljc registration does not warn"
+    (is (empty? (filter #(re-find #"redefined spec" (:message %))
+                        (lint! (str "(ns foo (:require " spec-require "))\n"
+                                    "(s/def ::x string?)")
+                               "--lang" "cljc")))))
+  (testing "a duplicate cljc registration warns exactly once"
+    (let [findings (filter #(re-find #"redefined spec" (:message %))
+                           (lint! (str "(ns foo (:require " spec-require "))\n"
+                                       "(s/def ::x string?)\n"
+                                       "(s/def ::x int?)")
+                                  "--lang" "cljc"))]
+      (is (= 1 (count findings)))))
+  (testing "same spec name in .clj and .cljs do not clash (disjoint runtimes)"
+    (fs/with-temp-dir [tmp {}]
+      (spit (fs/file tmp "p.clj")
+            (str "(ns p (:require " spec-require "))\n(s/def ::x string?)"))
+      (spit (fs/file tmp "p.cljs")
+            (str "(ns p (:require " spec-require "))\n(s/def ::x string?)"))
+      (is (empty? (filter #(re-find #"redefined spec" (:message %))
+                          (lint! (fs/file tmp))))))))
+
+(defn- redefined-spec-findings [findings]
+  (filter #(re-find #"redefined spec" (:message %)) findings))
+
+(deftest cross-run-cache-test
+  (testing "a redefinition is detected across runs via the global spec index,
+            even when the files don't require one another (both resolve to the
+            same spec via an alias)"
+    (fs/with-temp-dir [tmp {}]
+      (let [cache (str (fs/file tmp ".cache"))]
+        (spit (fs/file tmp "specs.clj") "(ns specs)")
+        (spit (fs/file tmp "a.clj")
+              (str "(ns a (:require " spec-require " [specs :as sp]))\n"
+                   "(s/def ::sp/bar string?)"))
+        (spit (fs/file tmp "b.clj")
+              (str "(ns b (:require " spec-require " [specs :as sp]))\n"
+                   "(s/def ::sp/bar int?)"))
+        (lint! (fs/file tmp "a.clj") "--cache" cache)
+        (assert-submaps2
+         '({:file #"b.clj" :row 2 :col 8 :level :warning
+            :message #"redefined spec :specs/bar, first defined at"})
+         (redefined-spec-findings
+          (lint! (fs/file tmp "b.clj") "--cache" cache))))))
+  (testing "re-linting the same file does not report it against its own cached
+            entry"
+    (fs/with-temp-dir [tmp {}]
+      (let [cache (str (fs/file tmp ".cache"))]
+        (spit (fs/file tmp "a.clj")
+              (str "(ns a (:require " spec-require "))\n"
+                   "(s/def ::foo string?)"))
+        (lint! (fs/file tmp "a.clj") "--cache" cache)
+        (is (empty? (redefined-spec-findings
+                     (lint! (fs/file tmp "a.clj") "--cache" cache))))))))
+
+(deftest cross-run-staleness-test
+  (testing "removing an s/def and re-linting clears it from the index"
+    (fs/with-temp-dir [tmp {}]
+      (let [cache (str (fs/file tmp ".cache"))]
+        (spit (fs/file tmp "specs.clj") "(ns specs)")
+        (spit (fs/file tmp "a.clj")
+              (str "(ns a (:require " spec-require " [specs :as sp]))\n"
+                   "(s/def ::sp/bar string?)"))
+        (spit (fs/file tmp "b.clj")
+              (str "(ns b (:require " spec-require " [specs :as sp]))\n"
+                   "(s/def ::sp/bar int?)"))
+        (lint! (fs/file tmp "a.clj") "--cache" cache)
+        ;; b now redefines specs/bar
+        (is (seq (redefined-spec-findings
+                  (lint! (fs/file tmp "b.clj") "--cache" cache))))
+        ;; remove the registration from a and re-lint it
+        (spit (fs/file tmp "a.clj")
+              (str "(ns a (:require " spec-require " [specs :as sp]))"))
+        (lint! (fs/file tmp "a.clj") "--cache" cache)
+        ;; b is no longer a redefinition
+        (is (empty? (redefined-spec-findings
+                     (lint! (fs/file tmp "b.clj") "--cache" cache))))))))
+
+(deftest config-test
+  (testing "the linter can be disabled"
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(s/def ::x string?)\n"
+                            "(s/def ::x int?)")
+                       {:linters {:redefined-spec {:level :off}}}))))
+  (testing "individual registrations can be ignored"
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(s/def ::x string?)\n"
+                            "#_{:clj-kondo/ignore [:redefined-spec]}\n"
+                            "(s/def ::x int?)"))))))

--- a/test/clj_kondo/redefined_spec_test.clj
+++ b/test/clj_kondo/redefined_spec_test.clj
@@ -25,14 +25,12 @@
                  "(defn f [x] x)\n"
                  "(s/fdef f :args (s/cat :x int?))\n"
                  "(s/fdef f :args (s/cat :y int?))"))))
-  (testing "s/def and s/fdef share one identity space"
-    (assert-submaps2
-     '({:row 4 :col 8 :level :warning
-        :message #"redefined spec :foo/f"})
-     (lint! (str "(ns foo (:require " spec-require "))\n"
-                 "(defn f [x] x)\n"
-                 "(s/fdef f :args (s/cat :x int?))\n"
-                 "(s/def ::f int?)")))))
+  (testing "a keyword s/def and a symbol s/fdef of the same name do not clash:
+            they occupy spec's two disjoint key spaces"
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(defn f [x] x)\n"
+                            "(s/fdef f :args (s/cat :x int?))\n"
+                            "(s/def ::f int?)"))))))
 
 (deftest edge-cases-test
   (testing "auto-resolved keywords in different namespaces are distinct"

--- a/test/clj_kondo/redefined_spec_test.clj
+++ b/test/clj_kondo/redefined_spec_test.clj
@@ -141,6 +141,33 @@
         (is (empty? (redefined-spec-findings
                      (lint! (fs/file tmp "b.clj") "--cache" cache))))))))
 
+(deftest path-spelling-test
+  (testing "the same file linted by different path spellings is one index entry"
+    (fs/with-temp-dir [tmp {}]
+      (let [cache (str (fs/file tmp ".cache"))]
+        (spit (fs/file tmp "a.clj")
+              (str "(ns a (:require " spec-require "))\n"
+                   "(s/def ::foo string?)"))
+        (lint! (fs/file tmp "a.clj") "--cache" cache)
+        (lint! (str (fs/canonicalize (fs/file tmp "a.clj"))) "--cache" cache)
+        (is (empty? (redefined-spec-findings
+                     (lint! (fs/file tmp "a.clj") "--cache" cache))))))))
+
+(deftest vanished-file-test
+  (testing "entries for deleted or renamed files are dropped from the index"
+    (fs/with-temp-dir [tmp {}]
+      (let [cache (str (fs/file tmp ".cache"))
+            src (str "(ns a (:require " spec-require " [specs :as sp]))\n"
+                     "(s/def ::sp/bar string?)")]
+        (spit (fs/file tmp "specs.clj") "(ns specs)")
+        (spit (fs/file tmp "a.clj") src)
+        (lint! (fs/file tmp "a.clj") "--cache" cache)
+        ;; rename a.clj to b.clj: b must not be reported against the old entry
+        (fs/delete (fs/file tmp "a.clj"))
+        (spit (fs/file tmp "b.clj") src)
+        (is (empty? (redefined-spec-findings
+                     (lint! (fs/file tmp "b.clj") "--cache" cache))))))))
+
 (deftest config-test
   (testing "the linter can be disabled"
     (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"

--- a/test/clj_kondo/redefined_spec_test.clj
+++ b/test/clj_kondo/redefined_spec_test.clj
@@ -189,6 +189,15 @@
         (is (empty? (redefined-spec-findings
                      (lint! (fs/file tmp "b.clj") "--cache" cache))))))))
 
+(deftest stdin-cache-test
+  (testing "stdin is not persisted in the cross-run index"
+    (fs/with-temp-dir [tmp {}]
+      (let [cache (str (fs/file tmp ".cache"))]
+        (is (empty? (redefined-spec-findings
+                     (lint! (str "(ns foo (:require " spec-require "))\n"
+                                 "(s/def ::foo string?)")
+                            "--cache" cache))))))))
+
 (deftest path-spelling-test
   (testing "the same file linted by different path spellings is one index entry"
     (fs/with-temp-dir [tmp {}]

--- a/test/clj_kondo/redefined_spec_test.clj
+++ b/test/clj_kondo/redefined_spec_test.clj
@@ -10,7 +10,7 @@
   (testing "s/def registering the same keyword twice"
     (assert-submaps2
      '({:row 3 :col 8 :level :warning
-        :message #"redefined spec :foo/x"})
+        :message #"spec :foo/x"})
      (lint! (str "(ns foo (:require " spec-require "))\n"
                  "(s/def ::x string?)\n"
                  "(s/def ::x int?)"))))
@@ -20,7 +20,7 @@
   (testing "s/fdef registering the same symbol twice"
     (assert-submaps2
      '({:row 4 :col 9 :level :warning
-        :message #"redefined spec foo/f"})
+        :message #"spec foo/f"})
      (lint! (str "(ns foo (:require " spec-require "))\n"
                  "(defn f [x] x)\n"
                  "(s/fdef f :args (s/cat :x int?))\n"
@@ -36,14 +36,14 @@
   (testing "s/def registering the same symbol twice"
     (assert-submaps2
      '({:row 3 :col 8 :level :warning
-        :message #"redefined spec foo/thing"})
+        :message #"spec foo/thing"})
      (lint! (str "(ns foo (:require " spec-require "))\n"
                  "(s/def foo/thing string?)\n"
                  "(s/def foo/thing int?)"))))
   (testing "s/fdef and a symbol-keyed s/def share spec's symbol key space"
     (assert-submaps2
      '({:row 4 :col 8 :level :warning
-        :message #"redefined spec foo/g"})
+        :message #"spec foo/g"})
      (lint! (str "(ns foo (:require " spec-require "))\n"
                  "(defn g [x] x)\n"
                  "(s/fdef g :args (s/cat :x int?))\n"
@@ -53,9 +53,9 @@
                             "(s/def foo/x string?)\n"
                             "(s/def ::x int?)"))))))
 
-(deftest load-order-test
-  (testing "the required namespace is reported as the original, even when its
-            filename sorts after the redefining one"
+(deftest original-is-source-order-test
+  (testing "the original is chosen by source order, not by the require graph:
+            b.clj requires z, but sorts first, so z.clj is reported"
     (fs/with-temp-dir [tmp {}]
       (spit (fs/file tmp "b.clj")
             (str "(ns b (:require " spec-require " [z]))\n"
@@ -64,9 +64,9 @@
             (str "(ns z (:require " spec-require "))\n"
                  "(s/def :shared/x string?)"))
       (assert-submaps2
-       '({:file #"b.clj" :row 2 :col 8 :level :warning
-          :message #"redefined spec :shared/x, first defined at .*z.clj:2:8"})
-       (filter #(re-find #"redefined spec" (:message %))
+       '({:file #"z.clj" :row 2 :col 8 :level :warning
+          :message #"spec :shared/x also defined at .*b.clj:2:8"})
+       (filter #(re-find #"also defined at" (:message %))
                (lint! (fs/file tmp)))))))
 
 (deftest comment-form-test
@@ -89,7 +89,7 @@
   (testing "aliased and fully-qualified keyword resolving to the same spec clash"
     (assert-submaps2
      '({:row 4 :col 8 :level :warning
-        :message #"redefined spec :shared/x"})
+        :message #"spec :shared/x"})
      (lint! (str "(ns foo (:require " spec-require " [shared :as sh]))\n"
                  "(s/def ::sh/x string?)\n"
                  "(ns bar (:require " spec-require "))\n"
@@ -107,18 +107,18 @@
       (spit (fs/file tmp "shared.clj") "(ns shared)")
       (assert-submaps2
        '({:file #"b.clj" :row 2 :col 8 :level :warning
-          :message #"redefined spec :shared/x, first defined at"})
-       (filter #(re-find #"redefined spec" (:message %))
+          :message #"spec :shared/x also defined at"})
+       (filter #(re-find #"also defined at" (:message %))
                (lint! (fs/file tmp)))))))
 
 (deftest cljc-test
   (testing "a single cljc registration does not warn"
-    (is (empty? (filter #(re-find #"redefined spec" (:message %))
+    (is (empty? (filter #(re-find #"also defined at" (:message %))
                         (lint! (str "(ns foo (:require " spec-require "))\n"
                                     "(s/def ::x string?)")
                                "--lang" "cljc")))))
   (testing "a duplicate cljc registration warns exactly once"
-    (let [findings (filter #(re-find #"redefined spec" (:message %))
+    (let [findings (filter #(re-find #"also defined at" (:message %))
                            (lint! (str "(ns foo (:require " spec-require "))\n"
                                        "(s/def ::x string?)\n"
                                        "(s/def ::x int?)")
@@ -130,11 +130,11 @@
             (str "(ns p (:require " spec-require "))\n(s/def ::x string?)"))
       (spit (fs/file tmp "p.cljs")
             (str "(ns p (:require " spec-require "))\n(s/def ::x string?)"))
-      (is (empty? (filter #(re-find #"redefined spec" (:message %))
+      (is (empty? (filter #(re-find #"also defined at" (:message %))
                           (lint! (fs/file tmp))))))))
 
 (defn- redefined-spec-findings [findings]
-  (filter #(re-find #"redefined spec" (:message %)) findings))
+  (filter #(re-find #"also defined at" (:message %)) findings))
 
 (deftest cross-run-cache-test
   (testing "a redefinition is detected across runs via the global spec index,
@@ -152,7 +152,7 @@
         (lint! (fs/file tmp "a.clj") "--cache" cache)
         (assert-submaps2
          '({:file #"b.clj" :row 2 :col 8 :level :warning
-            :message #"redefined spec :specs/bar, first defined at"})
+            :message #"spec :specs/bar also defined at"})
          (redefined-spec-findings
           (lint! (fs/file tmp "b.clj") "--cache" cache))))))
   (testing "re-linting the same file does not report it against its own cached

--- a/test/clj_kondo/redefined_spec_test.clj
+++ b/test/clj_kondo/redefined_spec_test.clj
@@ -32,6 +32,17 @@
                             "(s/fdef f :args (s/cat :x int?))\n"
                             "(s/def ::f int?)"))))))
 
+(deftest comment-form-test
+  (testing "a registration inside (comment ...) does not clash, consistent with :redefined-var"
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(s/def ::x string?)\n"
+                            "(comment (s/def ::x int?))"))))
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(comment (s/def ::x string?))\n"
+                            "(s/def ::x int?)"))))
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(comment (s/def ::x string?) (s/def ::x int?))"))))))
+
 (deftest edge-cases-test
   (testing "auto-resolved keywords in different namespaces are distinct"
     (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"

--- a/test/clj_kondo/redefined_spec_test.clj
+++ b/test/clj_kondo/redefined_spec_test.clj
@@ -32,6 +32,43 @@
                             "(s/fdef f :args (s/cat :x int?))\n"
                             "(s/def ::f int?)"))))))
 
+(deftest symbol-keyed-def-test
+  (testing "s/def registering the same symbol twice"
+    (assert-submaps2
+     '({:row 3 :col 8 :level :warning
+        :message #"redefined spec foo/thing"})
+     (lint! (str "(ns foo (:require " spec-require "))\n"
+                 "(s/def foo/thing string?)\n"
+                 "(s/def foo/thing int?)"))))
+  (testing "s/fdef and a symbol-keyed s/def share spec's symbol key space"
+    (assert-submaps2
+     '({:row 4 :col 8 :level :warning
+        :message #"redefined spec foo/g"})
+     (lint! (str "(ns foo (:require " spec-require "))\n"
+                 "(defn g [x] x)\n"
+                 "(s/fdef g :args (s/cat :x int?))\n"
+                 "(s/def foo/g int?)"))))
+  (testing "a symbol-keyed s/def does not clash with a keyword of the same name"
+    (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"
+                            "(s/def foo/x string?)\n"
+                            "(s/def ::x int?)"))))))
+
+(deftest load-order-test
+  (testing "the required namespace is reported as the original, even when its
+            filename sorts after the redefining one"
+    (fs/with-temp-dir [tmp {}]
+      (spit (fs/file tmp "b.clj")
+            (str "(ns b (:require " spec-require " [z]))\n"
+                 "(s/def :shared/x int?)"))
+      (spit (fs/file tmp "z.clj")
+            (str "(ns z (:require " spec-require "))\n"
+                 "(s/def :shared/x string?)"))
+      (assert-submaps2
+       '({:file #"b.clj" :row 2 :col 8 :level :warning
+          :message #"redefined spec :shared/x, first defined at .*z.clj:2:8"})
+       (filter #(re-find #"redefined spec" (:message %))
+               (lint! (fs/file tmp)))))))
+
 (deftest comment-form-test
   (testing "a registration inside (comment ...) does not clash, consistent with :redefined-var"
     (is (empty? (lint! (str "(ns foo (:require " spec-require "))\n"


### PR DESCRIPTION
Closes #2878

## Summary

Adds a new `:redefined-spec` linter that reports duplicate `clojure.spec.alpha` / `cljs.spec.alpha` `s/def` and `s/fdef` registrations (`:warning` by default).

`s/def` and `s/fdef` don't define vars, so `:redefined-var` doesn't apply and this is a separate linter.

### Example:

```clojure
(s/def ::foo string?)
(s/def ::foo int?)
;;      ^ redefined spec :user/foo, first defined at src/user.clj:1:8
```

### Identity semantics

Registrations are keyed by their resolved identity, which handles:

- `::foo` in two namespaces are distinct
- `:some-alias/foo` in two namespaces are the same spec

Keyword-keyed `s/def` and symbol-keyed `s/def`/`s/fdef` occupy the two disjoint key spaces of spec's registry, so a keyword spec `::foo` and an `(s/fdef foo ...)` do not clash, while two `s/fdef`s (or a symbol `s/def` and an `s/fdef`) resolving to the same name do.

Because a spec's identity is runtime-specific, a spec registered in a `.clj` file and one in a `.cljs` file with the same name do not clash, while a `.cljc` registration is checked against both.

### Project-wide detection

Detection is project-wide both within a single run and across runs. Across runs it uses a global spec index stored in the cache (`<cache-dir>/spec-index.transit.json`) that mirrors spec's own global registry: every registration from every previously linted file is considered, independent of the require graph. The index is keyed by source file, so re-linting a file refreshes exactly its entries — removing an `s/def` also removes it from the index.

## Notes / limitations

- Like clj-kondo's other caches, a deleted file's entries linger in the global index until a run refreshes them (there is no file-existence sweep).
- This does not change the `:keywords` analysis output used for navigation/find-references; it is purely a linter.
- I've never used spec with cljs, so I'm not 100% on the cljs details.

## Implementation

- `analyzer/spec.clj`, `namespace.clj`: resolve and record each `s/def` / `s/fdef` registration into per-namespace state.
- `linters.clj`: `lint-redefined-specs!` groups current-run and cache-loaded registrations by resolved identity and reports redefinitions.
- `cache.clj`: `read`/`write`/`sync-spec-index!` for the global index, updated under the existing cache lock.
- `config.clj`: default `:redefined-spec {:level :warning}`.

---

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

