### PR TITLE
Bump graal-build-time to 1.0.6 for GraalVM 25.1+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 <!-- - [ ] github release (publish the draft manually) -->
 <!-- - [ ] bb script/release-everything.clj -> homebrew, clj-kondo pod, clj-kondo-bb, lein-clj-kondo, post-release bump -->
 
+## Unreleased
+
+- Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
+
 ## 2026.08.04
 
 - Hooks: clj-kondo reloads a hook namespace when another config dir defines a namespace with the same name.

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                                    [io.github.borkdude/deflet "0.1.0"]
                                    [borkdude/missing.test.assertions "0.0.2"]]
                     :source-paths ["src" "parser" "inlined" "extract"]}
-             :uberjar {:dependencies [[com.github.clj-easy/graal-build-time "0.1.0"]]
+             :uberjar {:dependencies [[com.github.clj-easy/graal-build-time "1.0.6"]]
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"
                                   "-Dclojure.spec.skip-macros=true"]
                        :main clj-kondo.main

--- a/resources/META-INF/native-image/clj-kondo/clj-kondo/native-image.properties
+++ b/resources/META-INF/native-image/clj-kondo/clj-kondo/native-image.properties
@@ -1,5 +1,6 @@
 ImageName=clj-kondo
 Args=-J-Dborkdude.dynaload.aot=true \
+     --features=clj_easy.graal_build_time.InitClojureClasses \
      --initialize-at-build-time=com.fasterxml.jackson \
      --initialize-at-build-time=com.github.javaparser \
      -H:IncludeResources=clj_kondo/impl/cache/built_in/.* \


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [X] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). #2948 

- [ ] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions.

Not sure about a test here -- I think that depends on CI ultimately -- but I'll add it upstream in nixpkgs to catch depending on the shifting dev env for the future.

- [X] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
