### PR TITLE
Add :empty-binding linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2960](https://github.com/clj-kondo/clj-kondo/issues/2960): new linter `:empty-binding` warns on an empty destructuring form that binds no values.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -47,6 +47,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Dynamic vars](#dynamic-vars)
         - [Dynamic var not earmuffed](#dynamic-var-not-earmuffed)
         - [Earmuffed var not dynamic](#earmuffed-var-not-dynamic)
+    - [Empty binding](#empty-binding)
     - [Equals expected position](#equals-expected-position)
     - [Equals float](#equals-float)
     - [Equals false](#equals-false)
@@ -877,6 +878,19 @@ Explanation by Bozhidar Batsov:
 *Example trigger:* `(def *foo*)`
 
 *Example message:* `"Var has earmuffed name but is not declared dynamic: *foo*"`
+
+### Empty binding
+
+*Keyword:* `:empty-binding`.
+
+*Description:* warn when an empty sequential or map destructuring form binds no
+values.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(let [{} value] value)`.
+
+*Example message:* `Empty destructuring form binds no values`.
 
 ### Equals expected position
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -300,6 +300,16 @@
 
 (declare extract-bindings)
 
+(defn- lint-empty-binding [ctx expr opts]
+  (when (and (empty? (:children expr))
+             (not (:allow-empty-binding? opts))
+             (not (linter-disabled? ctx :empty-binding))
+             (not (:clj-kondo.impl/generated expr)))
+    (findings/reg-finding!
+     ctx
+     (node->line (:filename ctx) expr :empty-binding
+                 "Empty destructuring form binds no values"))))
+
 (defn node-contains-or?
   "Whether a destructuring form has an :or directive at any depth.
   Over-matches :or in other positions, which callers accept."
@@ -718,7 +728,8 @@
                         expr
                         :syntax
                         (str "unsupported binding form " expr))))
-         :vector (let [children (:children expr)
+         :vector (let [_ (lint-empty-binding ctx expr opts)
+                       children (:children expr)
                        all-tokens? (every? #(identical? :token %) (map :tag children))
                        exclude-as? (-> ctx :config :linters :unused-binding
                                        :exclude-destructured-as)
@@ -730,7 +741,8 @@
                        ;; the value's tag describes the whole sequence, not its
                        ;; elements, see the same guard in extract-map-bindings.
                        ;; Only :as names the whole value
-                       child-opts (assoc (dissoc opts :tag) :allow-amp true)
+                       child-opts (assoc (dissoc opts :tag :allow-empty-binding?)
+                                         :allow-amp true)
                        opts-for (fn [child]
                                   (if (and (identical? child as-node) (:tag opts))
                                     (assoc child-opts :tag (:tag opts))
@@ -777,7 +789,9 @@
                                            (assoc opts :namespaced-map true))
          :map
          ;; first check even amount of keys + vals
-         (extract-map-bindings ctx expr scoped-expr opts)
+         (do
+           (lint-empty-binding ctx expr opts)
+           (extract-map-bindings ctx expr scoped-expr opts))
          (findings/reg-finding!
           ctx
           (node->line (:filename ctx)
@@ -839,7 +853,10 @@
                                                  :syntax
                                                  "Function arguments should be wrapped in vector."))
               (let [fn-dupes (atom #{}) ;; used to detect duplicate fn arg names
-                    arg-bindings (extract-bindings (assoc ctx :fn-dupes fn-dupes) arg-vec body {:fn-args? true})
+                    arg-bindings (extract-bindings (assoc ctx :fn-dupes fn-dupes)
+                                                  arg-vec body
+                                                  {:fn-args? true
+                                                   :allow-empty-binding? true})
                     {return-tag :tag
                      arg-tags :tags
                      keys-bindings :keys-bindings} (meta arg-bindings)
@@ -2623,7 +2640,7 @@
                                           :mark-bindings-used? true)
                                    binding-vector
                                    expr
-                                   {})
+                                   {:allow-empty-binding? true})
         arglists? (:analyze-arglists? ctx)
         ctx (ctx-with-bindings ctx bindings)]
     (when (and record-name bindings)

--- a/src/clj_kondo/impl/analyzer/common.clj
+++ b/src/clj_kondo/impl/analyzer/common.clj
@@ -9,8 +9,10 @@
 (defn analyze-expression** [ctx expr]
   ((get @common 'analyze-expression**) ctx expr))
 
-(defn extract-bindings [ctx expr]
-  ((get @common 'extract-bindings) ctx expr))
+(defn extract-bindings
+  ([ctx expr] ((get @common 'extract-bindings) ctx expr))
+  ([ctx expr scoped-expr opts]
+   ((get @common 'extract-bindings) ctx expr scoped-expr opts)))
 
 (defn ctx-with-bindings [ctx expr]
   ((get @common 'ctx-with-bindings) ctx expr))

--- a/src/clj_kondo/impl/analyzer/compojure.clj
+++ b/src/clj_kondo/impl/analyzer/compojure.clj
@@ -33,6 +33,7 @@
         destructuring-form (if vec?
                              (normalize-compojure-vector ctx destructuring-form)
                              destructuring-form)
-        bindings (extract-bindings ctx destructuring-form)
+        bindings (extract-bindings ctx destructuring-form destructuring-form
+                                   {:allow-empty-binding? true})
         ctx (ctx-with-bindings ctx bindings)]
     (analyze-children ctx (next children))))

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -38,6 +38,7 @@
               :duplicate-require {:level :warning}
               :duplicate-field {:level :error}
               :duplicate-key-args {:level :warning}
+              :empty-binding {:level :warning}
               :missing-map-value {:level :error}
               :redefined-var {:level :warning}
               :redundant-declare {:level :warning}

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -1257,6 +1257,16 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 203}
+ {:end-row 442,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/actions/api_test.clj",
+  :col 29,
+  :end-col 31,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 442}
  {:end-row 19,
   :type :unresolved-symbol,
   :level :error,
@@ -1347,6 +1357,16 @@
   :langs (),
   :message "Condition always true",
   :row 460}
+ {:end-row 528,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/analytics/stats_test.clj",
+  :col 40,
+  :end-col 42,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 528}
  {:end-row 64,
   :type :unresolved-symbol,
   :level :error,
@@ -1517,6 +1537,16 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 248}
+ {:end-row 693,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/collections/api_test.clj",
+  :col 38,
+  :end-col 40,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 693}
  {:end-row 2,
   :type :unused-excluded-var,
   :level :info,
@@ -1557,6 +1587,16 @@
   :langs (),
   :message "Expected: char sequence, received: symbol.",
   :row 42}
+ {:end-row 724,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/dashboards/api_test.clj",
+  :col 29,
+  :end-col 31,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 724}
  {:end-row 2253,
   :type :unresolved-symbol,
   :level :error,
@@ -1724,6 +1764,16 @@
   :langs (:clj :cljs),
   :message "Condition always true",
   :row 96}
+ {:end-row 189,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/lib_be/metadata/jvm_test.clj",
+  :col 39,
+  :end-col 41,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 189}
  {:end-row 165,
   :type :unresolved-symbol,
   :level :error,
@@ -1734,6 +1784,26 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 165}
+ {:end-row 71,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/parameters/dashboard_test.clj",
+  :col 45,
+  :end-col 47,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 71}
+ {:end-row 76,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/parameters/dashboard_test.clj",
+  :col 45,
+  :end-col 47,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 76}
  {:end-row 93,
   :type :constant-condition,
   :level :warning,
@@ -1744,6 +1814,46 @@
   :langs (),
   :message "Condition always true",
   :row 93}
+ {:end-row 115,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/parameters/dashboard_test.clj",
+  :col 45,
+  :end-col 47,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 115}
+ {:end-row 120,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/parameters/dashboard_test.clj",
+  :col 45,
+  :end-col 47,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 120}
+ {:end-row 175,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/parameters/dashboard_test.clj",
+  :col 45,
+  :end-col 47,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 175}
+ {:end-row 180,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/parameters/dashboard_test.clj",
+  :col 45,
+  :end-col 47,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 180}
  {:end-row 72,
   :type :unresolved-symbol,
   :level :error,
@@ -1754,6 +1864,96 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 72}
+ {:end-row 161,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 161}
+ {:end-row 163,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 163}
+ {:end-row 203,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 203}
+ {:end-row 205,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 205}
+ {:end-row 246,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 54,
+  :end-col 56,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 246}
+ {:end-row 272,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 272}
+ {:end-row 274,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 274}
+ {:end-row 276,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 276}
+ {:end-row 278,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 278}
  {:end-row 293,
   :type :unresolved-symbol,
   :level :error,
@@ -1764,6 +1964,86 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 293}
+ {:end-row 457,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 457}
+ {:end-row 495,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 495}
+ {:end-row 525,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 54,
+  :end-col 56,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 525}
+ {:end-row 527,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 54,
+  :end-col 56,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 527}
+ {:end-row 529,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 54,
+  :end-col 56,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 529}
+ {:end-row 739,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/data_permissions_test.clj",
+  :col 52,
+  :end-col 54,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 739}
+ {:end-row 122,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/permissions_group_test.clj",
+  :col 42,
+  :end-col 44,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 122}
+ {:end-row 123,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/permissions/models/permissions_group_test.clj",
+  :col 42,
+  :end-col 44,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 123}
  {:end-row 125,
   :type :type-mismatch,
   :level :error,
@@ -1805,6 +2085,56 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 628}
+ {:end-row 997,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/public_sharing/api_test.clj",
+  :col 31,
+  :end-col 33,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 997}
+ {:end-row 1000,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/public_sharing/api_test.clj",
+  :col 29,
+  :end-col 31,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 1000}
+ {:end-row 1520,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/public_sharing/api_test.clj",
+  :col 31,
+  :end-col 33,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 1520}
+ {:end-row 1539,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/public_sharing/api_test.clj",
+  :col 33,
+  :end-col 35,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 1539}
+ {:end-row 1546,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/public_sharing/api_test.clj",
+  :col 33,
+  :end-col 35,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 1546}
  {:end-row 902,
   :type :unresolved-symbol,
   :level :error,
@@ -1855,6 +2185,26 @@
   :langs (),
   :message "Format string contains no format specifiers",
   :row 884}
+ {:end-row 927,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/pulse/dashboard_subscription_test.clj",
+  :col 28,
+  :end-col 30,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 927}
+ {:end-row 949,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/pulse/dashboard_subscription_test.clj",
+  :col 28,
+  :end-col 30,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 949}
  {:end-row 10,
   :type :deprecated-namespace,
   :level :warning,
@@ -2046,6 +2396,16 @@
   :langs (),
   :message "Write expected value first",
   :row 599}
+ {:end-row 227,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/revisions/models/revision_test.clj",
+  :col 31,
+  :end-col 33,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 227}
  {:end-row 394,
   :type :unresolved-symbol,
   :level :error,
@@ -2263,6 +2623,16 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 282}
+ {:end-row 138,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/warehouse_schema/api/table_test.clj",
+  :col 38,
+  :end-col 40,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 138}
  {:end-row 701,
   :type :redundant-format,
   :level :info,
@@ -2313,6 +2683,16 @@
   :langs (),
   :message "Unresolved symbol: partial=",
   :row 101}
+ {:end-row 154,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/warehouse_schema/models/table_test.clj",
+  :col 22,
+  :end-col 24,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 154}
  {:end-row 120,
   :type :redundant-format,
   :level :info,
@@ -2323,6 +2703,16 @@
   :langs (),
   :message "Format string contains no format specifiers",
   :row 120}
+ {:end-row 179,
+  :type :empty-binding,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/warehouses/api_test.clj",
+  :col 42,
+  :end-col 44,
+  :langs (),
+  :message "Empty destructuring form binds no values",
+  :row 179}
  {:end-row 408,
   :type :unresolved-symbol,
   :level :error,

--- a/test/clj_kondo/empty_binding_test.clj
+++ b/test/clj_kondo/empty_binding_test.clj
@@ -1,0 +1,16 @@
+(ns clj-kondo.empty-binding-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:empty-binding {:level :warning}}})
+
+(deftest empty-binding-test
+  (assert-submaps2
+   '({:row 1 :col 7 :message "Empty destructuring form binds no values"})
+   (lint! "(let [{} x] x)" config))
+  (assert-submaps2
+   '({:row 1 :col 7 :message "Empty destructuring form binds no values"})
+   (lint! "(let [[] x] x)" config))
+  (is (empty? (lint! "(fn []) (let [{:keys [x]} m] x)" config))))

--- a/test/clj_kondo/test_utils.clj
+++ b/test/clj_kondo/test_utils.clj
@@ -134,7 +134,8 @@
              :uninitialized-var {:level :off}
              :redundant-str-call {:level :off}
              :redundant-ignore {:level :off}
-             :constant-condition {:level :off}}})
+             :constant-condition {:level :off}
+             :empty-binding {:level :off}}})
 
 (defn lint-jvm!
   ([input]


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2960.

`(let [{} value] value)` binds nothing and is usually residue from a refactor.

This adds `:empty-binding`, at `:warning` by default, for empty sequential and map destructuring forms. Argument-style vectors are excluded, so an empty `fn` argument vector, a `deftype`/`defrecord` field vector and a compojure route vector such as `(GET "/" [] ...)` do not warn. Excluding the compojure vector needed a four-argument arity on the `extract-bindings` shim in `analyzer/common.clj`, which is the only change outside the linter itself.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.