### PR TITLE
Add :cljs-unsafe-integer linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2964](https://github.com/clj-kondo/clj-kondo/issues/2964): new linter `:cljs-unsafe-integer` warns on a ClojureScript integer literal that cannot be represented exactly.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -16,6 +16,7 @@ configuration. For general configurations options, go [here](config.md).
         - [Case quoted test](#case-quoted-test)
         - [Case symbol test constant](#case-symbol-test-constant)
     - [Clj-kondo config](#clj-kondo-config)
+    - [ClojureScript unsafe integer](#clojurescript-unsafe-integer)
     - [Cond-else](#cond-else)
     - [Conditional build-up](#conditional-build-up)
     - [Constant condition](#constant-condition)
@@ -281,6 +282,19 @@ enabling this linter, you can prepend the `case` expression with
 ```
 
 *Example message:* `Unexpected linter name: :foo`.
+
+### ClojureScript unsafe integer
+
+*Keyword:* `:cljs-unsafe-integer`.
+
+*Description:* warn when an unsuffixed integer literal cannot be represented
+exactly by a JavaScript number. This linter applies to ClojureScript only.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `9007199254740993`.
+
+*Example message:* `Integer cannot be represented exactly in ClojureScript`.
 
 ### Cond-else
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -52,6 +52,21 @@
 
 (declare analyze-expression**)
 
+(defn- lint-cljs-unsafe-integer [ctx expr]
+  (let [value (:value expr)
+        source (:string-value expr)]
+    (when (and (identical? :cljs (:lang ctx))
+               (integer? value)
+               (string? source)
+               (re-matches #"[+-]?\d+" source)
+               (> (abs value) 9007199254740991N)
+               (not (linter-disabled? ctx :cljs-unsafe-integer))
+               (not (:clj-kondo.impl/generated expr)))
+      (findings/reg-finding!
+       ctx
+       (node->line (:filename ctx) expr :cljs-unsafe-integer
+                   "Integer cannot be represented exactly in ClojureScript")))))
+
 (defn analyze-children
   ([ctx children]
    (analyze-children ctx children true))
@@ -4237,6 +4252,7 @@
           {:keys [row col]} (meta expr)
           arg-count (count (rest children))]
       (utils/handle-ignore ctx expr)
+      (lint-cljs-unsafe-integer ctx expr)
       ;; map's type is added in :map handler below
       ;; namespaced map's type is added when going through analyze-expression** via analyze-namespaced-map
       ;; list and quote are handled specially because of return types

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -140,6 +140,7 @@
               :bb.edn-unexpected-key {:level :warning}
               :bb.edn-task-missing-docstring {:level :off}
               :clj-kondo-config {:level :warning}
+              :cljs-unsafe-integer {:level :warning}
               :redundant-expression {:level :warning}
               :loop-without-recur {:level :warning}
               :unexpected-recur {:level :error}

--- a/test/clj_kondo/cljs_unsafe_integer_test.clj
+++ b/test/clj_kondo/cljs_unsafe_integer_test.clj
@@ -1,0 +1,16 @@
+(ns clj-kondo.cljs-unsafe-integer-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:cljs-unsafe-integer {:level :warning}}})
+
+(deftest cljs-unsafe-integer-test
+  (assert-submaps2
+   '({:row 1
+      :col 1
+      :message "Integer cannot be represented exactly in ClojureScript"})
+   (lint! "9007199254740993" config "--lang" "cljs"))
+  (is (empty? (lint! "9007199254740991" config "--lang" "cljs")))
+  (is (empty? (lint! "9007199254740993" config "--lang" "clj"))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2964.

A ClojureScript integer literal above `9007199254740991` cannot be represented exactly as a JavaScript number, so its value changes silently.

This adds `:cljs-unsafe-integer`, at `:warning` by default, for unsuffixed decimal integer literals outside the safe range. It only runs for ClojureScript and skips literals whose source form selects another numeric type.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.