### PR TITLE
Add :useless-catch linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2971](https://github.com/clj-kondo/clj-kondo/issues/2971): new linter `:useless-catch` warns when the last catch clause only rethrows the caught exception.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -135,6 +135,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Unsorted imports](#unsorted-imports)
     - [Unsorted required namespaces](#unsorted-required-namespaces)
     - [Unquote outside syntax-quote](#unquote-outside-syntax-quote)
+    - [Useless catch](#useless-catch)
     - [Unused namespace](#unused-namespace)
     - [Unused private var](#unused-private-var)
     - [Unused referred var](#unused-referred-var)
@@ -2590,6 +2591,19 @@ Possible values for `:sort` are `:case-insensitive` (default) and `:case-sensiti
 *Example trigger:* `~x`
 
 *Example message:* `Unquote (~) used outside syntax-quote`.
+
+### Useless catch
+
+*Keyword:* `:useless-catch`.
+
+*Description:* warn when the last catch clause only rethrows its caught
+exception.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(try (work) (catch Exception e (throw e)))`.
+
+*Example message:* `Catch clause only rethrows the caught exception`.
 
 ### Await without async fn
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2342,12 +2342,30 @@
                                  :defined-by defined-by
                                  :defined-by->lint-as defined-by->lint-as)))))
 
-(defn analyze-catch [ctx expr]
+(defn- direct-rethrow? [binding-expr body-expr]
+  (let [[_ thrown-expr] (:children body-expr)]
+    (and (= 'throw (symbol-call body-expr))
+         (= 2 (count (:children body-expr)))
+         (= (:value binding-expr) (:value thrown-expr)))))
+
+(defn- lint-useless-catch [ctx expr binding-expr exprs last-catch?]
+  (when (and last-catch?
+             (= 1 (count exprs))
+             (direct-rethrow? binding-expr (first exprs))
+             (not (linter-disabled? ctx :useless-catch))
+             (not (:clj-kondo.impl/generated expr)))
+    (findings/reg-finding!
+     ctx
+     (node->line (:filename ctx) expr :useless-catch
+                 "Catch clause only rethrows the caught exception"))))
+
+(defn analyze-catch [ctx expr last-catch?]
   (let [ctx (update ctx :callstack conj [nil 'catch])
         [class-expr binding-expr & exprs] (next (:children expr))
         _ (analyze-expression** ctx class-expr) ;; analyze usage for unused import linter
         ;; catch params are not let-bound, & is allowed there
         binding (extract-bindings ctx binding-expr (last exprs) {:allow-amp true})]
+    (lint-useless-catch ctx expr binding-expr exprs last-catch?)
     ;; a catch body only runs on an exception, so it is conditional code
     (analyze-children (ctx-with-bindings (in-branch-ctx ctx) binding)
                       exprs)))
@@ -2375,7 +2393,8 @@
       (if fst-child
         (case (symbol-call fst-child)
           catch
-          (let [analyzed-catch (analyze-catch ctx fst-child)]
+          (let [last-catch? (not-any? #(= 'catch (symbol-call %)) rst-children)
+                analyzed-catch (analyze-catch ctx fst-child last-catch?)]
             (recur rst-children (into analyzed analyzed-catch)
                    true false true))
           finally

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -199,6 +199,7 @@
               :missing-protocol-method-arity {:level :off}
               :locking-suspicious-lock {:level :warning}
               :destructured-or-always-evaluates {:level :off}
+              :useless-catch {:level :warning}
               :unquote-not-syntax-quoted {:level :warning}
               :await-without-async-fn {:level :error}
               :conditional-build-up {:level :off}}

--- a/test-regression/clj_kondo/metabase/findings.edn
+++ b/test-regression/clj_kondo/metabase/findings.edn
@@ -750,6 +750,16 @@
   :langs (),
   :message "Unquote (~) not syntax-quoted",
   :row 97}
+ {:end-row 191,
+  :type :useless-catch,
+  :level :warning,
+  :filename
+  "test-regression/checkouts/metabase/src/metabase/premium_features/token_check.clj",
+  :col 14,
+  :end-col 26,
+  :langs (),
+  :message "Catch clause only rethrows the caught exception",
+  :row 190}
  {:end-row 214,
   :type :type-mismatch,
   :level :error,

--- a/test/clj_kondo/useless_catch_test.clj
+++ b/test/clj_kondo/useless_catch_test.clj
@@ -1,0 +1,20 @@
+(ns clj-kondo.useless-catch-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(deftest useless-catch-test
+  (let [config {:linters {:useless-catch {:level :warning}}}]
+    (assert-submaps2
+     '({:row 1
+        :col 13
+        :message "Catch clause only rethrows the caught exception"})
+     (lint! "(try (work) (catch Exception e (throw e)))" config))
+    (is (empty? (lint! "(try (work)
+                         (catch java.io.IOException e (throw e))
+                         (catch Exception e (handle e)))"
+                       config)))
+    (is (empty? (lint! "(try (work) (catch Exception e (log e) (throw e)))"
+                       config)))
+    (is (empty? (lint! "(try (work) (catch Exception e (throw e)))"
+                       {:linters {:useless-catch {:level :off}}})))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2971.

`(try (work) (catch Exception e (throw e)))` has no effect and adds misleading control flow.

This adds `:useless-catch`, at `:warning` by default, for a final catch clause whose only expression rethrows its own binding. It stays quiet when the catch does something else first, throws another value, or is followed by a broader catch that would change behaviour, so `analyze-catch` now receives whether it is the last catch clause.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.