### PR TITLE
Report unreachable code after throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- [#641](https://github.com/clj-kondo/clj-kondo/issues/641): `:unreachable-code` also reports expressions after a `throw` in a body.
 - Bump graal-build-time to 1.0.6 to fix startup crash in binaries built with GraalVM 25.1+.
 - Bump edamame to 1.6.43: a function literal inside a syntax-quoted macro extracted with `:clj-kondo/macroexpand-hook` no longer fails with `unsupported binding form ns/%1`.
 

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -2362,12 +2362,13 @@ moved here from `:unreachable-code`. Config and ignores using the
 
 *Keyword:* `:unreachable-code`.
 
-*Description:* warn on code that can never execute. Currently: branches after
-a `:default` reader conditional branch, which never match.
+*Description:* warn on code that can never execute, including expressions after
+`throw` and branches after a `:default` reader conditional branch.
 
 *Default level:* `:warning`.
 
-*Example trigger:* `#?(:default 1 :clj 2)`.
+*Example triggers:* `(do (throw failure) (cleanup))`,
+`#?(:default 1 :clj 2)`.
 
 *Example message:* `Unreachable code: default reader conditional branch should go last`.
 

--- a/src/clj_kondo/impl/analyzer.clj
+++ b/src/clj_kondo/impl/analyzer.clj
@@ -1568,6 +1568,20 @@
       (lint-conditional-build-up! ctx bv @collector))
     analyzed))
 
+(defn- lint-code-after-throw [ctx expr]
+  (when-not (linter-disabled? ctx :unreachable-code)
+    (let [[throw-expr & unreachable]
+          (drop-while #(not= 'throw (symbol-call %))
+                      (next (:children expr)))]
+      (when (and throw-expr
+                 (seq unreachable)
+                 (not (:clj-kondo.impl/generated throw-expr))
+                 (not (:clj-kondo.impl/generated (first unreachable))))
+        (findings/reg-finding!
+         ctx
+         (node->line (:filename ctx) (first unreachable)
+                     :unreachable-code "Unreachable code"))))))
+
 (defn analyze-do [{:keys [filename callstack] :as ctx} expr]
   (let [parent-call (second callstack)
         core? (one-of (first parent-call) [clojure.core cljs.core])
@@ -1594,6 +1608,7 @@
                                       doseq try when when-not when-first
                                       when-some future
                                       catch])))))]
+    (lint-code-after-throw ctx expr)
     (when redundant?
       (findings/reg-finding!
        ctx

--- a/test/clj_kondo/unreachable_code_test.clj
+++ b/test/clj_kondo/unreachable_code_test.clj
@@ -1,0 +1,13 @@
+(ns clj-kondo.unreachable-code-test
+  (:require
+   [clj-kondo.test-utils :refer [assert-submaps2 lint!]]
+   [clojure.test :refer [deftest is]]))
+
+(def config
+  {:linters {:unreachable-code {:level :warning}}})
+
+(deftest unreachable-after-throw-test
+  (assert-submaps2
+   '({:row 1 :col 15 :message "Unreachable code"})
+   (lint! "(do (throw e) (cleanup))" config))
+  (is (empty? (lint! "(if failed? (throw e) (cleanup))" config))))


### PR DESCRIPTION
- [x] I have read the [Clojure etiquette](https://clojure.org/community/etiquette) and will respect it when communicating on this platform.

- [x] I have read the [developer documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md).

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/clj-kondo/clj-kondo/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md) file with a description of the addressed issue.

Addresses #641.

Expressions after a `throw` in a body never run, but `:unreachable-code` currently only reports branches after a `:default` reader conditional branch.

This extends the existing linter to report the first expression after a `throw` in a body, so `(do (throw e) (cleanup))` warns while `(if failed? (throw e) (cleanup))` does not. Generated forms do not warn. No new linter keyword and no configuration change, so existing `:unreachable-code` settings and ignores keep working.

Issue #641 has been open for a while, so please treat this as a concrete proposal rather than a finished decision. I am happy to change the message or scope, or to close it if you would rather not extend the linter this way.