### PR TITLE
Add :negative-zero-comparison linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2965](https://github.com/clj-kondo/clj-kondo/issues/2965): new linter `:negative-zero-comparison` warns on a ClojureScript equality comparison with negative zero.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -80,6 +80,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Missing protocol method arity](#missing-protocol-method-arity)
     - [Missing test assertion](#missing-test-assertion)
     - [Is message not string](#is-message-not-string)
+    - [Negative zero comparison](#negative-zero-comparison)
     - [Namespace name mismatch](#namespace-name-mismatch)
     - [Nil return from if-like forms](#nil-return-from-if-like-forms)
     - [Non-arg vec return type hint](#non-arg-vec-return-type-hint)
@@ -1504,6 +1505,19 @@ or
 ``` clojure
 (is (= 1 1) #_:clj-kondo/ignore 42)
 ```
+
+### Negative zero comparison
+
+*Keyword:* `:negative-zero-comparison`.
+
+*Description:* warn when a ClojureScript equality comparison uses negative
+zero.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(= value -0.0)`.
+
+*Example message:* `Use js/Object.is to compare against negative zero`.
 
 ### Namespace name mismatch
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3227,6 +3227,11 @@
   (analyze-children (ctx-with-bindings ctx with-precision-bindings)
                     children))
 
+(defn- negative-zero-node? [expr]
+  (some->> (:string-value expr)
+           (re-matches #"-0(?:\.0*)?(?:[eE][+-]?0+)?")
+           boolean))
+
 (defn- analyze-=-not= [ctx expr var-name]
   (let [[lhs rhs :as children] (rest (:children expr))
         var=? (= '= var-name)
@@ -3280,6 +3285,14 @@
                                             :type :equals-nil
                                             :message "Prefer (nil? x) over (= nil x)"
                                             :filename (:filename ctx))))))
+    (when (and (identical? :cljs (:lang ctx))
+               (or (negative-zero-node? lhs) (negative-zero-node? rhs))
+               (not (linter-disabled? ctx :negative-zero-comparison))
+               (not (:clj-kondo.impl/generated expr)))
+      (findings/reg-finding! ctx (assoc (meta expr)
+                                        :type :negative-zero-comparison
+                                        :message "Use js/Object.is to compare against negative zero"
+                                        :filename (:filename ctx))))
     res))
 
 (defn- analyze-+- [ctx sym expr]

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -199,6 +199,7 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
+              :negative-zero-comparison {:level :warning}
               :unquote-not-syntax-quoted {:level :warning}
               :await-without-async-fn {:level :error}
               :conditional-build-up {:level :off}}

--- a/test/clj_kondo/negative_zero_comparison_test.clj
+++ b/test/clj_kondo/negative_zero_comparison_test.clj
@@ -1,0 +1,16 @@
+(ns clj-kondo.negative-zero-comparison-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:negative-zero-comparison {:level :warning}}})
+
+(deftest negative-zero-comparison-test
+  (assert-submaps2
+   '({:row 1
+      :col 1
+      :message "Use js/Object.is to compare against negative zero"})
+   (lint! "(= x -0.0)" config "--lang" "cljs"))
+  (is (empty? (lint! "(= x 0.0)" config "--lang" "cljs")))
+  (is (empty? (lint! "(= x -0.0)" config "--lang" "clj"))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2965.

JavaScript equality cannot distinguish negative zero from positive zero, so a ClojureScript comparison such as `(= x -0.0)` expresses a distinction it cannot make.

This adds `:negative-zero-comparison`, at `:warning` by default, for ClojureScript equality comparisons with a syntactic negative-zero literal, recommending `js/Object.is`. Ordinary zero, other negative values and Clojure code do not warn.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.