### PR TITLE
Add :self-assignment linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#2973](https://github.com/clj-kondo/clj-kondo/issues/2973): new linter `:self-assignment` warns when `set!` assigns an expression to itself.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -106,6 +106,7 @@ configuration. For general configurations options, go [here](config.md).
     - [Refer clojure exclude unresolved var](#unresolved-excluded-var)
     - [Refer all](#refer-all)
     - [Schema misplaced return](#schema-misplaced-return)
+    - [Self-assignment](#self-assignment)
     - [Self-requiring namespace](#self-requiring-namespace)
     - [Seq rest](#seq-rest)
     - [Single key in](#single-key-in)
@@ -2000,6 +2001,18 @@ Example warning: `require with :refer`.
 *Example trigger:* `(ns foo (:require [foo]))`
 
 *Example message:* `Namespace is requiring itself: foo`
+
+### Self-assignment
+
+*Keyword:* `:self-assignment`.
+
+*Description:* warn when `set!` assigns an expression to itself.
+
+*Default level:* `:warning`.
+
+*Example trigger:* `(set! *x* *x*)`.
+
+*Example message:* `Value is assigned to itself`.
 
 ### Seq rest
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -2782,7 +2782,21 @@
 
 (defn analyze-set!
   [ctx expr]
-  (let [children (next (:children expr))]
+  (let [[target field-or-value value :as children] (next (:children expr))
+        self-assignment?
+        (if value
+          (= (sexpr value)
+             (list (symbol (str "." (:value field-or-value)))
+                   (sexpr target)))
+          (= (sexpr target) (sexpr field-or-value)))]
+    (when (and (one-of (count children) [2 3])
+               self-assignment?
+               (not (linter-disabled? ctx :self-assignment))
+               (not (:clj-kondo.impl/generated expr)))
+      (findings/reg-finding!
+       ctx
+       (node->line (:filename ctx) expr :self-assignment
+                   "Value is assigned to itself")))
     (if (and (identical? :cljs (:lang ctx))
              (= 3 (count children)))
       ;; ignore second argument which is the field, e.g. (set! o -x 3)

--- a/src/clj_kondo/impl/config.clj
+++ b/src/clj_kondo/impl/config.clj
@@ -180,6 +180,7 @@
               :protocol-method-varargs {:level :error}
               :unused-alias {:level :off}
               :alias-same-as-ns {:level :off}
+              :self-assignment {:level :warning}
               :self-requiring-namespace {:level :warning}
               :underscore-in-namespace {:level :warning}
               :multiple-async-in-deftest {:level :warning}

--- a/test/clj_kondo/self_assignment_test.clj
+++ b/test/clj_kondo/self_assignment_test.clj
@@ -1,0 +1,27 @@
+(ns clj-kondo.self-assignment-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:self-assignment {:level :warning}}})
+
+(deftest self-assignment-test
+  (assert-submaps2
+   '({:row 1
+      :col 23
+      :message "Value is assigned to itself"})
+   (lint! "(def ^:dynamic *x* 1) (set! *x* *x*)" config))
+  (assert-submaps2
+   '({:row 1
+      :col 9
+      :message "Value is assigned to itself"})
+   (lint! "(fn [o] (set! (.-x o) (.-x o)))" config "--lang" "cljs"))
+  (assert-submaps2
+   '({:row 1
+      :col 9
+      :message "Value is assigned to itself"})
+   (lint! "(fn [o] (set! o -x (.-x o)))" config "--lang" "cljs"))
+  (is (empty? (lint! "(def ^:dynamic *x* 1) (set! *x* 2)" config)))
+  (is (empty? (lint! "(def ^:dynamic *x* 1) (set! *x* *x*)"
+                     {:linters {:self-assignment {:level :off}}}))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #2973.

`(set! *x* *x*)` has no effect and often survives an incomplete refactor.

This adds `:self-assignment`, at `:warning` by default, for `set!` on a symbol target and on the ClojureScript field form when target and value are the same. Different targets or values do not warn.

The issue is still awaiting your feedback, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the level, message or scope, or to close it if you would rather not have this linter.