### PR TITLE
Add :duplicate-method-implementation linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2961](https://github.com/clj-kondo/clj-kondo/issues/2961): new linter `:duplicate-method-implementation` warns when a type, record, reify or proxy implements the same method and arity twice.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -39,6 +39,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Docstring no summary](#docstring-no-summary)
     - [Docstring leading trailing whitespace](#docstring-leading-trailing-whitespace)
     - [Duplicate map key](#duplicate-map-key)
+    - [Duplicate method implementation](#duplicate-method-implementation)
     - [Duplicate require](#duplicate-require)
     - [Duplicate refer](#duplicate-refer)
     - [Duplicate set key](#duplicate-set-key)
@@ -786,6 +787,19 @@ Explanation by Bozhidar Batsov:
 *Example trigger:* `{:a 1 :a 2}`
 
 *Example message:* `duplicate key :a`.
+
+### Duplicate method implementation
+
+*Keyword:* `:duplicate-method-implementation`.
+
+*Description:* warn when a type, record, reify, or proxy implements the same
+method and arity more than once.
+
+*Default level:* `:error`.
+
+*Example trigger:* `(deftype T [] Object (toString [this] "a") (toString [this] "b"))`.
+
+*Example message:* `Duplicate method implementation: toString`.
 
 ### Duplicate require
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2408,6 +2408,23 @@
                         interface? (map inc))))
             {} meths)))
 
+(defn- duplicate-method-implementation?
+  [methods method-name fixed-arities varargs-min-arity]
+  (some
+   (fn [method]
+     (when (= method-name method)
+       (let [{existing-fixed :impl-fixed-arities
+              existing-varargs :impl-varargs-min-arity} (meta method)]
+         (or (seq (set/intersection fixed-arities existing-fixed))
+             (and varargs-min-arity
+                  existing-varargs
+                  (= varargs-min-arity existing-varargs))
+             (and existing-varargs
+                  (some #(>= % existing-varargs) fixed-arities))
+             (and varargs-min-arity
+                  (some #(>= % varargs-min-arity) existing-fixed))))))
+   methods))
+
 (defn analyze-defprotocol [{:keys [ns] :as ctx} expr defined-by defined-by->lint-as]
   ;; for syntax, see https://clojure.org/reference/protocols#_basics
   (let [children (next (:children expr))
@@ -2589,16 +2606,28 @@
                       meta
                       :arity)
 
-                  methods (conj methods (let [val (:value protocol-method-name)
-                                              val (if (qualified-symbol? val)
-                                                    (symbol (name val))
-                                                    val)]
-                                          (cond-> val
-                                            (symbol? val)
-                                            (with-meta
-                                              (assoc (meta protocol-method-name)
-                                                     :impl-fixed-arities fixed-arities
-                                                     :impl-varargs-min-arity varargs-min-arity)))))]
+                  method-name (let [val (:value protocol-method-name)]
+                                (if (qualified-symbol? val)
+                                  (symbol (name val))
+                                  val))
+                  _ (when (and (symbol? method-name)
+                               (duplicate-method-implementation?
+                                methods method-name fixed-arities varargs-min-arity)
+                               (not (linter-disabled? ctx :duplicate-method-implementation))
+                               (not (:clj-kondo.impl/generated c)))
+                      (findings/reg-finding!
+                       ctx
+                       (node->line (:filename ctx) c
+                                   :duplicate-method-implementation
+                                   (str "Duplicate method implementation: "
+                                        method-name))))
+                  method (cond-> method-name
+                           (symbol? method-name)
+                           (with-meta
+                             (assoc (meta protocol-method-name)
+                                    :impl-fixed-arities fixed-arities
+                                    :impl-varargs-min-arity varargs-min-arity)))
+                  methods (conj methods method)]
               (when (end? (second children))
                 (namespace/reg-protocol-impl! ctx ns-name (assoc (meta protocol-node)
                                                                  :protocol-ns protocol-ns

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -38,6 +38,7 @@
               :duplicate-require {:level :warning}
               :duplicate-field {:level :error}
               :duplicate-key-args {:level :warning}
+              :duplicate-method-implementation {:level :error}
               :missing-map-value {:level :error}
               :redefined-var {:level :warning}
               :redundant-declare {:level :warning}

--- a/test/clj_kondo/duplicate_method_implementation_test.clj
+++ b/test/clj_kondo/duplicate_method_implementation_test.clj
@@ -1,0 +1,20 @@
+(ns clj-kondo.duplicate-method-implementation-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:duplicate-method-implementation {:level :error}}})
+
+(deftest duplicate-method-implementation-test
+  (assert-submaps2
+   '({:level :error :message "Duplicate method implementation: toString"})
+   (lint! "(deftype T []
+             Object
+             (toString [this] \"one\")
+             (toString [this] \"two\"))"
+          config))
+  (is (empty? (lint! "(deftype T []
+                       Object
+                       (toString [this] \"value\"))"
+                     config))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2961.

A `deftype`, `defrecord`, `reify` or `proxy` form can implement the same method and arity twice, which is invalid or ambiguous.

This adds `:duplicate-method-implementation`, at `:error` by default. It tracks fixed and variadic arities per method name and reports an overlap. Implementations that differ in arity remain valid.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.