### PR TITLE
Add :nan-comparison linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2968](https://github.com/clj-kondo/clj-kondo/issues/2968): new linter `:nan-comparison` warns when `=`, `not=` or `==` compares a value with `##NaN`.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -80,6 +80,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Missing protocol method arity](#missing-protocol-method-arity)
     - [Missing test assertion](#missing-test-assertion)
     - [Is message not string](#is-message-not-string)
+    - [NaN comparison](#nan-comparison)
     - [Namespace name mismatch](#namespace-name-mismatch)
     - [Nil return from if-like forms](#nil-return-from-if-like-forms)
     - [Non-arg vec return type hint](#non-arg-vec-return-type-hint)
@@ -1504,6 +1505,18 @@ or
 ``` clojure
 (is (= 1 1) #_:clj-kondo/ignore 42)
 ```
+
+### NaN comparison
+
+*Keyword:* `:nan-comparison`.
+
+*Description:* warn when `=`, `not=`, or `==` compares a value with `##NaN`.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(= value ##NaN)`.
+
+*Example message:* `NaN cannot be compared`.
 
 ### Namespace name mismatch
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -3227,6 +3227,10 @@
   (analyze-children (ctx-with-bindings ctx with-precision-bindings)
                     children))
 
+(defn- nan-node? [expr]
+  (let [value (:value expr)]
+    (and (double? value) (Double/isNaN value))))
+
 (defn- analyze-=-not= [ctx expr var-name]
   (let [[lhs rhs :as children] (rest (:children expr))
         var=? (= '= var-name)
@@ -3280,6 +3284,13 @@
                                             :type :equals-nil
                                             :message "Prefer (nil? x) over (= nil x)"
                                             :filename (:filename ctx))))))
+    (when (and (or (nan-node? lhs) (nan-node? rhs))
+               (not (linter-disabled? ctx :nan-comparison))
+               (not (:clj-kondo.impl/generated expr)))
+      (findings/reg-finding! ctx (assoc (meta expr)
+                                        :type :nan-comparison
+                                        :message "NaN cannot be compared"
+                                        :filename (:filename ctx))))
     res))
 
 (defn- analyze-+- [ctx sym expr]
@@ -3654,7 +3665,7 @@
     if-not (analyze-if-not ctx expr lint-as?)
     new (analyze-constructor ctx expr)
     set! (analyze-set! ctx expr)
-    (= not=) (analyze-=-not= ctx expr resolved-as-clojure-var-name)
+    (= not= ==) (analyze-=-not= ctx expr resolved-as-clojure-var-name)
     (+ -) (analyze-+- ctx resolved-name expr)
     (with-redefs binding) (analyze-with-redefs ctx expr)
     (when when-not) (analyze-when ctx expr resolved-as-clojure-var-name lint-as?)

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -199,6 +199,7 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
+              :nan-comparison {:level :warning}
               :unquote-not-syntax-quoted {:level :warning}
               :await-without-async-fn {:level :error}
               :conditional-build-up {:level :off}}

--- a/test/clj_kondo/nan_comparison_test.clj
+++ b/test/clj_kondo/nan_comparison_test.clj
@@ -1,0 +1,15 @@
+(ns clj-kondo.nan-comparison-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:nan-comparison {:level :warning}}})
+
+(deftest nan-comparison-test
+  (doseq [code ["(= x ##NaN)" "(not= ##NaN x)" "(== x ##NaN)"]]
+    (assert-submaps2
+     '({:row 1 :col 1 :message "NaN cannot be compared"})
+     (lint! code config)))
+  (is (empty? (lint! "(Double/isNaN x)" config)))
+  (is (empty? (lint! "(= x 1.0)" config))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2968.

NaN is not equal to itself, so `(= x ##NaN)` is always false and usually a bug.

This adds `:nan-comparison`, at `:warning` by default, when `=`, `not=` or `==` has a NaN literal on either side. `==` is routed through the same analysis as `=` and `not=` so the check covers it.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.