### PR TITLE
Add :missing-caught-exception-cause linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2969](https://github.com/clj-kondo/clj-kondo/issues/2969): new linter `:missing-caught-exception-cause` warns when a catch clause throws an `ex-info` without the caught exception as cause.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -70,6 +70,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Misplaced async metadata](#misplaced-async-metadata)
     - [Misplaced docstring](#misplaced-docstring)
     - [Missing body in when](#missing-body-in-when)
+    - [Missing caught exception cause](#missing-caught-exception-cause)
     - [Missing clause in try](#missing-clause-in-try)
     - [Missing docstring](#missing-docstring)
     - [Missing else branch](#missing-else-branch)
@@ -1170,6 +1171,19 @@ why this can be problematic.
 *Example trigger:* `(loop [])`.
 
 *Example message:* `Loop without recur.`
+
+### Missing caught exception cause
+
+*Keyword:* `:missing-caught-exception-cause`.
+
+*Description:* warn when a catch clause replaces the caught exception with a
+two-argument `ex-info`, losing the original cause.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(try (work) (catch Exception e (throw (ex-info "Failed" {}))))`.
+
+*Example message:* `Pass the caught exception as the ex-info cause`.
 
 ### Line length
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2342,12 +2342,40 @@
                                  :defined-by defined-by
                                  :defined-by->lint-as defined-by->lint-as)))))
 
+(defn- thrown-ex-info-without-cause [ctx body-expr]
+  (let [[_ thrown-expr] (:children body-expr)]
+    (when (and body-expr
+               (= 'throw (symbol-call body-expr))
+               (= 2 (count (:children body-expr)))
+               (let [call-sym (symbol-call thrown-expr)
+                     {:keys [ns name]}
+                     (when (and call-sym
+                                (not (contains? (:bindings ctx) call-sym)))
+                       (resolve-name ctx true (-> ctx :ns :name)
+                                     call-sym thrown-expr))]
+                 (and (= 'ex-info name)
+                      (one-of ns [clojure.core cljs.core])))
+               (= 3 (count (:children thrown-expr))))
+      thrown-expr)))
+
+(defn- lint-missing-caught-exception-cause [ctx expr binding-expr exprs]
+  (when (and (not (linter-disabled? ctx :missing-caught-exception-cause))
+             (not= '_ (:value binding-expr))
+             (not (:clj-kondo.impl/generated expr)))
+    (when-let [ex-info-expr (thrown-ex-info-without-cause ctx (last exprs))]
+      (findings/reg-finding!
+       ctx
+       (node->line (:filename ctx) ex-info-expr
+                   :missing-caught-exception-cause
+                   "Pass the caught exception as the ex-info cause")))))
+
 (defn analyze-catch [ctx expr]
   (let [ctx (update ctx :callstack conj [nil 'catch])
         [class-expr binding-expr & exprs] (next (:children expr))
         _ (analyze-expression** ctx class-expr) ;; analyze usage for unused import linter
         ;; catch params are not let-bound, & is allowed there
         binding (extract-bindings ctx binding-expr (last exprs) {:allow-amp true})]
+    (lint-missing-caught-exception-cause ctx expr binding-expr exprs)
     ;; a catch body only runs on an exception, so it is conditional code
     (analyze-children (ctx-with-bindings (in-branch-ctx ctx) binding)
                       exprs)))

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -126,6 +126,7 @@
               :redundant-nested-call {:level :info}
               :single-key-in {:level :off}
               :missing-clause-in-try {:level :warning}
+              :missing-caught-exception-cause {:level :warning}
               :missing-body-in-when {:level :warning}
               :hook {:level :error}
               :format {:level :error}

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -37,6 +37,16 @@
   :message
   "Redundant boolean coercion: expression already has type boolean",
   :row 410}
+ {:end-row 473,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/api/macros.clj",
+  :col 14,
+  :end-col 40,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 469}
  {:end-row 998,
   :type :redundant-format,
   :level :info,
@@ -395,6 +405,16 @@
   :langs (),
   :message "#'hiccup.core/html is deprecated since 2.0",
   :row 189}
+ {:end-row 279,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/channel/slack.clj",
+  :col 20,
+  :end-col 83,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 279}
  {:end-row 2,
   :type :unused-excluded-var,
   :level :info,
@@ -524,6 +544,16 @@
   :message
   "Redundant boolean coercion: expression already has type boolean",
   :row 113}
+ {:end-row 73,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/driver/sql_jdbc/actions.clj",
+  :col 14,
+  :end-col 50,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 66}
  {:end-row 2,
   :type :unused-excluded-var,
   :level :info,
@@ -534,6 +564,16 @@
   :langs (),
   :message "Unused excluded var: require",
   :row 2}
+ {:end-row 44,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/embedding/jwt.clj",
+  :col 16,
+  :end-col 59,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 44}
  {:type :aliased-referred-var,
   :level :info,
   :lang :clj,
@@ -652,6 +692,18 @@
   :langs (:clj :cljs),
   :message "Unused excluded var: remove",
   :row 2}
+ {:end-row 495,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :lang :clj,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/lib/query.cljc",
+  :col 16,
+  :end-col 71,
+  :cljc true,
+  :langs (:clj :cljs),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 495}
  {:end-row 431,
   :type :constant-condition,
   :level :warning,
@@ -780,6 +832,16 @@
   :langs (),
   :message "Expected: number, received: nil.",
   :row 220}
+ {:end-row 314,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/premium_features/token_check.clj",
+  :col 14,
+  :end-col 53,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 312}
  {:end-row 4,
   :type :deprecated-namespace,
   :level :warning,
@@ -850,6 +912,16 @@
   :langs (),
   :message "Condition always true",
   :row 266}
+ {:end-row 606,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/queries/api/card.clj",
+  :col 16,
+  :end-col 77,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 606}
  {:end-row 79,
   :type :redundant-let-binding,
   :level :warning,
@@ -988,6 +1060,16 @@
   :message "Var *current-user-id* is referred but used via alias: api",
   :level :info,
   :langs ()}
+ {:end-row 59,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/search/filter.clj",
+  :col 31,
+  :end-col 110,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 59}
  {:filename
   "test-regression/checkouts/metabase/src/metabase/search/impl.clj",
   :row 433,
@@ -997,6 +1079,26 @@
   "Var SearchContext is referred but used via alias: search.config",
   :level :info,
   :langs ()}
+ {:end-row 159,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/search/in_place/filter.clj",
+  :col 31,
+  :end-col 110,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 159}
+ {:end-row 118,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/session/api.clj",
+  :col 14,
+  :end-col 60,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 117}
  {:end-row 1410,
   :type :redundant-primitive-coercion,
   :level :warning,
@@ -1018,6 +1120,16 @@
   :langs (),
   :message "Condition always true",
   :row 253}
+ {:end-row 833,
+  :type :missing-caught-exception-cause,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/upload/impl.clj",
+  :col 22,
+  :end-col 65,
+  :langs (),
+  :message "Pass the caught exception as the ex-info cause",
+  :row 833}
  {:end-row 137,
   :type :redundant-let-binding,
   :level :warning,

--- a/test/clj_kondo/missing_caught_exception_cause_test.clj
+++ b/test/clj_kondo/missing_caught_exception_cause_test.clj
@@ -1,0 +1,31 @@
+(ns clj-kondo.missing-caught-exception-cause-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest missing-caught-exception-cause-test
+  (let [config {:linters {:missing-caught-exception-cause {:level :warning}}}]
+    (assert-submaps2
+     '({:row 1
+        :col 39
+        :message "Pass the caught exception as the ex-info cause"})
+     (lint! "(try (work) (catch Exception e (throw (ex-info \"Failed\" {}))))"
+            config))
+    (is (empty? (lint! "(try (work)
+                         (catch Exception e
+                           (throw (ex-info \"Failed\" {} e))))"
+                       config)))
+    (is (empty? (lint! "(try (work)
+                         (catch Exception _
+                           (throw (ex-info \"Replacement\" {}))))"
+                       config)))
+    (is (empty? (lint! "(let [ex-info replacement]
+                         (try (work)
+                           (catch Exception e
+                             (throw (ex-info \"Replacement\" {})))))"
+                       config)))
+    (is (empty? (lint! "(try (work)
+                         (catch Exception e
+                           (throw (ex-info \"Failed\" {}))))"
+                       {:linters {:missing-caught-exception-cause
+                                  {:level :off}}})))))

--- a/test/clj_kondo/test_utils.clj
+++ b/test/clj_kondo/test_utils.clj
@@ -134,7 +134,8 @@
              :uninitialized-var {:level :off}
              :redundant-str-call {:level :off}
              :redundant-ignore {:level :off}
-             :constant-condition {:level :off}}})
+             :constant-condition {:level :off}
+             :missing-caught-exception-cause {:level :off}}})
 
 (defn lint-jvm!
   ([input]


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2969.

`(catch Exception e (throw (ex-info "Failed" {})))` discards the caught exception and its stack.

This adds `:missing-caught-exception-cause`, at `:warning` by default, when the last expression of a catch throws a two-argument core `ex-info` while the caught binding is named. It stays quiet when a cause is passed, when the binding is `_`, and when `ex-info` resolves to a local binding rather than the core var.

The new linter is turned off in `test-utils/base-config`, following the existing convention for default-on linters.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.