### PR TITLE
fix: preserve highest min-clj-kondo-version when merging configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2947](https://github.com/clj-kondo/clj-kondo/issues/2947): config merging preserves the highest `:min-clj-kondo-version` value ([@arimu1](https://github.com/arimu1))
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 
 ## 2026.08.04

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -255,6 +255,18 @@
 (defn- merge-type-mismatch-namespaces [a b]
   (merge-with (partial merge-with merge-fn-types) a b))
 
+(defn- highest-min-clj-kondo-version
+  "When merging configs, preserve the strictest (highest) min-clj-kondo-version."
+  [merged cfg* cfg]
+  (if-let [highest (some->> [(:min-clj-kondo-version cfg*)
+                             (:min-clj-kondo-version cfg)]
+                            (remove nil?)
+                            seq
+                            sort
+                            last)]
+    (assoc merged :min-clj-kondo-version highest)
+    merged))
+
 (defn merge-config!
   ([])
   ([cfg] cfg)
@@ -270,7 +282,9 @@
                    (assoc-in [:linters :missing-else-branch] (:if (:linters cfg)))
                    (contains? (:linters cfg) :type-mismatch)
                    (update-in [:linters :type-mismatch] dissoc :namespaces))]
-         (deep-merge cfg* cfg))))
+         (-> cfg*
+             (deep-merge cfg)
+             (highest-min-clj-kondo-version cfg* cfg)))))
   ([cfg* cfg & cfgs]
    (reduce merge-config! cfg* (cons cfg cfgs))))
 

--- a/test/clj_kondo/impl/config_test.clj
+++ b/test/clj_kondo/impl/config_test.clj
@@ -27,6 +27,28 @@
                                           '{:linters {:unresolved-namespace {:exclude #{baz}}}})
                            :linters :unresolved-namespace :exclude))))
 
+(deftest merge-min-clj-kondo-version-test
+  (testing "preserves highest min-clj-kondo-version when later config is lower"
+    (is (= "2025.02.01"
+           (:min-clj-kondo-version
+            (merge-config! {:min-clj-kondo-version "2025.02.01"}
+                           {:min-clj-kondo-version "2025.01.01"})))))
+  (testing "preserves highest min-clj-kondo-version when later config is higher"
+    (is (= "2025.02.01"
+           (:min-clj-kondo-version
+            (merge-config! {:min-clj-kondo-version "2025.01.01"}
+                           {:min-clj-kondo-version "2025.02.01"})))))
+  (testing "preserves min-clj-kondo-version when only one config defines it"
+    (is (= "2025.01.01"
+           (:min-clj-kondo-version
+            (merge-config! {:min-clj-kondo-version "2025.01.01"} {})))))
+  (testing "highest min-clj-kondo-version across multiple merged configs"
+    (is (= "2025.03.01"
+           (:min-clj-kondo-version
+            (merge-config! {:min-clj-kondo-version "2025.01.01"}
+                           {:min-clj-kondo-version "2025.03.01"}
+                           {:min-clj-kondo-version "2025.02.01"}))))))
+
 (deftest merge-config!-test
   (testing "type-mismatch :arities are overwritten instead of merged"
     (is (= {:linters {:type-mismatch {:namespaces '{my-ns {shared   {:arities {1 {:args [:str] :ret :str}


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

## Summary

When merging configuration maps, `:min-clj-kondo-version` now keeps the strictest (highest) requirement from either side instead of letting the later config overwrite a higher dependency requirement.

Fixes #2947

## Changes

- Added `highest-min-clj-kondo-version` helper in `clj-kondo.impl.config/merge-config!`
- Added unit tests in `clj-kondo.impl.config-test` covering merge order and multi-config merges

## Test plan

- [x] `clojure -M:clojure-1.11.4:test -n clj-kondo.impl.config-test`
- [x] `clojure -M:clojure-1.11.4:test -n clj-kondo.clj-kondo-config-test`