### PR TITLE
[FIX]: Report (reduce str ...) as a problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
+- [#1734](https://github.com/clj-kondo/clj-kondo/issues/1734): NEW linter: `:reduce-str`: warn when reduce is called with `str`. Suggests using `apply str`.
 
 ## 2026.08.04
 
@@ -189,7 +190,7 @@ Performance: linting is faster and allocates less. Var usages and bindings are n
 - `unused-excluded-var`: Add location metadata to excluded vars in `ns-unmap`. This fixes some findings with not location. ([@jramosg](https://github.com/jramosg))
 - [#2747](https://github.com/clj-kondo/clj-kondo/issues/2747): Fix: Gensym bindings in nested syntax quotes are now correctly recognized ([@jramosg](https://github.com/jramosg))when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2746](https://github.com/clj-kondo/clj-kondo/issues/2746): Fix regression: primitive array class syntax (e.g., `byte/1`, `int/2`) now correctly recognized as class literals in type checking ([@jramosg](https://github.com/jramosg))
-- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg)) 
+- [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2749](https://github.com/clj-kondo/clj-kondo/issues/2749): Fix false positive for throw in CLJS when throwing non-throwable values ([@jramosg](https://github.com/jramosg))
 - [#2739](https://github.com/clj-kondo/clj-kondo/issues/2739): Extend `:equals-expected-position` linter to also warn for `not=` when expected value is not first ([@jramosg](https://github.com/jramosg))
 - [#2732](https://github.com/clj-kondo/clj-kondo/issues/2732): `unreachable-code`: warn when `:default` does not come last in reader conditionals ([@jramosg](https://github.com/jramosg))

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -61,6 +61,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Invalid arity](#invalid-arity)
     - [Conflicting arity](#conflicting-arity)
     - [Reduce without initial value](#reduce-without-initial-value)
+    - [Reduce `str`](#reduce-str)
     - [Loop without recur](#loop-without-recur)
     - [Line length](#line-length)
     - [Keyword in binding vector](#keyword-in-binding-vector)
@@ -1157,6 +1158,25 @@ why this can be problematic.
 
 ```clojure
 {:linters {:reduce-without-init {:exclude [clojure.core/max cljs.core/max]}}}
+```
+
+### Reduce `str`
+
+**Keyword:** `:reduce-str`
+
+*Description:* warn when a reduce is called using str instead of preferring `apply str` or `clojure.string/join`.
+`reduce str` accumulates new string object references each cycle.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(reduce str [\"Hello\" \" World\"])`.
+
+*Example message:* `Prefer apply str over reduce str`
+
+*Config:* to suppress the above warning:
+
+```clojure
+{:linters {:reduce-str {:level :off}}}
 ```
 
 ### Loop without recur

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3104,6 +3104,18 @@
        (node->line (:filename ctx) expr
                    :reduce-without-init
                    "Reduce called without explicit initial value.")))
+    (when (and (not (linter-disabled? ctx :reduce-str))
+               (= 'reduce hof-resolved-name)
+               (or (= 'clojure.core hof-ns-name)
+                   (= 'clojure.cljs hof-ns-name))
+               (one-of [resolved-namespace resolved-name]
+                       [[clojure.core str]
+                        [cljs.core str]]))
+      (findings/reg-finding!
+       ctx
+       (node->line (:filename ctx) expr
+                   :reduce-str
+                   "Prefer `apply str` over `reduce str`")))
     (concat fana
             (analyze-children ctx f-args false))))
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3115,7 +3115,7 @@
        ctx
        (node->line (:filename ctx) expr
                    :reduce-str
-                   "Prefer `apply str` over `reduce str`")))
+                   "Use `(apply str ...)` or `(str/join ...)`")))
     (concat fana
             (analyze-children ctx f-args false))))
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -80,6 +80,7 @@
               ;; for example: foo.bar is always loaded in a user profile
               :reduce-without-init {:level :off
                                     :exclude [#_foo.bar/baz]}
+              :reduce-str {:level :warning}
               :misplaced-docstring {:level :warning}
               :misplaced-async-metadata {:level :warning}
               :not-empty? {:level :warning}

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -1756,7 +1756,7 @@ foo/foo ;; this does use the private var
   (is (empty? (lint! "(defn foo [])")))
   (is (empty? (lint! "(ns foo (:refer-clojure :exclude [inc])) (defn inc [])")))
   (is (empty? (lint! "(declare foo) (def foo 1)")))
-  (is (empty? (lint! "(def foo 1) (declare foo)" 
+  (is (empty? (lint! "(def foo 1) (declare foo)"
                      {:linters {:redundant-declare {:level :off}}})))
   (is (empty? (lint! "(if (odd? 3) (def foo 1) (def foo 2))")))
   (testing "disable linter in comment"
@@ -4264,6 +4264,12 @@ x"
                    (lint! "(ns foo (:refer-global :only [String] :rename {String Str})) Str String"
                           {:linters {:unresolved-symbol {:level :error}}}
                           "--lang" "cljs")))
+
+(deftest reduce-str-test
+  (is (assert-submaps2
+       '({:file "<stdin>", :row 1, :col 8, :level :warning, :message "Prefer `apply str` over `reduce str`"})
+       (lint! "(reduce str \"\" [1 2 3])" {:linters {:shadowed-fn-param {:level :warning}}})))
+  (is (empty? (lint! "#_:clj-kondo/ignore (reduce str \"\" [1 2 3])" {:linters {:shadowed-fn-param {:level :warning}}}))))
 
 ;;;; Scratch
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -4267,7 +4267,7 @@ x"
 
 (deftest reduce-str-test
   (is (assert-submaps2
-       '({:file "<stdin>", :row 1, :col 8, :level :warning, :message "Use `(apply str ...)` or `(str/join ...)`"})
+       '({:file "<stdin>", :row 1, :col 1, :level :warning, :message "Use `(apply str ...)` or `(str/join ...)`"})
        (lint! "(reduce str \"\" [1 2 3])" {:linters {:shadowed-fn-param {:level :warning}}})))
   (is (empty? (lint! "#_:clj-kondo/ignore (reduce str \"\" [1 2 3])" {:linters {:shadowed-fn-param {:level :warning}}}))))
 

--- a/test/clj_kondo/main_test.clj
+++ b/test/clj_kondo/main_test.clj
@@ -4267,7 +4267,7 @@ x"
 
 (deftest reduce-str-test
   (is (assert-submaps2
-       '({:file "<stdin>", :row 1, :col 8, :level :warning, :message "Prefer `apply str` over `reduce str`"})
+       '({:file "<stdin>", :row 1, :col 8, :level :warning, :message "Use `(apply str ...)` or `(str/join ...)`"})
        (lint! "(reduce str \"\" [1 2 3])" {:linters {:shadowed-fn-param {:level :warning}}})))
   (is (empty? (lint! "#_:clj-kondo/ignore (reduce str \"\" [1 2 3])" {:linters {:shadowed-fn-param {:level :warning}}}))))
 


### PR DESCRIPTION
This adds a linter to suggest `apply str` and `clojure.string/join` as alternatives to `reduce str`. I recently ran into the performance implications of the underlying issue while working on `rewrite-clj`, and will copy the relevant profiling findings here: https://github.com/clj-commons/rewrite-clj/issues/478

The UUID comparison idea is something I saw in this (old) thread: https://clojurians.slack.com/archives/CPABC1H61/p1743526411083109

```clj
(comment
  
  ;; From: https://clojure-goes-fast.com/kb/benchmarking/time-plus/
  (let [time*
        (fn [^long duration-in-ms f]
          (let [^com.sun.management.ThreadMXBean bean (java.lang.management.ManagementFactory/getThreadMXBean)
                bytes-before (.getCurrentThreadAllocatedBytes bean)
                duration (* duration-in-ms 1000000)
                start (System/nanoTime)
                first-res (f)
                delta (- (System/nanoTime) start)
                deadline (+ start duration)
                tight-iters (max (quot (quot duration delta) 10) 1)]
            (loop [i 1]
              (let [now (System/nanoTime)]
                (if (< now deadline)
                  (do (dotimes [_ tight-iters] (f))
                    (recur (+ i tight-iters)))
                  (let [i' (double i)
                        bytes-after (.getCurrentThreadAllocatedBytes bean)
                        t (/ (- now start) i')]
                    (println
                      (format "Time per call: %s   Alloc per call: %,.0fb   Iterations: %d"
                        (cond (< t 1e3) (format "%.0f ns" t)
                          (< t 1e6) (format "%.2f us" (/ t 1e3))
                          (< t 1e9) (format "%.2f ms" (/ t 1e6))
                          :else (format "%.2f s" (/ t 1e9)))
                        (/ (- bytes-after bytes-before) i')
                        i))
                    first-res))))))]
    (defmacro time+
      "Like `time`, but runs the supplied body for 2000 ms and prints the average
    time for a single iteration. Custom total time in milliseconds can be provided
    as the first argument. Returns the returned value of the FIRST iteration."
      [?duration-in-ms & body]
      (let [[duration body] (if (integer? ?duration-in-ms)
                              [?duration-in-ms body]
                              [2000 (cons ?duration-in-ms body)])]
        `(~time* ~duration (fn [] ~@body)))))
  
  (defn ->random-string-seq
    [n]
    (take n (repeatedly #(str (random-uuid)))))
  
  (def one-k-seq
    (->random-string-seq 1000))
  
  (def five-k-seq
    (->random-string-seq 5000))
  
  (def ten-k-seq
    (->random-string-seq 10000))

  ;; I think this grows N^2 with the byte array copies
  (def one-k-slow (time+ (reduce str one-k-seq))) 
  (def five-k-slow (time+ (reduce str five-k-seq)))
  (def ten-k-slow (time+ (reduce str ten-k-seq)))
  ;; Time per call: 2.18 ms   Alloc per call: 72,176,282b   Iterations: 946 (n = 1000)
  ;; Time per call: 37.92 ms   Alloc per call: 1,800,879,753b   Iterations: 53 (n = 5000)
  ;; Time per call: 143.50 ms   Alloc per call: 7,202,096,681b   Iterations: 14 (n = 10000)
  
 ;; Linear growth with the StringBuilder reuse
  (def one-k-fast (time+ (clojure.string/join one-k-seq)))
  (def five-k-fast (time+ (clojure.string/join five-k-seq)))
  (def ten-k-fast (time+ (clojure.string/join ten-k-seq)))
  ;; Time per call: 23.61 us   Alloc per call: 146,784b   Iterations: 86527  (n = 1000)
  ;; Time per call: 115.05 us   Alloc per call: 622,592b   Iterations: 18021 (n = 5000)
  ;; Time per call: 227.52 us   Alloc per call: 1,244,976b   Iterations: 9009 (n = 10000)

  )
```

## Open Question

The regression tests _do_ contain an example of this issue in the wild. If the linter ought to stay enabled by default, I _think_ I know how to regenerate the relevant snapshot/regression tests. If you'd rather keep them as is, I'll update the config to default to off. In either case, it's probably not worth running the CI here until I make one of those two changes.

Any preference?

## GitHub Stuff

(Closes: https://github.com/clj-kondo/clj-kondo/issues/1734)

## Attestations

Please answer the following questions and leave the below in as part of your PR.

- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform. 

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - See: https://github.com/clj-kondo/clj-kondo/issues/1734

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions
  - See:  https://github.com/nnichols/clj-kondo/blob/18dd563c80ac457d2ce07cd8c8d0203fa307e15c/test/clj_kondo/main_test.clj#L4268

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.
  - See:  https://github.com/nnichols/clj-kondo/blob/18dd563c80ac457d2ce07cd8c8d0203fa307e15c/CHANGELOG.md#unreleased

(Sorry about the end of line changes. I have VSCode set up to trim those automatically. Happy to revert if you wanna keep this clean)