### PR TITLE
Fix conflicting alias for current namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2929](https://github.com/clj-kondo/clj-kondo/issues/2929): Fix false positive `:conflicting-alias` finding when an alias has the same name as the current namespace.
 - [#2928](https://github.com/clj-kondo/clj-kondo/issues/2928): Type checker: the return types of `keys` and `vals` are nilable. E.g. `(when (keys m) ...)` no longer warns with `Condition always true`.
 
 ## 2026.07.24

--- a/src/clj_kondo/impl/analyzer/namespace.clj
+++ b/src/clj_kondo/impl/analyzer/namespace.clj
@@ -410,7 +410,7 @@
                  analyzed))
              kw+libspecs)
         _ (doseq [analyzed analyzed]
-            (namespace/lint-conflicting-aliases! ctx ns-name analyzed)
+            (namespace/lint-conflicting-aliases! ctx analyzed)
             (let [namespaces (map :ns analyzed)]
               (namespace/lint-unsorted-required-namespaces! ctx namespaces)
               (namespace/lint-duplicate-requires! ctx namespaces)))

--- a/src/clj_kondo/impl/namespace.clj
+++ b/src/clj_kondo/impl/namespace.clj
@@ -34,15 +34,14 @@
            namespaces)
    nil))
 
-(defn lint-conflicting-aliases! [ctx ns-sym namespaces]
+(defn lint-conflicting-aliases! [ctx namespaces]
   (let [config (:config ctx)
         level (-> config :linters :conflicting-alias :level)]
     (when-not (identical? :off level)
       (loop [aliases #{}
              ns-maps (filter :as namespaces)]
         (let [{:keys [ns as]} (first ns-maps)]
-          (when (or (contains? aliases as)
-                    (= ns-sym as))
+          (when (contains? aliases as)
             (findings/reg-finding!
              ctx
              (node->line (:filename ctx)
@@ -416,7 +415,7 @@
 
 (defn reg-required-namespaces!
   [{:keys [base-lang lang namespaces] :as ctx} ns-sym analyzed-require-clauses]
-  (lint-conflicting-aliases! ctx ns-sym (:required analyzed-require-clauses))
+  (lint-conflicting-aliases! ctx (:required analyzed-require-clauses))
   (lint-unsorted-required-namespaces! ctx (:required analyzed-require-clauses))
   (let [path [base-lang lang ns-sym]
         ns (get-in @namespaces path)]

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -3559,11 +3559,9 @@ app.api/my-var"
                      {:linters {:conflicting-alias {:level :error}
                                 :unused-referred-var {:level :off}
                                 :unused-namespace {:level :off}}})))
-  (assert-submaps [{:file "<stdin>", :row 1, :col 54,
-                    :level :error, :message "Conflicting alias for foo.foo"}]
-                  (lint! "(ns foo (:require [foo.bar :as foo-bar] [foo.foo :as foo]))"
-                         {:linters {:conflicting-alias {:level :error}
-                                    :unused-namespace {:level :off}}})))
+  (is (empty? (lint! "(ns foo (:require [foo.bar :as foo-bar] [foo.foo :as foo]))"
+                     {:linters {:conflicting-alias {:level :error}
+                                :unused-namespace {:level :off}}}))))
 
 (deftest refer-test
   (is (empty? (lint! "(ns foo (:require [foo.bar :as foo-bar] [foo.baz :refer [asd]])) (foo-bar/bazbar) (asd)")))


### PR DESCRIPTION
 ## Summary
  - avoid reporting a conflicting alias when it matches the current namespace
  - preserve warnings for actual duplicate aliases
  - add regression coverage and update the changelog

  Fixes #2929

  ## Testing
  - focused regression test
  - self-lint
  - full JVM test suite