### PR TITLE
Add :throw-in-finally linter

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -42,6 +42,7 @@
  :auto-load-configs false
  :ns-groups [{:pattern ".*-test"
               :name test-namespaces}]
- :config-in-ns {test-namespaces {:linters {:warn-on-reflection {:level :off}}}}
+ :config-in-ns {clj-kondo.impl.analyzer {:linters {:throw-in-finally {:level :off}}}
+                test-namespaces {:linters {:warn-on-reflection {:level :off}}}}
  :config-paths ["imports/borkdude/deflet"]
  }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2970](https://github.com/clj-kondo/clj-kondo/issues/2970): new linter `:throw-in-finally` warns when a `throw` in `finally` replaces the pending value or exception.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -115,6 +115,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Shadowed var](#shadowed-var)
     - [Static field call](#static-field-call)
     - [Syntax](#syntax)
+    - [Throw in finally](#throw-in-finally)
     - [Type mismatch](#type-mismatch)
     - [Unbound destructuring default](#unbound-destructuring-default)
     - [Unexpected recur](#unexpected-recur)
@@ -2120,6 +2121,19 @@ the `ns` form.
 Mismatched bracket: found an opening [ and a closing ) on line 1
 Mismatched bracket: found an opening [ on line 1 and a closing )
 ```
+
+### Throw in finally
+
+*Keyword:* `:throw-in-finally`.
+
+*Description:* warn when a `throw` inside `finally` replaces the value or
+exception pending from `try` or `catch`.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(try (work) (finally (throw failure)))`.
+
+*Example message:* `Throw in finally replaces the pending value or exception`.
 
 ### Type mismatch
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -52,6 +52,24 @@
 
 (declare analyze-expression**)
 
+(defn- inside-finally? [callstack]
+  (when-let [[[_ call] & remaining] (seq callstack)]
+    (cond
+      (= 'finally call) true
+      (one-of call [fn fn* defn defn-]) false
+      :else (recur remaining))))
+
+(defn- lint-throw-in-finally [ctx expr]
+  (when (and expr
+             (= 'throw (symbol-call expr))
+             (inside-finally? (:callstack ctx))
+             (not (linter-disabled? ctx :throw-in-finally))
+             (not (:clj-kondo.impl/generated expr)))
+    (findings/reg-finding!
+     ctx
+     (node->line (:filename ctx) expr :throw-in-finally
+                 "Throw in finally replaces the pending value or exception"))))
+
 (defn analyze-children
   ([ctx children]
    (analyze-children ctx children true))
@@ -78,6 +96,7 @@
                      (assoc-new :len len))]
          (into []
                (comp (map-indexed (fn [i e]
+                                    (lint-throw-in-finally ctx e)
                                     (analyze-expression** (assoc ctx :idx i) e)))
                      cat)
                children))))))

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -199,6 +199,7 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
+              :throw-in-finally {:level :warning}
               :unquote-not-syntax-quoted {:level :warning}
               :await-without-async-fn {:level :error}
               :conditional-build-up {:level :off}}

--- a/test-regression/clj_kondo/clj_kondo/findings.edn
+++ b/test-regression/clj_kondo/clj_kondo/findings.edn
@@ -32823,6 +32823,15 @@
   :langs (),
   :message "Unresolved var: node/coerce",
   :row 106}
+ {:end-row 4757,
+  :type :throw-in-finally,
+  :level :warning,
+  :filename "src/clj_kondo/impl/analyzer.clj",
+  :col 15,
+  :end-col 24,
+  :langs (),
+  :message "Throw in finally replaces the pending value or exception",
+  :row 4757}
  {:end-row 46,
   :type :redundant-ignore,
   :level :info,

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -524,6 +524,16 @@
   :message
   "Redundant boolean coercion: expression already has type boolean",
   :row 113}
+ {:end-row 1901,
+  :type :throw-in-finally,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/driver/sql/query_processor.clj",
+  :col 13,
+  :end-col 32,
+  :langs (),
+  :message "Throw in finally replaces the pending value or exception",
+  :row 1897}
  {:end-row 2,
   :type :unused-excluded-var,
   :level :info,
@@ -2173,6 +2183,16 @@
   :langs (),
   :message "Format string contains no format specifiers",
   :row 123}
+ {:end-row 481,
+  :type :throw-in-finally,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/test/metabase/test/util.clj",
+  :col 17,
+  :end-col 36,
+  :langs (),
+  :message "Throw in finally replaces the pending value or exception",
+  :row 477}
  {:end-row 497,
   :type :is-message-not-string,
   :level :info,

--- a/test/clj_kondo/throw_in_finally_test.clj
+++ b/test/clj_kondo/throw_in_finally_test.clj
@@ -1,0 +1,19 @@
+(ns clj-kondo.throw-in-finally-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:throw-in-finally {:level :warning}}})
+
+(deftest throw-in-finally-test
+  (assert-submaps2
+   '({:row 1
+      :message "Throw in finally replaces the pending value or exception"})
+   (lint! "(try (work) (finally (throw failure)))" config))
+  (assert-submaps2
+   '({:row 1
+      :message "Throw in finally replaces the pending value or exception"})
+   (lint! "(try (work) (finally (when failed? (throw failure))))" config))
+  (is (empty? (lint! "(try (work) (finally (fn [] (throw failure))))"
+                     config))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2970.

A `throw` inside `finally` replaces the value or exception pending from `try` or `catch`, which can hide the original failure.

This adds `:throw-in-finally`, at `:warning` by default, for a `throw` that runs in the current `finally` scope. A `throw` inside a nested `fn` or `defn` does not warn because it runs elsewhere, and generated forms do not warn.

clj-kondo's own `analyzer.clj` has such a throw, so this PR also excludes that namespace in `.clj-kondo/config.edn`.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.