### PR TITLE
Add :duplicate-cond-test linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2962](https://github.com/clj-kondo/clj-kondo/issues/2962): new linter `:duplicate-cond-test` warns when a `cond` repeats a non-constant test.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -38,6 +38,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Docstring blank](#docstring-blank)
     - [Docstring no summary](#docstring-no-summary)
     - [Docstring leading trailing whitespace](#docstring-leading-trailing-whitespace)
+    - [Duplicate cond test](#duplicate-cond-test)
     - [Duplicate map key](#duplicate-map-key)
     - [Duplicate require](#duplicate-require)
     - [Duplicate refer](#duplicate-refer)
@@ -774,6 +775,19 @@ Explanation by Bozhidar Batsov:
 *Example trigger:* `(defn foo "Has trailing whitespace.\n" [a b] 1)`
 
 *Example message:* `Docstring should not have leading or trailing whitespace.`
+
+### Duplicate cond test
+
+*Keyword:* `:duplicate-cond-test`.
+
+*Description:* warn when a `cond` contains the same non-constant test more than
+once.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(cond (odd? x) :odd (odd? x) :also-odd)`.
+
+*Example message:* `Duplicate cond test`.
 
 ### Duplicate map key
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -36,6 +36,7 @@
               :duplicate-map-key {:level :error}
               :duplicate-set-key {:level :error}
               :duplicate-require {:level :warning}
+              :duplicate-cond-test {:level :warning}
               :duplicate-field {:level :error}
               :duplicate-key-args {:level :warning}
               :missing-map-value {:level :error}

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -89,6 +89,19 @@
     (when-not (lint-cond-even-number-of-forms! ctx expr)
       (when (seq conditions)
         (lint-cond-constants! ctx conditions)
+        (when-not (utils/linter-disabled? ctx :duplicate-cond-test)
+          (loop [[condition & remaining] conditions
+                 seen #{}]
+            (when condition
+              (let [form (utils/sexpr condition)]
+                (when (and (contains? seen form)
+                           (not (constant? condition))
+                           (not (:clj-kondo.impl/generated condition)))
+                  (findings/reg-finding!
+                   ctx
+                   (node->line (:filename ctx) condition :duplicate-cond-test
+                               "Duplicate cond test")))
+                (recur remaining (conj seen form))))))
         #_(lint-cond-as-case! filename expr conditions)))))
 
 (defn expected-test-assertion? [callstack idx]

--- a/test/clj_kondo/duplicate_cond_test.clj
+++ b/test/clj_kondo/duplicate_cond_test.clj
@@ -1,0 +1,22 @@
+(ns clj-kondo.duplicate-cond-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:duplicate-cond-test {:level :warning}}})
+
+(deftest duplicate-cond-test
+  (assert-submaps2
+   '({:row 1 :col 18 :message "Duplicate cond test"})
+   (lint! "(cond (odd? x) 1 (odd? x) 2 :else 3)" config))
+  (assert-submaps2
+   '({:row 1 :col 16 :message "Duplicate cond test"})
+   (lint! "(cond ready? 1 ready? 2)" config))
+  (is (empty? (lint! "(cond (odd? x) 1 (even? x) 2)" config)))
+  (is (empty? (lint! "(cond true 1 true 2)"
+                     {:linters {:duplicate-cond-test {:level :warning}
+                                :constant-condition {:level :off}
+                                :cond-else {:level :off}}})))
+  (is (empty? (lint! "(cond (odd? x) 1 (odd? x) 2)"
+                     {:linters {:duplicate-cond-test {:level :off}}}))))

--- a/test/clj_kondo/test_utils.clj
+++ b/test/clj_kondo/test_utils.clj
@@ -134,7 +134,8 @@
              :uninitialized-var {:level :off}
              :redundant-str-call {:level :off}
              :redundant-ignore {:level :off}
-             :constant-condition {:level :off}}})
+             :constant-condition {:level :off}
+             :duplicate-cond-test {:level :off}}})
 
 (defn lint-jvm!
   ([input]


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2962.

Repeating a test in `cond` makes the later branch unreachable and usually comes from copy and paste.

This adds `:duplicate-cond-test`, at `:warning` by default, which reports the second and later structurally equal non-constant tests. Constant tests stay with the existing condition linters, and generated forms do not warn.

The new linter is turned off in `test-utils/base-config`, following the existing convention for default-on linters that would otherwise change unrelated test expectations.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.