### PR TITLE
Add :range-direction linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2959](https://github.com/clj-kondo/clj-kondo/issues/2959): new linter `:range-direction` warns when a literal `range` step moves away from the end value.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -88,6 +88,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Plus one](#plus-one)
     - [Private call](#private-call)
     - [Protocol method varargs](#protocol-method-varargs)
+    - [Range direction](#range-direction)
     - [Redefined var](#redefined-var)
     - [Var same name except case](#var-same-name-except-case)
     - [Alias same as ns name](#alias-same-ns-name)
@@ -1842,6 +1843,18 @@ along with:
 
 *Example message:* `Redundant nested call: +`.
 
+### Range direction
+
+*Keyword:* `:range-direction`.
+
+*Description:* warn when a literal step passed to `range` moves away from its
+literal end value.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(range 0 10 -1)`.
+
+*Example message:* `Range step moves away from the end value`.
 ### Redundant let
 
 *Keyword:* `:redundant-let`.

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -199,6 +199,7 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
+              :range-direction {:level :warning}
               :unquote-not-syntax-quoted {:level :warning}
               :await-without-async-fn {:level :error}
               :conditional-build-up {:level :off}}

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -176,6 +176,24 @@
          (node->line (:filename ctx) keyvec :single-key-in
                      (format "%s with single key" called-name)))))))
 
+(defn lint-range-direction [ctx call]
+  (when-not (utils/linter-disabled? ctx :range-direction)
+    (let [[start end step] (rest (:children call))
+          start-value (:value start)
+          end-value (:value end)
+          step-value (if step (:value step) 1)]
+      (when (and (utils/one-of (count (:children call)) [3 4])
+                 (number? start-value)
+                 (number? end-value)
+                 (number? step-value)
+                 (or (and (< start-value end-value) (neg? step-value))
+                     (and (> start-value end-value) (pos? step-value)))
+                 (not (:clj-kondo.impl/generated call)))
+        (findings/reg-finding!
+         ctx
+         (node->line (:filename ctx) (or step end) :range-direction
+                     "Range step moves away from the end value"))))))
+
 (defn lint-specific-calls! [ctx call called-fn]
   (let [called-ns (:ns called-fn)
         called-name (:name called-fn)
@@ -185,6 +203,8 @@
     (case [called-ns called-name]
       ([clojure.core cond] [cljs.core cond])
       (lint-cond ctx (:expr call))
+      ([clojure.core range] [cljs.core range])
+      (lint-range-direction ctx (:expr call))
       ([clojure.core if-let] [clojure.core if-not] [clojure.core if-some]
                              [cljs.core if-let] [cljs.core if-not] [cljs.core if-some])
       (do (lint-missing-else-branch ctx (:expr call))

--- a/test/clj_kondo/range_direction_test.clj
+++ b/test/clj_kondo/range_direction_test.clj
@@ -1,0 +1,28 @@
+(ns clj-kondo.range-direction-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:range-direction {:level :warning}}})
+
+(deftest range-direction-test
+  (assert-submaps2
+   '({:row 1
+      :col 13
+      :message "Range step moves away from the end value"})
+   (lint! "(range 0 10 -1)" config))
+  (assert-submaps2
+   '({:row 1
+      :col 13
+      :message "Range step moves away from the end value"})
+   (lint! "(range 10 0 1)" config))
+  (assert-submaps2
+   '({:row 1
+      :col 11
+      :message "Range step moves away from the end value"})
+   (lint! "(range 10 0)" config))
+  (is (empty? (lint! "(range 0 10 1) (range 10 0 -1)" config)))
+  (is (empty? (lint! "(range start end step)" config)))
+  (is (empty? (lint! "(range 0 10 -1)"
+                     {:linters {:range-direction {:level :off}}}))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2959.

`(range 0 10 -1)` and `(range 10 0 1)` are always empty. When the bounds and the step are literal numbers this is provable during analysis.

This adds `:range-direction`, at `:warning` by default, which reports the step when it is supplied and the end value otherwise. It stays quiet when any argument is not a literal number and when the range is correctly directed.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.