### PR TITLE
Add :constant-logical-expression linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2963](https://github.com/clj-kondo/clj-kondo/issues/2963): new linter `:constant-logical-expression` warns when a constant `and` or `or` operand makes later operands unreachable.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -19,6 +19,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Cond-else](#cond-else)
     - [Conditional build-up](#conditional-build-up)
     - [Constant condition](#constant-condition)
+    - [Constant logical expression](#constant-logical-expression)
     - [Conflicting-alias](#conflicting-alias)
     - [Consistent-alias](#consistent-alias)
     - [Datalog syntax](#datalog-syntax)
@@ -2357,6 +2358,19 @@ moved here from `:unreachable-code`. Config and ignores using the
 (is 42)                   ;;=> Condition always true
 (cond :else 1 (odd? 1) 2) ;;=> Unreachable code
 ```
+
+### Constant logical expression
+
+*Keyword:* `:constant-logical-expression`.
+
+*Description:* warn when a constant `and` or `or` operand makes every later
+operand unreachable.
+
+*Default level:* `:warning`.
+
+*Example triggers:* `(or true (work))`, `(and false (work))`.
+
+*Example message:* `Later logical operands are unreachable`.
 
 ### Unreachable code
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -43,6 +43,7 @@
               :redundant-declare {:level :warning}
               :var-same-name-except-case {:level :warning}
               :constant-condition {:level :warning}
+              :constant-logical-expression {:level :warning}
               :unreachable-code {:level :warning}
               :datalog-syntax {:level :error}
               :unbound-destructuring-default {:level :warning}

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -176,6 +176,25 @@
          (node->line (:filename ctx) keyvec :single-key-in
                      (format "%s with single key" called-name)))))))
 
+(defn lint-constant-logical-expression [ctx call operator]
+  (when-not (or (utils/linter-disabled? ctx :constant-logical-expression)
+                (:condition (:expr call)))
+    (loop [[operand & remaining] (rest (-> call :expr :children))]
+      (when (and operand (seq remaining))
+        (let [decisive? (case operator
+                          and (or (utils/nil-token? operand)
+                                  (false? (:value operand)))
+                          or (constant-condition-truthy? operand)
+                          false)]
+          (if decisive?
+            (when-not (:clj-kondo.impl/generated (:expr call))
+              (findings/reg-finding!
+               ctx
+               (node->line (:filename ctx) operand
+                           :constant-logical-expression
+                           "Later logical operands are unreachable")))
+            (recur remaining)))))))
+
 (defn lint-specific-calls! [ctx call called-fn]
   (let [called-ns (:ns called-fn)
         called-name (:name called-fn)
@@ -185,6 +204,10 @@
     (case [called-ns called-name]
       ([clojure.core cond] [cljs.core cond])
       (lint-cond ctx (:expr call))
+      ([clojure.core and] [cljs.core and])
+      (lint-constant-logical-expression ctx call 'and)
+      ([clojure.core or] [cljs.core or])
+      (lint-constant-logical-expression ctx call 'or)
       ([clojure.core if-let] [clojure.core if-not] [clojure.core if-some]
                              [cljs.core if-let] [cljs.core if-not] [cljs.core if-some])
       (do (lint-missing-else-branch ctx (:expr call))

--- a/test/clj_kondo/constant_logical_expression_test.clj
+++ b/test/clj_kondo/constant_logical_expression_test.clj
@@ -1,0 +1,19 @@
+(ns clj-kondo.constant-logical-expression-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:constant-logical-expression {:level :warning}}})
+
+(deftest constant-logical-expression-test
+  (assert-submaps2
+   '({:row 1 :col 5 :message "Later logical operands are unreachable"})
+   (lint! "(or true (work))" config))
+  (assert-submaps2
+   '({:row 1 :col 6 :message "Later logical operands are unreachable"})
+   (lint! "(and false (work))" config))
+  (is (empty? (lint! "(or false (work)) (and true (work))" config)))
+  (is (empty? (lint! "(or true (work))"
+                     {:linters {:constant-logical-expression
+                                {:level :off}}}))))

--- a/test/clj_kondo/test_utils.clj
+++ b/test/clj_kondo/test_utils.clj
@@ -134,7 +134,8 @@
              :uninitialized-var {:level :off}
              :redundant-str-call {:level :off}
              :redundant-ignore {:level :off}
-             :constant-condition {:level :off}}})
+             :constant-condition {:level :off}
+             :constant-logical-expression {:level :off}}})
 
 (defn lint-jvm!
   ([input]


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2963.

A decisive constant before the last operand of `and` or `or` makes every later operand unreachable, for example `(and false (save! value))`.

This adds `:constant-logical-expression`, at `:warning` by default. For `and` a `nil` or `false` operand is decisive, for `or` any compile-time truthy operand is. Generated forms do not warn.

To avoid reporting the same code twice, the linter skips calls in condition position, where `:constant-condition` already reports the short circuit. It is also turned off in `test-utils/base-config`, following the existing convention for default-on linters.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.