### PR TITLE
Add :redundant-boolean-call linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2967](https://github.com/clj-kondo/clj-kondo/issues/2967): new linter `:redundant-boolean-call` warns when `boolean` wraps an expression already used as a condition.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -92,6 +92,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Var same name except case](#var-same-name-except-case)
     - [Alias same as ns name](#alias-same-ns-name)
     - [Redundant do](#redundant-do)
+    - [Redundant boolean call](#redundant-boolean-call)
     - [Redundant call](#redundant-call)
     - [Redundant declare](#redundant-declare)
     - [Redundant fn wrapper](#redundant-fn-wrapper)
@@ -1867,6 +1868,19 @@ type-hinted symbols, which may be used for performance reasons.
 *Example trigger:* `(let [x x] x)`.
 
 *Example message:* `Redundant let binding: x`.
+
+### Redundant boolean call
+
+*Keyword:* `:redundant-boolean-call`.
+
+*Description:* warn when `boolean` wraps an expression already used as a
+condition.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(if (boolean x) :yes :no)`.
+
+*Example message:* `Boolean call is redundant in condition position`.
 
 ### Redundant str call
 

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -155,6 +155,7 @@
               :redundant-call {:level :off
                                #_#_:exclude #{clojure.core/->}
                                #_#_:include #{clojure.core/conj!}}
+              :redundant-boolean-call {:level :warning}
               :redundant-str-call {:level :info}
               :is-message-not-string {:level :info}
               :redundant-primitive-coercion {:level :info}

--- a/src/clj_kondo/impl/linters.clj
+++ b/src/clj_kondo/impl/linters.clj
@@ -176,6 +176,16 @@
          (node->line (:filename ctx) keyvec :single-key-in
                      (format "%s with single key" called-name)))))))
 
+(defn lint-redundant-boolean-call [ctx call]
+  (let [expr (:expr call)]
+    (when (and (true? (:condition expr))
+               (not (utils/linter-disabled? ctx :redundant-boolean-call))
+               (not (:clj-kondo.impl/generated expr)))
+      (findings/reg-finding!
+       ctx
+       (node->line (:filename ctx) expr :redundant-boolean-call
+                   "Boolean call is redundant in condition position")))))
+
 (defn lint-specific-calls! [ctx call called-fn]
   (let [called-ns (:ns called-fn)
         called-name (:name called-fn)
@@ -185,6 +195,8 @@
     (case [called-ns called-name]
       ([clojure.core cond] [cljs.core cond])
       (lint-cond ctx (:expr call))
+      ([clojure.core boolean] [cljs.core boolean])
+      (lint-redundant-boolean-call ctx call)
       ([clojure.core if-let] [clojure.core if-not] [clojure.core if-some]
                              [cljs.core if-let] [cljs.core if-not] [cljs.core if-some])
       (do (lint-missing-else-branch ctx (:expr call))

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -1008,6 +1008,46 @@
   :message
   "Redundant boolean coercion: expression already has type boolean",
   :row 1409}
+ {:end-row 176,
+  :type :redundant-boolean-call,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/sso/settings.clj",
+  :col 36,
+  :end-col 55,
+  :langs (),
+  :message "Boolean call is redundant in condition position",
+  :row 176}
+ {:end-row 50,
+  :type :redundant-boolean-call,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/timeline/api/timeline_event.clj",
+  :col 33,
+  :end-col 49,
+  :langs (),
+  :message "Boolean call is redundant in condition position",
+  :row 50}
+ {:end-row 51,
+  :type :redundant-boolean-call,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/timeline/api/timeline_event.clj",
+  :col 33,
+  :end-col 54,
+  :langs (),
+  :message "Boolean call is redundant in condition position",
+  :row 51}
+ {:end-row 77,
+  :type :redundant-boolean-call,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/timeline/api/timeline_event.clj",
+  :col 34,
+  :end-col 53,
+  :langs (),
+  :message "Boolean call is redundant in condition position",
+  :row 77}
  {:end-row 253,
   :type :constant-condition,
   :level :warning,

--- a/test/clj_kondo/redundant_boolean_call_test.clj
+++ b/test/clj_kondo/redundant_boolean_call_test.clj
@@ -1,0 +1,27 @@
+(ns clj-kondo.redundant-boolean-call-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:redundant-boolean-call {:level :warning}}})
+
+(deftest redundant-boolean-call-test
+  (assert-submaps2
+   '({:row 1
+      :col 5
+      :message "Boolean call is redundant in condition position"})
+   (lint! "(if (boolean x) 1 2)" config))
+  (assert-submaps2
+   '({:row 1
+      :col 7
+      :message "Boolean call is redundant in condition position"})
+   (lint! "(when (boolean (seq xs)) 1)" config))
+  (is (empty? (lint! "(boolean x)" config)))
+  (is (empty? (lint! "(ns foo)
+                       (defmacro m [& xs])
+                       (m (boolean x) 1 2)"
+                     {:linters {:redundant-boolean-call {:level :warning}}
+                      :lint-as {'foo/m 'clojure.core/if}})))
+  (is (empty? (lint! "(if (boolean x) 1 2)"
+                     {:linters {:redundant-boolean-call {:level :off}}}))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2967.

Condition positions already use truthiness, so `(if (boolean x) :yes :no)` adds nothing and hides the predicate.

This adds `:redundant-boolean-call`, at `:warning` by default, which reports a `boolean` call only when the call itself is analyzed in condition position. Calls that produce a real boolean value elsewhere are untouched.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.