### PR TITLE
Add :invalid-regex linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2966](https://github.com/clj-kondo/clj-kondo/issues/2966): new linter `:invalid-regex` reports a literal `re-pattern` argument that is not a valid regex.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -59,6 +59,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Inline def](#inline-def)
     - [Destructured or always evaluates](#destructured-or-always-evaluates)
     - [Invalid arity](#invalid-arity)
+    - [Invalid regex](#invalid-regex)
     - [Conflicting arity](#conflicting-arity)
     - [Reduce without initial value](#reduce-without-initial-value)
     - [Loop without recur](#loop-without-recur)
@@ -1125,6 +1126,19 @@ Normally a call to this macro will give an invalid arity error for `(select-keys
 ``` clojure
 {:linters {:invalid-arity {:skip-args [silly-macros/with-map]}}}
 ```
+
+### Invalid regex
+
+*Keyword:* `:invalid-regex`.
+
+*Description:* warn when `re-pattern` receives a constant string that is not a
+valid Java regular expression. This linter applies to Clojure only.
+
+*Default level:* `:error`.
+
+*Example trigger:* `(re-pattern "[")`.
+
+*Example message:* `Invalid regex: Unclosed character class`.
 
 ### Conflicting arity
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -159,6 +159,7 @@
               :is-message-not-string {:level :info}
               :redundant-primitive-coercion {:level :info}
               :redundant-format {:level :info}
+              :invalid-regex {:level :error}
               :warn-on-reflection {:level :off
                                    :warn-only-on-interop true}
               :aliased-namespace-symbol {:level :off

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -176,6 +176,19 @@
          (node->line (:filename ctx) keyvec :single-key-in
                      (format "%s with single key" called-name)))))))
 
+(defn lint-re-pattern [ctx call]
+  (when (and (identical? :clj (:lang call))
+             (not (utils/linter-disabled? ctx :invalid-regex)))
+    (let [pattern-node (-> call :expr :children second)]
+      (when-let [pattern (utils/string-from-token pattern-node)]
+        (try
+          (java.util.regex.Pattern/compile pattern)
+          (catch java.util.regex.PatternSyntaxException e
+            (findings/reg-finding!
+             ctx
+             (node->line (:filename ctx) pattern-node :invalid-regex
+                         (str "Invalid regex: " (.getDescription e))))))))))
+
 (defn lint-specific-calls! [ctx call called-fn]
   (let [called-ns (:ns called-fn)
         called-name (:name called-fn)
@@ -185,6 +198,8 @@
     (case [called-ns called-name]
       ([clojure.core cond] [cljs.core cond])
       (lint-cond ctx (:expr call))
+      [clojure.core re-pattern]
+      (lint-re-pattern ctx call)
       ([clojure.core if-let] [clojure.core if-not] [clojure.core if-some]
                              [cljs.core if-let] [cljs.core if-not] [cljs.core if-some])
       (do (lint-missing-else-branch ctx (:expr call))

--- a/test/clj_kondo/invalid_regex_test.clj
+++ b/test/clj_kondo/invalid_regex_test.clj
@@ -1,0 +1,15 @@
+(ns clj-kondo.invalid-regex-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:invalid-regex {:level :error}}})
+
+(deftest invalid-regex-test
+  (assert-submaps2
+   '({:row 1 :col 13 :level :error :message #"Invalid regex"})
+   (lint! "(re-pattern \"[\")" config))
+  (is (empty? (lint! "(re-pattern \"[a-z]\")" config)))
+  (is (empty? (lint! "(re-pattern pattern)" config)))
+  (is (empty? (lint! "(re-pattern \"[\")" config "--lang" "cljs"))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2966.

`(re-pattern "[")` fails only when the code runs, even though the pattern is a literal that can be compiled during analysis.

This adds `:invalid-regex`, at `:error` by default, which compiles literal string arguments to `re-pattern` and reports the `PatternSyntaxException` description. Dynamic arguments are skipped, and the check is limited to Clojure because JavaScript regex syntax differs.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.